### PR TITLE
fix(sensor_msgs/NavSatFix): drop manual CDR padding that drifted lat/lon/alt

### DIFF
--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/NavSatFix.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/NavSatFix.swift
@@ -26,13 +26,11 @@ public struct NavSatStatus: CDRCodable, Sendable {
 
     public func encode(to encoder: CDREncoder) throws {
         encoder.writeInt8(status)
-        encoder.writePadding(1)
         encoder.writeUInt16(service)
     }
 
     public init(from decoder: CDRDecoder) throws {
         self.status = try decoder.readInt8()
-        _ = try decoder.readRawBytes(count: 1)  // padding
         self.service = try decoder.readUInt16()
     }
 }
@@ -81,7 +79,6 @@ public struct NavSatFix: ROS2Message {
         encoder.writeEncapsulationHeader()
         try header.encode(to: encoder)
         try status.encode(to: encoder)
-        encoder.writePadding(4)
         encoder.writeFloat64(latitude)
         encoder.writeFloat64(longitude)
         encoder.writeFloat64(altitude)
@@ -92,7 +89,6 @@ public struct NavSatFix: ROS2Message {
     public init(from decoder: CDRDecoder) throws {
         self.header = try Header(from: decoder)
         self.status = try NavSatStatus(from: decoder)
-        _ = try decoder.readRawBytes(count: 4)  // padding
         self.latitude = try decoder.readFloat64()
         self.longitude = try decoder.readFloat64()
         self.altitude = try decoder.readFloat64()

--- a/Tests/SwiftROS2Tests/MessageRoundTripTests.swift
+++ b/Tests/SwiftROS2Tests/MessageRoundTripTests.swift
@@ -415,4 +415,70 @@ final class MessageRoundTripTests: XCTestCase {
         XCTAssertEqual(decoded.magneticField, original.magneticField)
         XCTAssertEqual(decoded.magneticFieldCovariance, original.magneticFieldCovariance)
     }
+
+    func testNavSatFixRoundTrip() throws {
+        let original = NavSatFix(
+            header: Header(sec: 1700000000, nanosec: 123456789, frameId: "gps_link"),
+            status: NavSatStatus(status: NavSatStatus.statusFix, service: NavSatStatus.serviceGPS),
+            latitude: 37.7749,
+            longitude: -122.4194,
+            altitude: 30.5,
+            positionCovariance: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+            positionCovarianceType: .diagonalKnown
+        )
+
+        let encoder = CDREncoder()
+        try original.encode(to: encoder)
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try NavSatFix(from: decoder)
+
+        XCTAssertEqual(decoded.header.frameId, "gps_link")
+        XCTAssertEqual(decoded.status.status, NavSatStatus.statusFix)
+        XCTAssertEqual(decoded.status.service, NavSatStatus.serviceGPS)
+        XCTAssertEqual(decoded.latitude, 37.7749, accuracy: 1e-9)
+        XCTAssertEqual(decoded.longitude, -122.4194, accuracy: 1e-9)
+        XCTAssertEqual(decoded.altitude, 30.5, accuracy: 1e-9)
+        XCTAssertEqual(decoded.positionCovariance, original.positionCovariance)
+        XCTAssertEqual(decoded.positionCovarianceType, NavSatFix.CovarianceType.diagonalKnown.rawValue)
+    }
+
+    /// Locks the byte-level CDR layout of sensor_msgs/NavSatFix to the IDL offsets so
+    /// stray manual padding cannot drift the fields again. Round-trip tests alone miss
+    /// this class of bug because a buggy encoder pairs with a symmetrically-buggy
+    /// decoder — a receiver that auto-aligns per CDR spec would read garbage in the
+    /// latitude slot (see GPS lat/alt swap report in downstream projects).
+    ///
+    /// With frame_id = "gps_link" (8 chars + null), the relative dataPosition after
+    /// encoding the Header is 21. NavSatStatus then writes int8 (→22) and auto-aligned
+    /// uint16 (→24), which leaves the first float64 (latitude) 8-aligned at
+    /// dataPosition 24. Absolute offsets include the 4-byte encapsulation header.
+    func testNavSatFixCDRLayoutMatchesROS2IDL() throws {
+        let latitude = 37.7749
+        let longitude = -122.4194
+        let altitude = 30.5
+
+        let message = NavSatFix(
+            header: Header(sec: 0, nanosec: 0, frameId: "gps_link"),
+            status: NavSatStatus(status: NavSatStatus.statusFix, service: NavSatStatus.serviceGPS),
+            latitude: latitude,
+            longitude: longitude,
+            altitude: altitude
+        )
+
+        let encoder = CDREncoder()
+        try message.encode(to: encoder)
+        let bytes = encoder.getData()
+
+        func readF64(_ offset: Int) -> Double {
+            let raw = bytes.subdata(in: offset..<(offset + 8))
+            let bits = raw.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) }
+            return Double(bitPattern: UInt64(littleEndian: bits))
+        }
+
+        // encap(4) + Header → dataPos 21, int8 status → 22, uint16 service (auto-aligned) → 24.
+        // latitude / longitude / altitude land at absolute 28 / 36 / 44.
+        XCTAssertEqual(readF64(28), latitude, accuracy: 1e-12, "latitude must be at IDL offset 28")
+        XCTAssertEqual(readF64(36), longitude, accuracy: 1e-12, "longitude must be at IDL offset 36")
+        XCTAssertEqual(readF64(44), altitude, accuracy: 1e-12, "altitude must be at IDL offset 44")
+    }
 }


### PR DESCRIPTION
## Summary

`NavSatStatus.encode` and `NavSatFix.encode` each emitted manual `writePadding` bytes before primitives that `CDREncoder` already auto-aligns (`writeUInt16` → `alignTo(2)`, `writeFloat64` → `alignTo(8)`). The extra padding compounded with the auto-alignment and pushed every field after `status` by 2 bytes on the wire.

Round-trip tests passed despite this because the matching `readRawBytes(count:)` calls on the decoder skipped exactly the same bytes — so Swift-to-Swift decoding masked the divergence. A conformant consumer (e.g. `rmw_zenoh_cpp`) auto-aligns per CDR, reads our `uint16 service` bytes as a subnormal double (`~5e-324`) in the `latitude` slot, and each subsequent coordinate lands in the next field. This matches a downstream iOS user report where GPS latitude appeared in the altitude field.

## Fix

- Remove `writePadding(1)` / `writePadding(4)` in `NavSatFix.swift` encode paths.
- Remove the symmetric `readRawBytes(count: 1)` / `readRawBytes(count: 4)` in decode paths.

## Tests

- `testNavSatFixRoundTrip` — end-to-end encode/decode sanity.
- `testNavSatFixCDRLayoutMatchesROS2IDL` — locks absolute byte offsets of `latitude` / `longitude` / `altitude` for `frame_id = "gps_link"` so this class of bug cannot silently reappear. A round-trip test alone cannot catch it (the buggy encoder pairs with a symmetrically-buggy decoder); a byte-layout assertion is required.

All 59 package tests pass (`swift test`).

## Scope

`NavSatFix` is the only message in `Sources/SwiftROS2Messages/BuiltinMessages/` that called `writePadding` inside `encode`. I grepped the whole `Sources/` tree to confirm; no other message has the same pattern.