### PR TITLE
fix(wire): avoid double slash in keyexpr for global topics

### DIFF
--- a/Sources/SwiftROS2Wire/ZenohWireCodec.swift
+++ b/Sources/SwiftROS2Wire/ZenohWireCodec.swift
@@ -30,7 +30,9 @@ public struct ZenohWireCodec: WireCodec {
         let cleanNamespace = TypeNameConverter.stripLeadingSlash(namespace)
         let ddsTypeName = TypeNameConverter.toDDSTypeName(typeName)
         let hashComponent = distro.formatTypeHash(typeHash)
-        let topicPath = "\(cleanNamespace)/\(topic)"
+        // Global topics (e.g. /tf_static) are published with an empty namespace;
+        // avoid emitting `domain//topic` which Zenoh rejects as invalid.
+        let topicPath = cleanNamespace.isEmpty ? topic : "\(cleanNamespace)/\(topic)"
 
         if !distro.alwaysIncludeTypeHashInKey && hashComponent.isEmpty {
             return "\(domainId)/\(topicPath)/\(ddsTypeName)"

--- a/Tests/SwiftROS2WireTests/WireCodecTests.swift
+++ b/Tests/SwiftROS2WireTests/WireCodecTests.swift
@@ -70,6 +70,20 @@ final class WireCodecTests: XCTestCase {
         XCTAssertEqual(key, "0/ios/imu/sensor_msgs::msg::dds_::Imu_/TypeHashNotSupported")
     }
 
+    func testJazzyKeyExpressionEmptyNamespace() {
+        // Global topics like /tf_static are published with an empty namespace.
+        // The key must NOT contain a double slash between the domain id and topic.
+        let codec = ZenohWireCodec(distro: .jazzy)
+        let key = codec.makeKeyExpr(
+            domainId: 0,
+            namespace: "",
+            topic: "tf_static",
+            typeName: "tf2_msgs/msg/TFMessage",
+            typeHash: "RIHS01_abc123"
+        )
+        XCTAssertEqual(key, "0/tf_static/tf2_msgs::msg::dds_::TFMessage_/RIHS01_abc123")
+    }
+
     func testJazzyKeyExpressionWithoutTypeHash() {
         let codec = ZenohWireCodec(distro: .jazzy)
         let key = codec.makeKeyExpr(


### PR DESCRIPTION
## Summary

`ZenohWireCodec.makeKeyExpr` emitted `"<domain>//<topic>"` for callers that pass an empty namespace (global topics like `/tf_static`). Zenoh rejects the double slash as an invalid key expression and `z_view_keyexpr_from_str` returns `-75`, so the publisher fails to start.

Drop the joining slash when the namespace is empty so the key becomes `"<domain>/<topic>/<type>/<hash>"`.

## Verification

- Added `testJazzyKeyExpressionEmptyNamespace` locking in the tf_static key shape.
- `swift test --filter WireCodecTests` — 14 tests, 0 failures.
- Reproduced the `-75` failure on device (Conduit iOS app publishing `/tf_static`); fix lets the keyexpr declare cleanly.