### PR TITLE
Phase 1: integrate zenoh-pico / CycloneDDS FFI into swift-ros2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ xcuserdata/
 DerivedData/
 .DS_Store
 .claude/
+
+# Bootstrap-only artifacts (Phase 1 macCatalyst-arm64 .a files + headers).
+# Phase 2 replaces these with xcframework binaryTargets hosted on GitHub
+# Releases. Run Scripts/bootstrap-maccatalyst.sh to populate locally.
+/Vendor/
+/vendor/include/
+/vendor/maccatalyst-arm64/
+/vendor/pkgconfig/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vendor/zenoh-pico"]
+	path = vendor/zenoh-pico
+	url = https://github.com/youtalk/zenoh-pico.git
+	branch = swift-ros2-main

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = vendor/zenoh-pico
 	url = https://github.com/youtalk/zenoh-pico.git
 	branch = swift-ros2-main
+[submodule "vendor/cyclonedds"]
+	path = vendor/cyclonedds
+	url = https://github.com/youtalk/cyclonedds.git
+	branch = swift-ros2-main

--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     platforms: [
         .iOS(.v16),
         .macOS(.v13),
+        .macCatalyst(.v16),
         .visionOS(.v1),
     ],
     products: [
@@ -15,6 +16,8 @@ let package = Package(
         .library(name: "SwiftROS2Messages", targets: ["SwiftROS2Messages"]),
         .library(name: "SwiftROS2Wire", targets: ["SwiftROS2Wire"]),
         .library(name: "SwiftROS2Transport", targets: ["SwiftROS2Transport"]),
+        .library(name: "SwiftROS2Zenoh", targets: ["SwiftROS2Zenoh"]),
+        .library(name: "SwiftROS2DDS", targets: ["SwiftROS2DDS"]),
     ],
     targets: [
         // CDR serialization (pure Swift, no dependencies)
@@ -41,6 +44,57 @@ let package = Package(
             name: "SwiftROS2Transport",
             dependencies: ["SwiftROS2CDR", "SwiftROS2Wire"],
             path: "Sources/SwiftROS2Transport"
+        ),
+
+        // System libraries wrapping the native C FFI (local .a bootstrap;
+        // Phase 2 switches these to xcframework binaryTargets hosted on
+        // GitHub Releases). PKG_CONFIG_PATH must include Vendor/pkgconfig
+        // during bootstrap builds.
+        .systemLibrary(
+            name: "CZenohPico",
+            path: "Sources/CZenohPico",
+            pkgConfig: "ZenohPico"
+        ),
+        .systemLibrary(
+            name: "CCycloneDDS",
+            path: "Sources/CCycloneDDS",
+            pkgConfig: "CycloneDDS"
+        ),
+
+        // C bridges (Conduit-authored FFI shims that simplify the zenoh-pico
+        // and CycloneDDS APIs for Swift callers).
+        .target(
+            name: "CZenohBridge",
+            dependencies: ["CZenohPico"],
+            path: "Sources/CZenohBridge",
+            sources: ["zenoh_bridge.c"],
+            publicHeadersPath: "include",
+            cSettings: [
+                .define("ZENOH_MACOS", to: "1", .when(platforms: [.macOS, .macCatalyst])),
+                .define("ZENOH_LINUX", to: "1", .when(platforms: [.linux])),
+                .define("Z_FEATURE_LINK_TCP", to: "1"),
+                .define("Z_FEATURE_LIVELINESS", to: "1"),
+            ]
+        ),
+        .target(
+            name: "CDDSBridge",
+            dependencies: ["CCycloneDDS"],
+            path: "Sources/CDDSBridge",
+            sources: ["dds_bridge.c", "raw_cdr_sertype.c", "raw_cdr_regression_bridge.c"],
+            publicHeadersPath: "include"
+        ),
+
+        // Swift-facing Zenoh / DDS modules. Expand in T1.7 and T1.8 with
+        // DefaultZenohClient / DefaultDDSClient implementations.
+        .target(
+            name: "SwiftROS2Zenoh",
+            dependencies: ["CZenohBridge", "SwiftROS2Transport", "SwiftROS2Wire"],
+            path: "Sources/SwiftROS2Zenoh"
+        ),
+        .target(
+            name: "SwiftROS2DDS",
+            dependencies: ["CDDSBridge", "SwiftROS2Transport", "SwiftROS2Wire"],
+            path: "Sources/SwiftROS2DDS"
         ),
 
         // Public API: Context, Node, Publisher, Subscription

--- a/Package.swift
+++ b/Package.swift
@@ -83,7 +83,7 @@ let package = Package(
             sources: ["dds_bridge.c", "raw_cdr_sertype.c", "raw_cdr_regression_bridge.c"],
             publicHeadersPath: "include",
             cSettings: [
-                .define("DDS_AVAILABLE", to: "1"),
+                .define("DDS_AVAILABLE", to: "1")
             ]
         ),
 

--- a/Package.swift
+++ b/Package.swift
@@ -124,5 +124,10 @@ let package = Package(
             dependencies: ["SwiftROS2", "SwiftROS2Messages", "SwiftROS2CDR"],
             path: "Tests/SwiftROS2Tests"
         ),
+        .testTarget(
+            name: "SwiftROS2ZenohTests",
+            dependencies: ["SwiftROS2Zenoh"],
+            path: "Tests/SwiftROS2ZenohTests"
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -107,6 +107,8 @@ let package = Package(
                 "SwiftROS2Messages",
                 "SwiftROS2Transport",
                 "SwiftROS2Wire",
+                "SwiftROS2Zenoh",
+                "SwiftROS2DDS",
             ],
             path: "Sources/SwiftROS2"
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -139,5 +139,10 @@ let package = Package(
             dependencies: ["SwiftROS2DDS"],
             path: "Tests/SwiftROS2DDSTests"
         ),
+        .testTarget(
+            name: "SwiftROS2IntegrationTests",
+            dependencies: ["SwiftROS2", "SwiftROS2Messages", "SwiftROS2Transport"],
+            path: "Tests/SwiftROS2IntegrationTests"
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -87,8 +87,9 @@ let package = Package(
             ]
         ),
 
-        // Swift-facing Zenoh / DDS modules. Expand in T1.7 and T1.8 with
-        // DefaultZenohClient / DefaultDDSClient implementations.
+        // Swift-facing Zenoh / DDS modules. Host DefaultZenohClient /
+        // DefaultDDSClient, which conform to the ZenohClientProtocol /
+        // DDSClientProtocol defined in SwiftROS2Transport.
         .target(
             name: "SwiftROS2Zenoh",
             dependencies: ["CZenohBridge", "SwiftROS2Transport", "SwiftROS2Wire"],

--- a/Package.swift
+++ b/Package.swift
@@ -81,7 +81,10 @@ let package = Package(
             dependencies: ["CCycloneDDS"],
             path: "Sources/CDDSBridge",
             sources: ["dds_bridge.c", "raw_cdr_sertype.c", "raw_cdr_regression_bridge.c"],
-            publicHeadersPath: "include"
+            publicHeadersPath: "include",
+            cSettings: [
+                .define("DDS_AVAILABLE", to: "1"),
+            ]
         ),
 
         // Swift-facing Zenoh / DDS modules. Expand in T1.7 and T1.8 with
@@ -128,6 +131,11 @@ let package = Package(
             name: "SwiftROS2ZenohTests",
             dependencies: ["SwiftROS2Zenoh"],
             path: "Tests/SwiftROS2ZenohTests"
+        ),
+        .testTarget(
+            name: "SwiftROS2DDSTests",
+            dependencies: ["SwiftROS2DDS"],
+            path: "Tests/SwiftROS2DDSTests"
         ),
     ]
 )

--- a/Scripts/bootstrap-maccatalyst.sh
+++ b/Scripts/bootstrap-maccatalyst.sh
@@ -1,44 +1,79 @@
 #!/usr/bin/env bash
 # Bootstrap Vendor/ with pre-built CycloneDDS + zenoh-pico static libs
-# from the parent Conduit checkout (deps/maccatalyst). Used during Phase 1
-# so `swift build` can compile the Swift layer before xcframeworks are
-# published in Phase 2. Safe to re-run.
+# from the parent Conduit checkout. Used during Phase 1 so `swift build`
+# and `swift test` can compile + link before xcframeworks are published
+# in Phase 2. Safe to re-run.
+#
+# Produces:
+#   Vendor/include/            — zenoh-pico + cyclonedds headers
+#   Vendor/maccatalyst-arm64/  — libs for Mac Catalyst (xcodebuild)
+#   Vendor/macos-arm64/        — libs for native macOS (swift test)
+#   Vendor/pkgconfig/*.pc      — pkg-config files pointing at macos-arm64
+#                                (swift test default). Override Libs:
+#                                manually if you need a different slice.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-CONDUIT_DEPS="${CONDUIT_DEPS:-$ROOT/../../deps}"
+CONDUIT="${CONDUIT:-$ROOT/../..}"
+CONDUIT_DEPS="${CONDUIT_DEPS:-$CONDUIT/deps}"
 
-if [ ! -f "$CONDUIT_DEPS/maccatalyst/libzenohpico.a" ]; then
-    echo "error: $CONDUIT_DEPS/maccatalyst/libzenohpico.a not found." >&2
-    echo "Build Conduit deps first: SDK=maccatalyst bash $CONDUIT_DEPS/../scripts/build_deps.sh" >&2
-    exit 1
-fi
+require() {
+    local path="$1" hint="$2"
+    if [ ! -f "$path" ]; then
+        echo "error: $path not found. $hint" >&2
+        exit 1
+    fi
+}
 
-mkdir -p "$ROOT/Vendor/maccatalyst-arm64" "$ROOT/Vendor/include" "$ROOT/Vendor/pkgconfig"
+mkdir -p "$ROOT/Vendor/include" "$ROOT/Vendor/maccatalyst-arm64" \
+         "$ROOT/Vendor/macos-arm64" "$ROOT/Vendor/pkgconfig"
 
+# Mac Catalyst libs
+require "$CONDUIT_DEPS/maccatalyst/libzenohpico.a" \
+    "Build via: SDK=maccatalyst bash $CONDUIT/scripts/build_deps.sh"
+require "$CONDUIT_DEPS/maccatalyst/libddsc.a" \
+    "Build via: SDK=maccatalyst bash $CONDUIT/scripts/build_cyclonedds.sh"
 cp "$CONDUIT_DEPS/maccatalyst/libzenohpico.a" "$ROOT/Vendor/maccatalyst-arm64/"
-cp "$CONDUIT_DEPS/maccatalyst/libddsc.a" "$ROOT/Vendor/maccatalyst-arm64/"
-cp -R "$CONDUIT_DEPS/include/zenoh-pico" "$ROOT/Vendor/include/"
-cp "$CONDUIT_DEPS/include/zenoh-pico.h" "$ROOT/Vendor/include/"
-cp -R "$CONDUIT_DEPS/include/dds" "$ROOT/Vendor/include/"
-cp -R "$CONDUIT_DEPS/include/ddsc" "$ROOT/Vendor/include/"
+cp "$CONDUIT_DEPS/maccatalyst/libddsc.a"      "$ROOT/Vendor/maccatalyst-arm64/"
 
+# Native macOS libs (for swift test). These come from out-of-tree CMake
+# builds Conduit performs when running the native macOS-arm64 scheme.
+require "$CONDUIT_DEPS/zenoh-pico/build-macos-arm64/lib/libzenohpico.a" \
+    "Build via: (cd $CONDUIT_DEPS/zenoh-pico && mkdir -p build-macos-arm64 && \
+cd build-macos-arm64 && cmake .. -DBUILD_SHARED_LIBS=OFF -DZ_FEATURE_LINK_TCP=1 \
+-DZ_FEATURE_LIVELINESS=1 && cmake --build .)"
+require "$CONDUIT_DEPS/cyclonedds/build-macos-arm64/lib/libddsc.a" \
+    "Build via: (cd $CONDUIT_DEPS/cyclonedds && mkdir -p build-macos-arm64 && \
+cd build-macos-arm64 && cmake .. -DBUILD_SHARED_LIBS=OFF -DBUILD_EXAMPLES=OFF \
+-DBUILD_TESTING=OFF -DENABLE_SSL=OFF -DENABLE_SECURITY=OFF && cmake --build .)"
+cp "$CONDUIT_DEPS/zenoh-pico/build-macos-arm64/lib/libzenohpico.a" "$ROOT/Vendor/macos-arm64/"
+cp "$CONDUIT_DEPS/cyclonedds/build-macos-arm64/lib/libddsc.a"      "$ROOT/Vendor/macos-arm64/"
+
+# Headers (same content across slices)
+rm -rf "$ROOT/Vendor/include/zenoh-pico" "$ROOT/Vendor/include/dds" "$ROOT/Vendor/include/ddsc"
+cp -R "$CONDUIT_DEPS/include/zenoh-pico" "$ROOT/Vendor/include/"
+cp    "$CONDUIT_DEPS/include/zenoh-pico.h" "$ROOT/Vendor/include/"
+cp -R "$CONDUIT_DEPS/include/dds"   "$ROOT/Vendor/include/"
+cp -R "$CONDUIT_DEPS/include/ddsc"  "$ROOT/Vendor/include/"
+
+# pkg-config files default to macos-arm64 (what `swift test` links).
+# For xcodebuild/iOS builds the xcframework (Phase 2) replaces this.
 cat > "$ROOT/Vendor/pkgconfig/ZenohPico.pc" <<'EOF'
 prefix=${pcfiledir}/../..
 Name: ZenohPico
-Description: zenoh-pico (local bootstrap .a for macCatalyst-arm64)
+Description: zenoh-pico (local bootstrap .a for macOS-arm64)
 Version: 1.1.0
 Cflags: -I${prefix}/Vendor/include
-Libs: -L${prefix}/Vendor/maccatalyst-arm64 -lzenohpico
+Libs: -L${prefix}/Vendor/macos-arm64 -lzenohpico
 EOF
 
 cat > "$ROOT/Vendor/pkgconfig/CycloneDDS.pc" <<'EOF'
 prefix=${pcfiledir}/../..
 Name: CycloneDDS
-Description: Eclipse Cyclone DDS (local bootstrap .a for macCatalyst-arm64)
+Description: Eclipse Cyclone DDS (local bootstrap .a for macOS-arm64)
 Version: 0.10.5
 Cflags: -I${prefix}/Vendor/include
-Libs: -L${prefix}/Vendor/maccatalyst-arm64 -lddsc
+Libs: -L${prefix}/Vendor/macos-arm64 -lddsc
 EOF
 
-echo "Bootstrap complete. Export PKG_CONFIG_PATH=$ROOT/Vendor/pkgconfig before 'swift build'."
+echo "Bootstrap complete. Export PKG_CONFIG_PATH=$ROOT/Vendor/pkgconfig before 'swift build' / 'swift test'."

--- a/Scripts/bootstrap-maccatalyst.sh
+++ b/Scripts/bootstrap-maccatalyst.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Bootstrap Vendor/ with pre-built CycloneDDS + zenoh-pico static libs
+# from the parent Conduit checkout (deps/maccatalyst). Used during Phase 1
+# so `swift build` can compile the Swift layer before xcframeworks are
+# published in Phase 2. Safe to re-run.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONDUIT_DEPS="${CONDUIT_DEPS:-$ROOT/../../deps}"
+
+if [ ! -f "$CONDUIT_DEPS/maccatalyst/libzenohpico.a" ]; then
+    echo "error: $CONDUIT_DEPS/maccatalyst/libzenohpico.a not found." >&2
+    echo "Build Conduit deps first: SDK=maccatalyst bash $CONDUIT_DEPS/../scripts/build_deps.sh" >&2
+    exit 1
+fi
+
+mkdir -p "$ROOT/Vendor/maccatalyst-arm64" "$ROOT/Vendor/include" "$ROOT/Vendor/pkgconfig"
+
+cp "$CONDUIT_DEPS/maccatalyst/libzenohpico.a" "$ROOT/Vendor/maccatalyst-arm64/"
+cp "$CONDUIT_DEPS/maccatalyst/libddsc.a" "$ROOT/Vendor/maccatalyst-arm64/"
+cp -R "$CONDUIT_DEPS/include/zenoh-pico" "$ROOT/Vendor/include/"
+cp "$CONDUIT_DEPS/include/zenoh-pico.h" "$ROOT/Vendor/include/"
+cp -R "$CONDUIT_DEPS/include/dds" "$ROOT/Vendor/include/"
+cp -R "$CONDUIT_DEPS/include/ddsc" "$ROOT/Vendor/include/"
+
+cat > "$ROOT/Vendor/pkgconfig/ZenohPico.pc" <<'EOF'
+prefix=${pcfiledir}/../..
+Name: ZenohPico
+Description: zenoh-pico (local bootstrap .a for macCatalyst-arm64)
+Version: 1.1.0
+Cflags: -I${prefix}/Vendor/include
+Libs: -L${prefix}/Vendor/maccatalyst-arm64 -lzenohpico
+EOF
+
+cat > "$ROOT/Vendor/pkgconfig/CycloneDDS.pc" <<'EOF'
+prefix=${pcfiledir}/../..
+Name: CycloneDDS
+Description: Eclipse Cyclone DDS (local bootstrap .a for macCatalyst-arm64)
+Version: 0.10.5
+Cflags: -I${prefix}/Vendor/include
+Libs: -L${prefix}/Vendor/maccatalyst-arm64 -lddsc
+EOF
+
+echo "Bootstrap complete. Export PKG_CONFIG_PATH=$ROOT/Vendor/pkgconfig before 'swift build'."

--- a/Sources/CCycloneDDS/module.modulemap
+++ b/Sources/CCycloneDDS/module.modulemap
@@ -1,0 +1,5 @@
+module CCycloneDDS [system] {
+    header "shim.h"
+    link "ddsc"
+    export *
+}

--- a/Sources/CCycloneDDS/shim.h
+++ b/Sources/CCycloneDDS/shim.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "dds/dds.h"
+#include "dds/ddsc/dds_public_qosdefs.h"
+#include "dds/ddsi/ddsi_sertype.h"
+#include "dds/ddsi/ddsi_serdata.h"

--- a/Sources/CDDSBridge/dds_bridge.c
+++ b/Sources/CDDSBridge/dds_bridge.c
@@ -11,7 +11,9 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
-#include <dispatch/dispatch.h>
+#ifdef __APPLE__
+  #include <dispatch/dispatch.h>
+#endif
 
 // Only compile CycloneDDS implementation when available
 #ifdef DDS_AVAILABLE
@@ -322,6 +324,7 @@ void dds_bridge_destroy_session(bridge_dds_session_t* session) {
         if (g_skip_participant_delete) {
             session->participant = 0;
         } else {
+#ifdef __APPLE__
             __block dds_return_t delete_result = -1;
             dds_entity_t participant_to_delete = session->participant;
 
@@ -342,7 +345,12 @@ void dds_bridge_destroy_session(bridge_dds_session_t* session) {
                        (int)participant_to_delete);
                 g_skip_participant_delete = true;
             }
-
+#else
+            /* Non-Apple (Linux): no GCD dispatch timeout — just call
+             * dds_delete directly. CycloneDDS on Linux does not exhibit
+             * the iOS sleep/wake hang that motivated the Apple path. */
+            (void)dds_delete(session->participant);
+#endif
             session->participant = 0;
         }
     }

--- a/Sources/CDDSBridge/dds_bridge.c
+++ b/Sources/CDDSBridge/dds_bridge.c
@@ -1,0 +1,787 @@
+//
+// dds_bridge.c
+// C-FFI bridge for CycloneDDS
+//
+// Implementation of the DDS bridge that wraps CycloneDDS functionality
+// for use from Swift via C-FFI.
+//
+
+#include "dds_bridge.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <dispatch/dispatch.h>
+
+// Only compile CycloneDDS implementation when available
+#ifdef DDS_AVAILABLE
+#include <dds/dds.h>
+#include <dds/ddsc/dds_opcodes.h>
+#include "raw_cdr_sertype.h"
+#endif
+
+// =============================================================================
+// MARK: - Thread-Local Error Storage
+// =============================================================================
+
+#ifdef _Thread_local
+#define THREAD_LOCAL _Thread_local
+#elif defined(__GNUC__) || defined(__clang__)
+#define THREAD_LOCAL __thread
+#else
+#define THREAD_LOCAL
+#endif
+
+static THREAD_LOCAL char g_last_error[512] = {0};
+
+static void set_error(const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    vsnprintf(g_last_error, sizeof(g_last_error), format, args);
+    va_end(args);
+}
+
+const char* dds_bridge_get_last_error(void) {
+    return g_last_error;
+}
+
+void dds_bridge_clear_error(void) {
+    g_last_error[0] = '\0';
+}
+
+// =============================================================================
+// MARK: - Version and Availability
+// =============================================================================
+
+const char* dds_bridge_get_version(void) {
+#ifdef DDS_AVAILABLE
+    // CycloneDDS version is defined at build time
+    return "0.10.5";  // Matches deps/cyclonedds tag
+#else
+    return "unavailable";
+#endif
+}
+
+bool dds_bridge_is_available(void) {
+#ifdef DDS_AVAILABLE
+    return true;
+#else
+    return false;
+#endif
+}
+
+// =============================================================================
+// MARK: - Session Structure
+// =============================================================================
+
+struct bridge_dds_session_s {
+#ifdef DDS_AVAILABLE
+    dds_entity_t domain;
+    dds_entity_t participant;
+    dds_entity_t publisher;
+#else
+    int dummy_domain;
+    int dummy_participant;
+    int dummy_publisher;
+#endif
+    int32_t domain_id;
+    char session_id[33];  // 32 hex chars + null terminator
+    bool is_connected;
+};
+
+// =============================================================================
+// MARK: - Writer Structure
+// =============================================================================
+
+struct bridge_dds_writer_s {
+#ifdef DDS_AVAILABLE
+    dds_entity_t writer;
+    dds_entity_t topic;
+    struct ddsi_sertype* raw_sertype;  // For raw CDR writers (NULL for standard writers)
+#else
+    int dummy_writer;
+    int dummy_topic;
+#endif
+    bridge_dds_session_t* session;
+    char topic_name[256];
+    bool is_active;
+    bool is_raw_cdr;  // True if using raw CDR sertype
+};
+
+// =============================================================================
+// MARK: - Session Management Implementation
+// =============================================================================
+
+// Track whether a domain has been created for this process.
+// CycloneDDS domains are shared per domain_id - once created, the config
+// applies to all participants. Multiple sessions share the same domain.
+#ifdef DDS_AVAILABLE
+static bool g_domain_created = false;
+static int32_t g_domain_id = -1;
+#endif
+
+#ifdef DDS_AVAILABLE
+/// Build XML configuration string for CycloneDDS domain
+/// Returns a malloc'd string that must be freed by the caller
+static char* build_domain_config_xml(int32_t domain_id, const bridge_discovery_config_t* config) {
+    // Buffer for XML configuration
+    char* xml = malloc(8192);
+    if (!xml) {
+        return NULL;
+    }
+
+    // Start building XML
+    int offset = 0;
+    offset += snprintf(xml + offset, 8192 - offset,
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<CycloneDDS xmlns=\"https://cdds.io/config\">\n"
+        "  <Domain id=\"%d\">\n",
+        domain_id);
+
+    // Add discovery configuration
+    if (config && (config->unicast_peers && config->peer_count > 0)) {
+        offset += snprintf(xml + offset, 8192 - offset,
+            "    <Discovery>\n"
+            "      <Peers>\n");
+
+        // Add each peer
+        for (int i = 0; i < config->peer_count; i++) {
+            offset += snprintf(xml + offset, 8192 - offset,
+                "        <Peer address=\"%s\"/>\n",
+                config->unicast_peers[i]);
+        }
+
+        offset += snprintf(xml + offset, 8192 - offset,
+            "      </Peers>\n");
+
+        // Disable multicast SPDP if in unicast-only mode
+        if (config->mode == BRIDGE_DISCOVERY_UNICAST) {
+            offset += snprintf(xml + offset, 8192 - offset,
+                "      <EnableTopicDiscoveryEndpoints>true</EnableTopicDiscoveryEndpoints>\n");
+        }
+
+        // Faster SPDP discovery for mobile devices (default is 30s)
+        offset += snprintf(xml + offset, 8192 - offset,
+            "      <SPDPInterval>1s</SPDPInterval>\n");
+
+        offset += snprintf(xml + offset, 8192 - offset,
+            "    </Discovery>\n");
+    }
+
+    // General configuration: network interface + large message support
+    offset += snprintf(xml + offset, 8192 - offset,
+        "    <General>\n");
+
+    // Network interface binding
+    if (config && config->network_interface && strlen(config->network_interface) > 0) {
+        offset += snprintf(xml + offset, 8192 - offset,
+            "      <Interfaces>\n"
+            "        <NetworkInterface name=\"%s\"/>\n"
+            "      </Interfaces>\n",
+            config->network_interface);
+    }
+
+    // Keep default MaxMessageSize (14720B) and FragmentSize (1344B).
+    // Large payloads like camera images are automatically fragmented at
+    // the DDS level by CycloneDDS's RTPS fragmentation (DATA_FRAG).
+    offset += snprintf(xml + offset, 8192 - offset,
+        "    </General>\n");
+
+    // Close XML
+    snprintf(xml + offset, 8192 - offset,
+        "  </Domain>\n"
+        "</CycloneDDS>\n");
+
+    return xml;
+}
+#endif
+
+bridge_dds_session_t* dds_bridge_create_session(
+    int32_t domain_id,
+    const bridge_discovery_config_t* discovery_config
+) {
+    // Validate domain ID
+    if (domain_id < 0 || domain_id > 232) {
+        set_error("Invalid domain ID: %d (must be 0-232)", domain_id);
+        return NULL;
+    }
+
+    // Allocate session structure
+    bridge_dds_session_t* session = calloc(1, sizeof(bridge_dds_session_t));
+    if (!session) {
+        set_error("Failed to allocate session structure");
+        return NULL;
+    }
+
+    session->domain_id = domain_id;
+    session->is_connected = false;
+
+#ifdef DDS_AVAILABLE
+    // Build XML configuration for discovery peers
+    char* config_xml = build_domain_config_xml(domain_id, discovery_config);
+    if (config_xml) {
+        // Create domain with XML configuration only if not yet created or domain ID changed.
+        // CycloneDDS domains are shared: all participants with the same domain_id
+        // use the same domain config. Only the first dds_create_domain() call applies
+        // the config; subsequent calls for the same ID return an error (already exists).
+        // This means domain config (NetworkInterface, MaxMessageSize, etc.) is fixed
+        // for the lifetime of the process - changing it requires an app restart.
+        if (!g_domain_created || g_domain_id != domain_id) {
+            dds_entity_t domain = dds_create_domain(domain_id, config_xml);
+
+            if (domain >= 0) {
+                session->domain = domain;
+                g_domain_created = true;
+                g_domain_id = domain_id;
+            }
+        }
+
+        free(config_xml);
+    }
+
+    // Create participant QoS with enclave USER_DATA (required by rmw_cyclonedds_cpp)
+    dds_qos_t* ppant_qos = dds_create_qos();
+    if (ppant_qos) {
+        const char* enclave_data = "enclave=/;";
+        dds_qset_userdata(ppant_qos, enclave_data, strlen(enclave_data));
+    }
+
+    // Create domain participant (will use the domain configuration we just set)
+    session->participant = dds_create_participant(domain_id, ppant_qos, NULL);
+    if (ppant_qos) {
+        dds_delete_qos(ppant_qos);
+    }
+    if (session->participant < 0) {
+        set_error("Failed to create participant: %s", dds_strretcode(session->participant));
+        free(session);
+        return NULL;
+    }
+
+    // Create publisher
+    session->publisher = dds_create_publisher(session->participant, NULL, NULL);
+    if (session->publisher < 0) {
+        set_error("Failed to create publisher: %s", dds_strretcode(session->publisher));
+        dds_delete(session->participant);
+        free(session);
+        return NULL;
+    }
+
+    // Get participant GUID for session ID
+    dds_guid_t guid;
+    if (dds_get_guid(session->participant, &guid) == 0) {
+        // Convert GUID to hex string (first 16 bytes)
+        for (int i = 0; i < 16; i++) {
+            snprintf(session->session_id + (i * 2), 3, "%02x", guid.v[i]);
+        }
+    } else {
+        // Fallback: generate random session ID
+        for (int i = 0; i < 32; i++) {
+            session->session_id[i] = "0123456789abcdef"[rand() % 16];
+        }
+    }
+    session->session_id[32] = '\0';
+
+    session->is_connected = true;
+#else
+    // Stub implementation for when CycloneDDS is not available
+    (void)discovery_config;
+    set_error("DDS not available - CycloneDDS not built");
+
+    // Generate fake session ID for testing
+    for (int i = 0; i < 32; i++) {
+        session->session_id[i] = "0123456789abcdef"[rand() % 16];
+    }
+    session->session_id[32] = '\0';
+
+    session->dummy_participant = 1;
+    session->dummy_publisher = 1;
+    session->is_connected = true;
+#endif
+
+    return session;
+}
+
+// Flag to control whether to skip participant deletion (workaround for hang issue)
+// When true, participant is leaked but reconnection works
+static bool g_skip_participant_delete = true;
+
+void dds_bridge_destroy_session(bridge_dds_session_t* session) {
+    if (!session) {
+        return;
+    }
+
+#ifdef DDS_AVAILABLE
+    // Delete publisher first
+    if (session->publisher > 0) {
+        dds_delete(session->publisher);
+        session->publisher = 0;
+    }
+
+    // Participant deletion with timeout to avoid indefinite hang on iOS
+    if (session->participant > 0) {
+        if (g_skip_participant_delete) {
+            session->participant = 0;
+        } else {
+            __block dds_return_t delete_result = -1;
+            dds_entity_t participant_to_delete = session->participant;
+
+            dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+            dispatch_queue_t dq = dispatch_queue_create(
+                "com.conduit.dds.participant_delete", DISPATCH_QUEUE_SERIAL);
+
+            dispatch_async(dq, ^{
+                delete_result = dds_delete(participant_to_delete);
+                dispatch_semaphore_signal(sem);
+            });
+
+            long timeout = dispatch_semaphore_wait(sem,
+                dispatch_time(DISPATCH_TIME_NOW, 3LL * NSEC_PER_SEC));
+
+            if (timeout != 0) {
+                fprintf(stderr, "[DDS] WARNING: Participant deletion timed out, leaking entity %d\n",
+                       (int)participant_to_delete);
+                g_skip_participant_delete = true;
+            }
+
+            session->participant = 0;
+        }
+    }
+#endif
+
+    session->is_connected = false;
+    free(session);
+}
+
+// API to control participant deletion behavior
+void dds_bridge_set_skip_participant_delete(bool skip) {
+    g_skip_participant_delete = skip;
+}
+
+bool dds_bridge_session_is_connected(const bridge_dds_session_t* session) {
+    if (!session) {
+        return false;
+    }
+    return session->is_connected;
+}
+
+int32_t dds_bridge_get_session_id(
+    const bridge_dds_session_t* session,
+    char* buffer,
+    size_t buffer_size
+) {
+    if (!session || !buffer || buffer_size < 33) {
+        set_error("Invalid parameters for dds_bridge_get_session_id");
+        return -1;
+    }
+
+    strncpy(buffer, session->session_id, buffer_size - 1);
+    buffer[buffer_size - 1] = '\0';
+    return 0;
+}
+
+// =============================================================================
+// MARK: - Writer Management Implementation
+// =============================================================================
+
+bridge_dds_writer_t* dds_bridge_create_writer(
+    bridge_dds_session_t* session,
+    const char* topic_name,
+    const char* type_name,
+    const bridge_qos_config_t* qos
+) {
+    if (!session || !topic_name || !type_name) {
+        set_error("Invalid parameters for dds_bridge_create_writer");
+        return NULL;
+    }
+
+    if (!session->is_connected) {
+        set_error("Session is not connected");
+        return NULL;
+    }
+
+    // Allocate writer structure
+    bridge_dds_writer_t* writer = calloc(1, sizeof(bridge_dds_writer_t));
+    if (!writer) {
+        set_error("Failed to allocate writer structure");
+        return NULL;
+    }
+
+    writer->session = session;
+    strncpy(writer->topic_name, topic_name, sizeof(writer->topic_name) - 1);
+    writer->is_active = false;
+    writer->is_raw_cdr = false;
+
+#ifdef DDS_AVAILABLE
+    writer->raw_sertype = NULL;
+    // Use default QoS if not specified
+    const bridge_qos_config_t* effective_qos = qos ? qos : &BRIDGE_QOS_SENSOR_DATA;
+
+    // Create topic descriptor for raw CDR data
+    // We need a minimal valid ops array representing struct { octet data; }
+    // Format: [ADR, TYPE_1BY, 0] [offset=0] [RTS]
+    // DDS_OP_ADR = 0x01000000, DDS_OP_TYPE_1BY = 0x00010000
+    static const uint32_t minimal_ops[] = {
+        (0x01 << 24) | (0x01 << 16),  // DDS_OP_ADR | DDS_OP_TYPE_1BY
+        0,                             // offset = 0
+        0x00000000                     // DDS_OP_RTS
+    };
+
+    // Create descriptor with minimal valid ops
+    // This represents struct { octet data; } - a single byte structure
+    dds_topic_descriptor_t desc = {
+        .m_size = 1,
+        .m_align = 1,
+        .m_flagset = DDS_TOPIC_NO_OPTIMIZE | DDS_TOPIC_FIXED_SIZE,
+        .m_typename = type_name,
+        .m_keys = NULL,
+        .m_nkeys = 0,
+        .m_ops = minimal_ops,
+        .m_nops = 3
+    };
+
+    // Create topic
+    writer->topic = dds_create_topic(
+        session->participant,
+        &desc,
+        topic_name,
+        NULL,
+        NULL
+    );
+
+    if (writer->topic < 0) {
+        set_error("Failed to create topic '%s': %s", topic_name, dds_strretcode(writer->topic));
+        free(writer);
+        return NULL;
+    }
+
+    // Create writer QoS
+    dds_qos_t* writer_qos = dds_create_qos();
+    if (!writer_qos) {
+        set_error("Failed to create writer QoS");
+        dds_delete(writer->topic);
+        free(writer);
+        return NULL;
+    }
+
+    // Set reliability
+    if (effective_qos->reliability == BRIDGE_RELIABILITY_RELIABLE) {
+        dds_qset_reliability(writer_qos, DDS_RELIABILITY_RELIABLE, DDS_MSECS(100));
+    } else {
+        dds_qset_reliability(writer_qos, DDS_RELIABILITY_BEST_EFFORT, 0);
+    }
+
+    // Set durability
+    if (effective_qos->durability == BRIDGE_DURABILITY_TRANSIENT_LOCAL) {
+        dds_qset_durability(writer_qos, DDS_DURABILITY_TRANSIENT_LOCAL);
+    } else {
+        dds_qset_durability(writer_qos, DDS_DURABILITY_VOLATILE);
+    }
+
+    // Set history
+    if (effective_qos->history_kind == BRIDGE_HISTORY_KEEP_ALL) {
+        dds_qset_history(writer_qos, DDS_HISTORY_KEEP_ALL, 0);
+    } else {
+        dds_qset_history(writer_qos, DDS_HISTORY_KEEP_LAST, effective_qos->history_depth);
+    }
+
+    // Create writer
+    writer->writer = dds_create_writer(session->publisher, writer->topic, writer_qos, NULL);
+    dds_delete_qos(writer_qos);
+
+    if (writer->writer < 0) {
+        set_error("Failed to create writer for topic '%s': %s",
+                  topic_name, dds_strretcode(writer->writer));
+        dds_delete(writer->topic);
+        free(writer);
+        return NULL;
+    }
+
+    writer->is_active = true;
+#else
+    // Stub implementation
+    (void)qos;
+    writer->dummy_writer = 1;
+    writer->dummy_topic = 1;
+    writer->is_active = true;
+#endif
+
+    return writer;
+}
+
+void dds_bridge_destroy_writer(bridge_dds_writer_t* writer) {
+    if (!writer) {
+        return;
+    }
+
+#ifdef DDS_AVAILABLE
+    if (writer->writer > 0) {
+        dds_delete(writer->writer);
+        writer->writer = 0;
+    }
+    if (writer->topic > 0) {
+        dds_delete(writer->topic);
+        writer->topic = 0;
+    }
+    writer->raw_sertype = NULL;
+#endif
+
+    free(writer);
+}
+
+bool dds_bridge_writer_is_active(const bridge_dds_writer_t* writer) {
+    if (!writer) {
+        return false;
+    }
+    return writer->is_active;
+}
+
+// =============================================================================
+// MARK: - Publishing Implementation
+// =============================================================================
+
+int32_t dds_bridge_write_cdr(
+    bridge_dds_writer_t* writer,
+    const uint8_t* cdr_data,
+    size_t cdr_len,
+    uint64_t timestamp_ns
+) {
+    if (!writer || !cdr_data || cdr_len == 0) {
+        set_error("Invalid parameters for dds_bridge_write_cdr");
+        return -1;
+    }
+
+    if (!writer->is_active) {
+        set_error("Writer is not active");
+        return -2;
+    }
+
+#ifdef DDS_AVAILABLE
+    // Verify CDR data has encapsulation header
+    if (cdr_len < 4) {
+        set_error("CDR data too short (missing encapsulation header)");
+        return -3;
+    }
+
+    // Write pre-serialized CDR data
+    // Note: CycloneDDS requires using dds_write_ts for timestamped data
+    // The timestamp is set via the source timestamp
+    dds_time_t timestamp = (dds_time_t)timestamp_ns;
+
+    // Set source timestamp
+    // Note: This may require a custom serdata implementation for full control
+    dds_return_t ret = dds_write_ts(writer->writer, cdr_data, timestamp);
+
+    if (ret < 0) {
+        set_error("Failed to write CDR data: %s", dds_strretcode(ret));
+        return -4;
+    }
+
+    return 0;
+#else
+    // Stub implementation - just validate parameters
+    (void)timestamp_ns;
+    return 0;
+#endif
+}
+
+// =============================================================================
+// MARK: - Raw CDR Publishing Implementation
+// =============================================================================
+
+bridge_dds_writer_t* dds_bridge_create_raw_writer(
+    bridge_dds_session_t* session,
+    const char* topic_name,
+    const char* type_name,
+    const bridge_qos_config_t* qos,
+    const char* user_data
+) {
+    if (!session || !topic_name || !type_name) {
+        set_error("Invalid parameters for dds_bridge_create_raw_writer");
+        return NULL;
+    }
+
+    if (!session->is_connected) {
+        set_error("Session is not connected");
+        return NULL;
+    }
+
+    // Allocate writer structure
+    bridge_dds_writer_t* writer = calloc(1, sizeof(bridge_dds_writer_t));
+    if (!writer) {
+        set_error("Failed to allocate writer structure");
+        return NULL;
+    }
+
+    writer->session = session;
+    strncpy(writer->topic_name, topic_name, sizeof(writer->topic_name) - 1);
+    writer->is_active = false;
+    writer->is_raw_cdr = true;  // Mark as raw CDR writer
+
+#ifdef DDS_AVAILABLE
+    // Use default QoS if not specified
+    const bridge_qos_config_t* effective_qos = qos ? qos : &BRIDGE_QOS_SENSOR_DATA;
+
+    // Create raw CDR sertype
+    writer->raw_sertype = raw_cdr_sertype_new(type_name);
+    if (!writer->raw_sertype) {
+        set_error("Failed to create raw CDR sertype for '%s'", type_name);
+        free(writer);
+        return NULL;
+    }
+
+    // Create topic using raw CDR sertype
+    // Note: dds_create_topic_sertype takes ownership of sertype reference,
+    // and may replace the sertype pointer with an existing compatible one.
+    // We add a reference before calling, and after the call we need to use
+    // the (possibly updated) sertype pointer.
+    struct ddsi_sertype* sertype_for_topic = ddsi_sertype_ref(writer->raw_sertype);
+    writer->topic = dds_create_topic_sertype(
+        session->participant,
+        topic_name,
+        &sertype_for_topic,
+        NULL,  // qos
+        NULL,  // listener
+        NULL   // sedp_plist
+    );
+
+    if (writer->topic < 0) {
+        set_error("Failed to create raw CDR topic '%s': %s", topic_name, dds_strretcode(writer->topic));
+        ddsi_sertype_unref(writer->raw_sertype);
+        free(writer);
+        return NULL;
+    }
+
+    // If dds_create_topic_sertype returned a different sertype (because a matching
+    // one was already registered), we need to use that one for creating serdata.
+    // Release our original reference and use the one from topic creation.
+    if (sertype_for_topic != writer->raw_sertype) {
+        ddsi_sertype_unref(writer->raw_sertype);
+        writer->raw_sertype = ddsi_sertype_ref(sertype_for_topic);
+    }
+
+    // Create writer QoS
+    dds_qos_t* writer_qos = dds_create_qos();
+    if (!writer_qos) {
+        set_error("Failed to create writer QoS");
+        dds_delete(writer->topic);
+        ddsi_sertype_unref(writer->raw_sertype);
+        free(writer);
+        return NULL;
+    }
+
+    // Set reliability
+    if (effective_qos->reliability == BRIDGE_RELIABILITY_RELIABLE) {
+        dds_qset_reliability(writer_qos, DDS_RELIABILITY_RELIABLE, DDS_MSECS(100));
+    } else {
+        dds_qset_reliability(writer_qos, DDS_RELIABILITY_BEST_EFFORT, 0);
+    }
+
+    // Set durability
+    if (effective_qos->durability == BRIDGE_DURABILITY_TRANSIENT_LOCAL) {
+        dds_qset_durability(writer_qos, DDS_DURABILITY_TRANSIENT_LOCAL);
+    } else {
+        dds_qset_durability(writer_qos, DDS_DURABILITY_VOLATILE);
+    }
+
+    // Set history
+    if (effective_qos->history_kind == BRIDGE_HISTORY_KEEP_ALL) {
+        dds_qset_history(writer_qos, DDS_HISTORY_KEEP_ALL, 0);
+    } else {
+        dds_qset_history(writer_qos, DDS_HISTORY_KEEP_LAST, effective_qos->history_depth);
+    }
+
+    // Set USER_DATA QoS (type hash for rmw_cyclonedds_cpp discovery)
+    if (user_data && strlen(user_data) > 0) {
+        dds_qset_userdata(writer_qos, user_data, strlen(user_data));
+    }
+
+    // Create writer
+    writer->writer = dds_create_writer(session->publisher, writer->topic, writer_qos, NULL);
+    dds_delete_qos(writer_qos);
+
+    if (writer->writer < 0) {
+        set_error("Failed to create raw CDR writer for topic '%s': %s",
+                  topic_name, dds_strretcode(writer->writer));
+        dds_delete(writer->topic);
+        ddsi_sertype_unref(writer->raw_sertype);
+        free(writer);
+        return NULL;
+    }
+
+    writer->is_active = true;
+#else
+    // Stub implementation
+    (void)qos;
+    (void)user_data;
+    writer->dummy_writer = 1;
+    writer->dummy_topic = 1;
+    writer->is_active = true;
+#endif
+
+    return writer;
+}
+
+int32_t dds_bridge_write_raw_cdr(
+    bridge_dds_writer_t* writer,
+    const uint8_t* cdr_data,
+    size_t cdr_len,
+    uint64_t timestamp_ns
+) {
+    if (!writer || !cdr_data || cdr_len == 0) {
+        set_error("Invalid parameters for dds_bridge_write_raw_cdr");
+        return -1;
+    }
+
+    if (!writer->is_active) {
+        set_error("Writer is not active");
+        return -2;
+    }
+
+    if (!writer->is_raw_cdr) {
+        set_error("Writer was not created as raw CDR writer");
+        return -3;
+    }
+
+#ifdef DDS_AVAILABLE
+    // Verify CDR data has encapsulation header
+    if (cdr_len < 4) {
+        set_error("CDR data too short (missing encapsulation header)");
+        return -4;
+    }
+
+    if (writer->raw_sertype == NULL) {
+        set_error("raw_sertype is NULL");
+        return -10;
+    }
+
+    // Create raw CDR serdata
+    dds_time_t timestamp = (dds_time_t)timestamp_ns;
+    struct ddsi_serdata* serdata = raw_cdr_serdata_new(
+        writer->raw_sertype,
+        cdr_data,
+        cdr_len,
+        timestamp
+    );
+
+    if (!serdata) {
+        set_error("Failed to create raw CDR serdata");
+        return -5;
+    }
+
+    // Write using dds_writecdr (this takes ownership of serdata reference)
+    dds_return_t ret = dds_writecdr(writer->writer, serdata);
+
+    if (ret < 0) {
+        set_error("Failed to write raw CDR data: %s", dds_strretcode(ret));
+        // Note: dds_writecdr may not consume the reference on error
+        // but in practice we shouldn't double-unref
+        return -6;
+    }
+
+    return 0;
+#else
+    // Stub implementation - just validate parameters
+    (void)timestamp_ns;
+    return 0;
+#endif
+}

--- a/Sources/CDDSBridge/dds_bridge.c
+++ b/Sources/CDDSBridge/dds_bridge.c
@@ -123,76 +123,124 @@ static int32_t g_domain_id = -1;
 #endif
 
 #ifdef DDS_AVAILABLE
+#define DOMAIN_CONFIG_XML_SIZE 8192
+
+// Append formatted text to the XML buffer, checking for overflow/truncation.
+// On overflow or encoding error, frees the buffer, sets *xml_out to NULL, and
+// returns false so the caller can abort.
+static bool xml_append(char** xml_out, size_t* offset, const char* fmt, ...)
+    __attribute__((format(printf, 3, 4)));
+
+static bool xml_append(char** xml_out, size_t* offset, const char* fmt, ...) {
+    if (!xml_out || !*xml_out || !offset) {
+        return false;
+    }
+    if (*offset >= DOMAIN_CONFIG_XML_SIZE) {
+        free(*xml_out);
+        *xml_out = NULL;
+        return false;
+    }
+    size_t remaining = DOMAIN_CONFIG_XML_SIZE - *offset;
+
+    va_list ap;
+    va_start(ap, fmt);
+    int needed = vsnprintf(*xml_out + *offset, remaining, fmt, ap);
+    va_end(ap);
+
+    if (needed < 0 || (size_t)needed >= remaining) {
+        // Encoding error or truncation - treat as fatal.
+        free(*xml_out);
+        *xml_out = NULL;
+        return false;
+    }
+    *offset += (size_t)needed;
+    return true;
+}
+
 /// Build XML configuration string for CycloneDDS domain
 /// Returns a malloc'd string that must be freed by the caller
 static char* build_domain_config_xml(int32_t domain_id, const bridge_discovery_config_t* config) {
-    // Buffer for XML configuration
-    char* xml = malloc(8192);
+    char* xml = malloc(DOMAIN_CONFIG_XML_SIZE);
     if (!xml) {
         return NULL;
     }
 
-    // Start building XML
-    int offset = 0;
-    offset += snprintf(xml + offset, 8192 - offset,
+    size_t offset = 0;
+    if (!xml_append(&xml, &offset,
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
         "<CycloneDDS xmlns=\"https://cdds.io/config\">\n"
         "  <Domain id=\"%d\">\n",
-        domain_id);
+        domain_id)) {
+        return NULL;
+    }
 
     // Add discovery configuration
     if (config && (config->unicast_peers && config->peer_count > 0)) {
-        offset += snprintf(xml + offset, 8192 - offset,
+        if (!xml_append(&xml, &offset,
             "    <Discovery>\n"
-            "      <Peers>\n");
+            "      <Peers>\n")) {
+            return NULL;
+        }
 
         // Add each peer
         for (int i = 0; i < config->peer_count; i++) {
-            offset += snprintf(xml + offset, 8192 - offset,
+            if (!xml_append(&xml, &offset,
                 "        <Peer address=\"%s\"/>\n",
-                config->unicast_peers[i]);
+                config->unicast_peers[i])) {
+                return NULL;
+            }
         }
 
-        offset += snprintf(xml + offset, 8192 - offset,
-            "      </Peers>\n");
+        if (!xml_append(&xml, &offset, "      </Peers>\n")) {
+            return NULL;
+        }
 
         // Disable multicast SPDP if in unicast-only mode
         if (config->mode == BRIDGE_DISCOVERY_UNICAST) {
-            offset += snprintf(xml + offset, 8192 - offset,
-                "      <EnableTopicDiscoveryEndpoints>true</EnableTopicDiscoveryEndpoints>\n");
+            if (!xml_append(&xml, &offset,
+                "      <EnableTopicDiscoveryEndpoints>true</EnableTopicDiscoveryEndpoints>\n")) {
+                return NULL;
+            }
         }
 
         // Faster SPDP discovery for mobile devices (default is 30s)
-        offset += snprintf(xml + offset, 8192 - offset,
-            "      <SPDPInterval>1s</SPDPInterval>\n");
+        if (!xml_append(&xml, &offset, "      <SPDPInterval>1s</SPDPInterval>\n")) {
+            return NULL;
+        }
 
-        offset += snprintf(xml + offset, 8192 - offset,
-            "    </Discovery>\n");
+        if (!xml_append(&xml, &offset, "    </Discovery>\n")) {
+            return NULL;
+        }
     }
 
     // General configuration: network interface + large message support
-    offset += snprintf(xml + offset, 8192 - offset,
-        "    <General>\n");
+    if (!xml_append(&xml, &offset, "    <General>\n")) {
+        return NULL;
+    }
 
     // Network interface binding
     if (config && config->network_interface && strlen(config->network_interface) > 0) {
-        offset += snprintf(xml + offset, 8192 - offset,
+        if (!xml_append(&xml, &offset,
             "      <Interfaces>\n"
             "        <NetworkInterface name=\"%s\"/>\n"
             "      </Interfaces>\n",
-            config->network_interface);
+            config->network_interface)) {
+            return NULL;
+        }
     }
 
     // Keep default MaxMessageSize (14720B) and FragmentSize (1344B).
     // Large payloads like camera images are automatically fragmented at
     // the DDS level by CycloneDDS's RTPS fragmentation (DATA_FRAG).
-    offset += snprintf(xml + offset, 8192 - offset,
-        "    </General>\n");
+    if (!xml_append(&xml, &offset, "    </General>\n")) {
+        return NULL;
+    }
 
-    // Close XML
-    snprintf(xml + offset, 8192 - offset,
+    if (!xml_append(&xml, &offset,
         "  </Domain>\n"
-        "</CycloneDDS>\n");
+        "</CycloneDDS>\n")) {
+        return NULL;
+    }
 
     return xml;
 }
@@ -553,43 +601,22 @@ int32_t dds_bridge_write_cdr(
     size_t cdr_len,
     uint64_t timestamp_ns
 ) {
-    if (!writer || !cdr_data || cdr_len == 0) {
-        set_error("Invalid parameters for dds_bridge_write_cdr");
-        return -1;
-    }
-
-    if (!writer->is_active) {
-        set_error("Writer is not active");
-        return -2;
-    }
-
-#ifdef DDS_AVAILABLE
-    // Verify CDR data has encapsulation header
-    if (cdr_len < 4) {
-        set_error("CDR data too short (missing encapsulation header)");
-        return -3;
-    }
-
-    // Write pre-serialized CDR data
-    // Note: CycloneDDS requires using dds_write_ts for timestamped data
-    // The timestamp is set via the source timestamp
-    dds_time_t timestamp = (dds_time_t)timestamp_ns;
-
-    // Set source timestamp
-    // Note: This may require a custom serdata implementation for full control
-    dds_return_t ret = dds_write_ts(writer->writer, cdr_data, timestamp);
-
-    if (ret < 0) {
-        set_error("Failed to write CDR data: %s", dds_strretcode(ret));
-        return -4;
-    }
-
-    return 0;
-#else
-    // Stub implementation - just validate parameters
+    // This API is documented as publishing pre-serialized CDR bytes, but
+    // dds_write_ts expects a pointer to an in-memory sample matching the
+    // writer's topic descriptor, not serialized wire-format data. Using it
+    // here would publish incorrect data on the wire. Until this function is
+    // reworked to use CycloneDDS's proper serialized/CDR write path (similar
+    // to dds_bridge_write_raw_cdr), fail explicitly instead of attempting an
+    // invalid write. New code should use dds_bridge_create_raw_writer +
+    // dds_bridge_write_raw_cdr.
+    (void)writer;
+    (void)cdr_data;
+    (void)cdr_len;
     (void)timestamp_ns;
-    return 0;
-#endif
+    set_error(
+        "dds_bridge_write_cdr is not supported: use dds_bridge_create_raw_writer "
+        "+ dds_bridge_write_raw_cdr for pre-serialized CDR publishing");
+    return -4;
 }
 
 // =============================================================================
@@ -776,13 +803,14 @@ int32_t dds_bridge_write_raw_cdr(
         return -5;
     }
 
-    // Write using dds_writecdr (this takes ownership of serdata reference)
+    // Write using dds_writecdr. On success CycloneDDS consumes the serdata
+    // reference; on failure ownership stays with us, so we must unref to avoid
+    // leaking one serdata per failed publish.
     dds_return_t ret = dds_writecdr(writer->writer, serdata);
 
     if (ret < 0) {
         set_error("Failed to write raw CDR data: %s", dds_strretcode(ret));
-        // Note: dds_writecdr may not consume the reference on error
-        // but in practice we shouldn't double-unref
+        ddsi_serdata_unref(serdata);
         return -6;
     }
 

--- a/Sources/CDDSBridge/include/dds_bridge.h
+++ b/Sources/CDDSBridge/include/dds_bridge.h
@@ -1,0 +1,270 @@
+//
+// dds_bridge.h
+// C-FFI bridge for CycloneDDS
+//
+// This header provides a Swift-callable interface to CycloneDDS.
+// The bridge abstracts CycloneDDS complexity and provides a simple
+// session/writer model for publishing ROS 2 messages.
+//
+// NOTE: Types use "bridge_" prefix to avoid conflicts with CycloneDDS types.
+//
+
+#ifndef DDS_BRIDGE_H
+#define DDS_BRIDGE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// MARK: - Opaque Handle Types
+// =============================================================================
+
+/// Opaque handle to a DDS session (participant + publisher)
+typedef struct bridge_dds_session_s bridge_dds_session_t;
+
+/// Opaque handle to a DDS data writer
+typedef struct bridge_dds_writer_s bridge_dds_writer_t;
+
+// =============================================================================
+// MARK: - Discovery Configuration
+// =============================================================================
+
+/// DDS discovery mode
+typedef enum {
+    /// Standard SPDP multicast discovery (default)
+    /// Automatic peer discovery on local network
+    BRIDGE_DISCOVERY_MULTICAST = 0,
+
+    /// Unicast-only discovery
+    /// Manual peer configuration required
+    BRIDGE_DISCOVERY_UNICAST = 1,
+
+    /// Hybrid mode: multicast + specific unicast peers
+    BRIDGE_DISCOVERY_HYBRID = 2
+} bridge_discovery_mode_t;
+
+/// Discovery configuration structure
+typedef struct {
+    /// Discovery mode (multicast, unicast, hybrid)
+    bridge_discovery_mode_t mode;
+
+    /// NULL-terminated array of unicast peer locators
+    /// Format: "address:port" (e.g., "192.168.1.100:7400")
+    /// Only used when mode is UNICAST or HYBRID
+    const char** unicast_peers;
+
+    /// Number of unicast peers
+    int peer_count;
+
+    /// Network interface to bind to (NULL = all interfaces)
+    const char* network_interface;
+} bridge_discovery_config_t;
+
+// =============================================================================
+// MARK: - QoS Configuration
+// =============================================================================
+
+/// DDS reliability setting
+typedef enum {
+    BRIDGE_RELIABILITY_BEST_EFFORT = 0,
+    BRIDGE_RELIABILITY_RELIABLE = 1
+} bridge_reliability_t;
+
+/// DDS durability setting
+typedef enum {
+    BRIDGE_DURABILITY_VOLATILE = 0,
+    BRIDGE_DURABILITY_TRANSIENT_LOCAL = 1
+} bridge_durability_t;
+
+/// DDS history setting
+typedef enum {
+    BRIDGE_HISTORY_KEEP_LAST = 0,
+    BRIDGE_HISTORY_KEEP_ALL = 1
+} bridge_history_kind_t;
+
+/// QoS configuration structure
+typedef struct {
+    bridge_reliability_t reliability;
+    bridge_durability_t durability;
+    bridge_history_kind_t history_kind;
+    int32_t history_depth;
+} bridge_qos_config_t;
+
+/// Default QoS for sensor data
+static const bridge_qos_config_t BRIDGE_QOS_SENSOR_DATA = {
+    .reliability = BRIDGE_RELIABILITY_RELIABLE,
+    .durability = BRIDGE_DURABILITY_VOLATILE,
+    .history_kind = BRIDGE_HISTORY_KEEP_LAST,
+    .history_depth = 10
+};
+
+// =============================================================================
+// MARK: - Session Management
+// =============================================================================
+
+/// Create a DDS session with the specified domain ID and discovery configuration
+///
+/// @param domain_id ROS 2 domain ID (0-232)
+/// @param discovery_config Discovery configuration (NULL for defaults)
+/// @return Session handle, or NULL on failure (check dds_bridge_get_last_error())
+bridge_dds_session_t* dds_bridge_create_session(
+    int32_t domain_id,
+    const bridge_discovery_config_t* discovery_config
+);
+
+/// Destroy a DDS session and release all resources
+///
+/// @param session Session to destroy
+void dds_bridge_destroy_session(bridge_dds_session_t* session);
+
+/// Control whether to skip participant deletion during session destroy
+///
+/// When enabled (default), participant entities are leaked instead of deleted
+/// to avoid the hang issue with dds_delete(participant). This allows
+/// reconnection to work at the cost of resource leaks.
+///
+/// @param skip true to skip deletion (leak), false for normal deletion (may hang)
+void dds_bridge_set_skip_participant_delete(bool skip);
+
+/// Check if a session is connected and healthy
+///
+/// @param session Session to check
+/// @return true if session is healthy, false otherwise
+bool dds_bridge_session_is_connected(const bridge_dds_session_t* session);
+
+/// Get the session's participant GUID as a hex string
+///
+/// @param session Session to query
+/// @param buffer Output buffer (must be at least 33 bytes)
+/// @param buffer_size Size of the output buffer
+/// @return 0 on success, negative on failure
+int32_t dds_bridge_get_session_id(
+    const bridge_dds_session_t* session,
+    char* buffer,
+    size_t buffer_size
+);
+
+// =============================================================================
+// MARK: - Writer Management
+// =============================================================================
+
+/// Create a DDS data writer for a topic
+///
+/// @param session Active DDS session
+/// @param topic_name Full topic name (e.g., "/ios/imu")
+/// @param type_name DDS type name (e.g., "sensor_msgs::msg::dds_::Imu_")
+/// @param qos QoS configuration (NULL for sensor data defaults)
+/// @return Writer handle, or NULL on failure (check dds_bridge_get_last_error())
+bridge_dds_writer_t* dds_bridge_create_writer(
+    bridge_dds_session_t* session,
+    const char* topic_name,
+    const char* type_name,
+    const bridge_qos_config_t* qos
+);
+
+/// Destroy a DDS data writer
+///
+/// @param writer Writer to destroy
+void dds_bridge_destroy_writer(bridge_dds_writer_t* writer);
+
+/// Check if a writer is active
+///
+/// @param writer Writer to check
+/// @return true if writer is active, false otherwise
+bool dds_bridge_writer_is_active(const bridge_dds_writer_t* writer);
+
+// =============================================================================
+// MARK: - Publishing
+// =============================================================================
+
+/// Publish pre-serialized CDR data
+///
+/// @param writer Active DDS writer
+/// @param cdr_data CDR-serialized payload (with 4-byte encapsulation header)
+/// @param cdr_len Length of CDR data in bytes
+/// @param timestamp_ns Timestamp in nanoseconds since Unix epoch
+/// @return 0 on success, negative on failure (check dds_bridge_get_last_error())
+int32_t dds_bridge_write_cdr(
+    bridge_dds_writer_t* writer,
+    const uint8_t* cdr_data,
+    size_t cdr_len,
+    uint64_t timestamp_ns
+);
+
+// =============================================================================
+// MARK: - Raw CDR Publishing (Custom Sertype)
+// =============================================================================
+
+/// Create a DDS data writer using custom raw CDR sertype
+///
+/// This function creates a writer that can publish pre-serialized CDR data
+/// using a custom sertype implementation. Unlike dds_bridge_create_writer,
+/// this does not require a schema-based topic descriptor.
+///
+/// @param session Active DDS session
+/// @param topic_name Full topic name (e.g., "/ios/imu")
+/// @param type_name DDS type name (e.g., "sensor_msgs::msg::dds_::Imu_")
+/// @param qos QoS configuration (NULL for sensor data defaults)
+/// @param user_data USER_DATA QoS string for writer (e.g., "typehash=RIHS01_...;"), NULL to omit
+/// @return Writer handle, or NULL on failure (check dds_bridge_get_last_error())
+bridge_dds_writer_t* dds_bridge_create_raw_writer(
+    bridge_dds_session_t* session,
+    const char* topic_name,
+    const char* type_name,
+    const bridge_qos_config_t* qos,
+    const char* user_data
+);
+
+/// Write pre-serialized CDR data using raw CDR sertype
+///
+/// This function writes data using the custom sertype/serdata implementation.
+/// The writer must have been created with dds_bridge_create_raw_writer.
+///
+/// @param writer Active DDS writer (created with dds_bridge_create_raw_writer)
+/// @param cdr_data CDR-serialized payload (with 4-byte encapsulation header)
+/// @param cdr_len Length of CDR data in bytes
+/// @param timestamp_ns Timestamp in nanoseconds since Unix epoch
+/// @return 0 on success, negative on failure (check dds_bridge_get_last_error())
+int32_t dds_bridge_write_raw_cdr(
+    bridge_dds_writer_t* writer,
+    const uint8_t* cdr_data,
+    size_t cdr_len,
+    uint64_t timestamp_ns
+);
+
+// =============================================================================
+// MARK: - Error Handling
+// =============================================================================
+
+/// Get the last error message
+///
+/// @return Error message string (thread-local, do not free)
+const char* dds_bridge_get_last_error(void);
+
+/// Clear the last error
+void dds_bridge_clear_error(void);
+
+// =============================================================================
+// MARK: - Version Information
+// =============================================================================
+
+/// Get CycloneDDS version string
+///
+/// @return Version string (e.g., "11.0.1")
+const char* dds_bridge_get_version(void);
+
+/// Check if DDS bridge is available (compiled with CycloneDDS)
+///
+/// @return true if DDS is available, false otherwise
+bool dds_bridge_is_available(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DDS_BRIDGE_H

--- a/Sources/CDDSBridge/include/module.modulemap
+++ b/Sources/CDDSBridge/include/module.modulemap
@@ -1,0 +1,7 @@
+module CDDSBridge {
+    header "dds_bridge.h"
+    header "raw_cdr_sertype.h"
+    header "raw_cdr_regression_bridge.h"
+    link "ddsc"
+    export *
+}

--- a/Sources/CDDSBridge/include/raw_cdr_regression_bridge.h
+++ b/Sources/CDDSBridge/include/raw_cdr_regression_bridge.h
@@ -1,0 +1,52 @@
+//
+// raw_cdr_regression_bridge.h
+// Opaque Swift-visible wrappers for raw_cdr_sertype/serdata regression tests.
+//
+// The underlying raw_cdr_sertype.h pulls in CycloneDDS ddsi internals that
+// collide with Foundation types (notably ddsi's `Data` struct), so Swift
+// test code goes through these opaque wrappers instead.
+//
+
+#ifndef RAW_CDR_REGRESSION_BRIDGE_H
+#define RAW_CDR_REGRESSION_BRIDGE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef DDS_AVAILABLE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Opaque handle for a raw_cdr sertype (wraps struct ddsi_sertype *).
+typedef struct raw_cdr_regression_sertype_s raw_cdr_regression_sertype_t;
+
+/// Opaque handle for a raw_cdr serdata (wraps struct ddsi_serdata *).
+typedef struct raw_cdr_regression_serdata_s raw_cdr_regression_serdata_t;
+
+/// Create a raw CDR sertype for regression tests. Returns NULL on failure.
+raw_cdr_regression_sertype_t *raw_cdr_regression_sertype_new(const char *type_name);
+
+/// Release a sertype reference obtained via raw_cdr_regression_sertype_new.
+void raw_cdr_regression_sertype_unref(raw_cdr_regression_sertype_t *sertype);
+
+/// Create a raw CDR serdata. Returns NULL on failure or too-small cdr_len.
+raw_cdr_regression_serdata_t *raw_cdr_regression_serdata_new(
+    raw_cdr_regression_sertype_t *sertype,
+    const uint8_t *cdr_data,
+    size_t cdr_len,
+    int64_t timestamp
+);
+
+/// Release a serdata reference obtained via raw_cdr_regression_serdata_new.
+void raw_cdr_regression_serdata_unref(raw_cdr_regression_serdata_t *serdata);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DDS_AVAILABLE
+
+#endif // RAW_CDR_REGRESSION_BRIDGE_H

--- a/Sources/CDDSBridge/include/raw_cdr_sertype.h
+++ b/Sources/CDDSBridge/include/raw_cdr_sertype.h
@@ -1,0 +1,103 @@
+//
+// raw_cdr_sertype.h
+// Custom sertype/serdata for raw CDR data publishing
+//
+// This implementation allows publishing pre-serialized CDR data directly
+// via CycloneDDS without requiring a schema-based topic descriptor.
+// It implements the ddsi_sertype and ddsi_serdata interfaces.
+//
+
+#ifndef RAW_CDR_SERTYPE_H
+#define RAW_CDR_SERTYPE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef DDS_AVAILABLE
+
+#include <dds/dds.h>
+#include <dds/ddsi/ddsi_sertype.h>
+#include <dds/ddsi/ddsi_serdata.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// MARK: - Raw CDR Sertype
+// =============================================================================
+
+/// Custom sertype for raw CDR data
+/// Extends ddsi_sertype with no additional fields (type name is stored in base)
+struct raw_cdr_sertype {
+    struct ddsi_sertype c;  // Base sertype (must be first member)
+};
+
+// =============================================================================
+// MARK: - Raw CDR Serdata
+// =============================================================================
+
+/// Custom serdata for raw CDR data
+/// Contains the pre-serialized CDR data including the 4-byte encapsulation header
+struct raw_cdr_serdata {
+    struct ddsi_serdata c;   // Base serdata (must be first member)
+    size_t cdr_size;         // Size of CDR data including 4-byte header
+    uint8_t cdr_data[];      // Flexible array member for CDR data
+};
+
+// =============================================================================
+// MARK: - Sertype Operations
+// =============================================================================
+
+/// Operations table for raw CDR sertype
+extern const struct ddsi_sertype_ops raw_cdr_sertype_ops;
+
+/// Operations table for raw CDR serdata
+extern const struct ddsi_serdata_ops raw_cdr_serdata_ops;
+
+// =============================================================================
+// MARK: - Factory Functions
+// =============================================================================
+
+/// Create a new raw CDR sertype
+///
+/// @param type_name The DDS type name (e.g., "sensor_msgs::msg::dds_::Imu_")
+/// @return Newly allocated sertype, or NULL on failure
+///         Caller is responsible for calling ddsi_sertype_unref when done
+struct ddsi_sertype *raw_cdr_sertype_new(const char *type_name);
+
+/// Create a new raw CDR serdata from pre-serialized CDR data
+///
+/// @param type The sertype this serdata belongs to
+/// @param cdr_data Pre-serialized CDR data (must include 4-byte encapsulation header)
+/// @param cdr_len Length of CDR data in bytes
+/// @param timestamp Timestamp in nanoseconds since Unix epoch
+/// @return Newly allocated serdata with refcount=1, or NULL on failure
+///         Caller is responsible for calling ddsi_serdata_unref when done
+struct ddsi_serdata *raw_cdr_serdata_new(
+    const struct ddsi_sertype *type,
+    const uint8_t *cdr_data,
+    size_t cdr_len,
+    dds_time_t timestamp
+);
+
+/// Initialize a raw CDR sertype (for use when sertype is embedded in another struct)
+///
+/// @param st Pointer to sertype structure to initialize
+/// @param type_name The DDS type name
+/// @return true on success, false on failure
+bool raw_cdr_sertype_init(struct raw_cdr_sertype *st, const char *type_name);
+
+/// Finalize a raw CDR sertype (for use when sertype is embedded in another struct)
+///
+/// @param st Pointer to sertype structure to finalize
+void raw_cdr_sertype_fini(struct raw_cdr_sertype *st);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DDS_AVAILABLE
+
+#endif // RAW_CDR_SERTYPE_H

--- a/Sources/CDDSBridge/raw_cdr_regression_bridge.c
+++ b/Sources/CDDSBridge/raw_cdr_regression_bridge.c
@@ -1,0 +1,51 @@
+//
+// raw_cdr_regression_bridge.c
+// Thin wrappers that expose raw_cdr_sertype/serdata to Swift regression
+// tests without leaking CycloneDDS ddsi internal headers (which clash with
+// Foundation.Data).
+//
+
+#include "raw_cdr_regression_bridge.h"
+
+#ifdef DDS_AVAILABLE
+
+#include "raw_cdr_sertype.h"
+#include <dds/ddsi/ddsi_sertype.h>
+#include <dds/ddsi/ddsi_serdata.h>
+
+raw_cdr_regression_sertype_t *raw_cdr_regression_sertype_new(const char *type_name)
+{
+    return (raw_cdr_regression_sertype_t *)raw_cdr_sertype_new(type_name);
+}
+
+void raw_cdr_regression_sertype_unref(raw_cdr_regression_sertype_t *sertype)
+{
+    if (sertype != NULL) {
+        ddsi_sertype_unref((struct ddsi_sertype *)sertype);
+    }
+}
+
+raw_cdr_regression_serdata_t *raw_cdr_regression_serdata_new(
+    raw_cdr_regression_sertype_t *sertype,
+    const uint8_t *cdr_data,
+    size_t cdr_len,
+    int64_t timestamp)
+{
+    if (sertype == NULL) {
+        return NULL;
+    }
+    return (raw_cdr_regression_serdata_t *)raw_cdr_serdata_new(
+        (const struct ddsi_sertype *)sertype,
+        cdr_data,
+        cdr_len,
+        (dds_time_t)timestamp);
+}
+
+void raw_cdr_regression_serdata_unref(raw_cdr_regression_serdata_t *serdata)
+{
+    if (serdata != NULL) {
+        ddsi_serdata_unref((struct ddsi_serdata *)serdata);
+    }
+}
+
+#endif // DDS_AVAILABLE

--- a/Sources/CDDSBridge/raw_cdr_sertype.c
+++ b/Sources/CDDSBridge/raw_cdr_sertype.c
@@ -1,0 +1,471 @@
+//
+// raw_cdr_sertype.c
+// Custom sertype/serdata implementation for raw CDR data publishing
+//
+// This implementation provides minimal sertype/serdata operations
+// for publishing pre-serialized CDR data via CycloneDDS.
+//
+
+#include "raw_cdr_sertype.h"
+
+#ifdef DDS_AVAILABLE
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <dds/ddsrt/heap.h>
+#include <dds/ddsrt/md5.h>
+
+// =============================================================================
+// MARK: - Sertype Operations Implementation
+// =============================================================================
+
+/// Free a raw CDR sertype
+static void raw_cdr_sertype_free(struct ddsi_sertype *tp)
+{
+    struct raw_cdr_sertype *st = (struct raw_cdr_sertype *)tp;
+    ddsrt_free(st);
+}
+
+/// Zero out samples (no-op for raw CDR - we don't have a native sample type)
+static void raw_cdr_sertype_zero_samples(const struct ddsi_sertype *d, void *samples, size_t count)
+{
+    (void)d;
+    (void)samples;
+    (void)count;
+    // No-op: raw CDR doesn't have a native sample type
+}
+
+/// Reallocate samples (no-op for raw CDR)
+static void raw_cdr_sertype_realloc_samples(
+    void **ptrs,
+    const struct ddsi_sertype *d,
+    void *old,
+    size_t oldcount,
+    size_t count)
+{
+    (void)d;
+    (void)old;
+    (void)oldcount;
+    // No-op: raw CDR doesn't support sample allocation
+    for (size_t i = 0; i < count; i++) {
+        ptrs[i] = NULL;
+    }
+}
+
+/// Free samples (no-op for raw CDR)
+static void raw_cdr_sertype_free_samples(
+    const struct ddsi_sertype *d,
+    void **ptrs,
+    size_t count,
+    dds_free_op_t op)
+{
+    (void)d;
+    (void)ptrs;
+    (void)count;
+    (void)op;
+    // No-op: raw CDR doesn't allocate samples
+}
+
+/// Check equality of two raw CDR sertypes
+static bool raw_cdr_sertype_equal(const struct ddsi_sertype *a, const struct ddsi_sertype *b)
+{
+    // Raw CDR sertypes are equal if they have the same type name
+    // (type name comparison is done by the caller)
+    (void)a;
+    (void)b;
+    return true;
+}
+
+/// Hash a raw CDR sertype
+static uint32_t raw_cdr_sertype_hash(const struct ddsi_sertype *tp)
+{
+    (void)tp;
+    // Type name is hashed by the base implementation
+    return 0;
+}
+
+// =============================================================================
+// MARK: - Serdata Operations Implementation
+// =============================================================================
+
+/// Get the serialized size of serdata (including 4-byte CDR header)
+static uint32_t raw_cdr_serdata_get_size(const struct ddsi_serdata *d)
+{
+    const struct raw_cdr_serdata *rd = (const struct raw_cdr_serdata *)d;
+    assert(rd->cdr_size >= 4);
+    return (uint32_t)rd->cdr_size;
+}
+
+/// Free a raw CDR serdata
+static void raw_cdr_serdata_free(struct ddsi_serdata *d)
+{
+    struct raw_cdr_serdata *rd = (struct raw_cdr_serdata *)d;
+    // Note: ddsi_serdata_init does NOT ref the type (just stores pointer),
+    // so we should NOT unref here. The type's lifecycle is managed by topic/writer.
+    ddsrt_free(rd);
+}
+
+/// Create serdata from serialized iovec data (for receiving)
+static struct ddsi_serdata *raw_cdr_serdata_from_ser_iov(
+    const struct ddsi_sertype *type,
+    enum ddsi_serdata_kind kind,
+    ddsrt_msg_iovlen_t niov,
+    const ddsrt_iovec_t *iov,
+    size_t size)
+{
+    // Calculate total size from iovecs
+    size_t total_size = 0;
+    for (ddsrt_msg_iovlen_t i = 0; i < niov; i++) {
+        total_size += iov[i].iov_len;
+    }
+
+    // Allocate serdata with flexible array
+    struct raw_cdr_serdata *rd = ddsrt_malloc(sizeof(struct raw_cdr_serdata) + total_size);
+    if (!rd) {
+        return NULL;
+    }
+
+    ddsi_serdata_init(&rd->c, type, kind);
+    rd->cdr_size = total_size;
+
+    // Copy data from iovecs
+    size_t offset = 0;
+    for (ddsrt_msg_iovlen_t i = 0; i < niov; i++) {
+        memcpy(rd->cdr_data + offset, iov[i].iov_base, iov[i].iov_len);
+        offset += iov[i].iov_len;
+    }
+
+    (void)size; // size parameter is the expected size (we computed it from iovecs)
+
+    return &rd->c;
+}
+
+/// Create serdata from fragchain (for receiving - used by DDSI)
+static struct ddsi_serdata *raw_cdr_serdata_from_ser(
+    const struct ddsi_sertype *type,
+    enum ddsi_serdata_kind kind,
+    const struct nn_rdata *fragchain,
+    size_t size)
+{
+    (void)type;
+    (void)kind;
+    (void)fragchain;
+    (void)size;
+    // Not implemented for publish-only use case
+    return NULL;
+}
+
+/// Create serdata from keyhash (for tkmap lookups)
+static struct ddsi_serdata *raw_cdr_serdata_from_keyhash(
+    const struct ddsi_sertype *type,
+    const struct ddsi_keyhash *keyhash)
+{
+    (void)keyhash;  // Ignore keyhash for keyless types
+
+    // Create a minimal serdata for keyhash lookup
+    size_t alloc_size = sizeof(struct raw_cdr_serdata) + 4;
+    struct raw_cdr_serdata *rd = ddsrt_malloc(alloc_size);
+    if (!rd) {
+        return NULL;
+    }
+
+    ddsi_serdata_init(&rd->c, type, SDK_KEY);
+    // For keyless types, use the sertype's basehash
+    rd->c.hash = type->serdata_basehash;
+    rd->cdr_size = 4;
+    rd->cdr_data[0] = 0x00;
+    rd->cdr_data[1] = 0x01;
+    rd->cdr_data[2] = 0x00;
+    rd->cdr_data[3] = 0x00;
+
+    return &rd->c;
+}
+
+/// Create serdata from application sample (not supported for raw CDR)
+static struct ddsi_serdata *raw_cdr_serdata_from_sample(
+    const struct ddsi_sertype *type,
+    enum ddsi_serdata_kind kind,
+    const void *sample)
+{
+    (void)type;
+    (void)kind;
+    (void)sample;
+    // Not supported: use raw_cdr_serdata_new instead
+    return NULL;
+}
+
+/// Convert serdata to untyped serdata (for key-based operations)
+static struct ddsi_serdata *raw_cdr_serdata_to_untyped(const struct ddsi_serdata *d)
+{
+    // For keyless types, create a minimal "keyhash-only" serdata.
+    // This is stored in the tkmap and must be a separate allocation.
+    // Use SDK_KEY kind for the untyped representation.
+    size_t alloc_size = sizeof(struct raw_cdr_serdata) + 4; // Minimal CDR header only
+    struct raw_cdr_serdata *rd = ddsrt_malloc(alloc_size);
+    if (!rd) {
+        return NULL;
+    }
+
+    // Initialize as SDK_KEY (untyped/keyhash-only representation)
+    ddsi_serdata_init(&rd->c, d->type, SDK_KEY);
+
+    // For keyless types, all serdatas share the same hash
+    rd->c.hash = d->type->serdata_basehash;
+    rd->c.timestamp = d->timestamp;
+    rd->c.statusinfo = d->statusinfo;
+
+    rd->cdr_size = 4;
+    // Minimal CDR header for keyhash
+    rd->cdr_data[0] = 0x00;
+    rd->cdr_data[1] = 0x01;
+    rd->cdr_data[2] = 0x00;
+    rd->cdr_data[3] = 0x00;
+
+    return &rd->c;
+}
+
+/// Copy serialized data to buffer
+static void raw_cdr_serdata_to_ser(
+    const struct ddsi_serdata *d,
+    size_t off,
+    size_t sz,
+    void *buf)
+{
+    const struct raw_cdr_serdata *rd = (const struct raw_cdr_serdata *)d;
+    if (off >= rd->cdr_size) {
+        memset(buf, 0, sz);
+        return;
+    }
+    // Copy available data and zero-fill any remainder (for aligned reads
+    // that extend beyond the actual CDR data)
+    size_t avail = rd->cdr_size - off;
+    if (avail >= sz) {
+        memcpy(buf, rd->cdr_data + off, sz);
+    } else {
+        memcpy(buf, rd->cdr_data + off, avail);
+        memset((uint8_t *)buf + avail, 0, sz - avail);
+    }
+}
+
+/// Get reference to serialized data
+static struct ddsi_serdata *raw_cdr_serdata_to_ser_ref(
+    const struct ddsi_serdata *d,
+    size_t off,
+    size_t sz,
+    ddsrt_iovec_t *ref)
+{
+    const struct raw_cdr_serdata *rd = (const struct raw_cdr_serdata *)d;
+    if (off >= rd->cdr_size) {
+        ref->iov_base = (void *)(rd->cdr_data);
+        ref->iov_len = 0;
+        return ddsi_serdata_ref(d);
+    }
+    // CycloneDDS requests 4-byte aligned sizes (align4u) for fragment payloads.
+    // The last fragment's aligned size may exceed cdr_size by up to 3 bytes.
+    // The buffer is allocated with extra padding to handle this safely.
+    ref->iov_base = (void *)(rd->cdr_data + off);
+    ref->iov_len = (ddsrt_iov_len_t)sz;
+    return ddsi_serdata_ref(d);
+}
+
+/// Release reference to serialized data
+static void raw_cdr_serdata_to_ser_unref(struct ddsi_serdata *d, const ddsrt_iovec_t *ref)
+{
+    (void)ref;
+    ddsi_serdata_unref(d);
+}
+
+/// Convert serdata to application sample (not supported)
+static bool raw_cdr_serdata_to_sample(
+    const struct ddsi_serdata *d,
+    void *sample,
+    void **bufptr,
+    void *buflim)
+{
+    (void)d;
+    (void)sample;
+    (void)bufptr;
+    (void)buflim;
+    // Not supported: raw CDR doesn't have a native sample type
+    return false;
+}
+
+/// Convert untyped serdata to sample (not supported)
+static bool raw_cdr_serdata_untyped_to_sample(
+    const struct ddsi_sertype *type,
+    const struct ddsi_serdata *d,
+    void *sample,
+    void **bufptr,
+    void *buflim)
+{
+    (void)type;
+    (void)d;
+    (void)sample;
+    (void)bufptr;
+    (void)buflim;
+    // Not supported: raw CDR doesn't have a native sample type
+    return false;
+}
+
+/// Check if two serdatas have equal keys (always TRUE for keyless types)
+static bool raw_cdr_serdata_eqkey(const struct ddsi_serdata *a, const struct ddsi_serdata *b)
+{
+    (void)a;
+    (void)b;
+    // Keyless type: all instances are considered the same (there's only one instance)
+    return true;
+}
+
+/// Print serdata (for debugging)
+static size_t raw_cdr_serdata_print(
+    const struct ddsi_sertype *type,
+    const struct ddsi_serdata *d,
+    char *buf,
+    size_t size)
+{
+    const struct raw_cdr_serdata *rd = (const struct raw_cdr_serdata *)d;
+    int n = snprintf(buf, size, "[raw CDR %zu bytes, type=%s]",
+                     rd->cdr_size, type->type_name);
+    return (size_t)(n < 0 ? 0 : (size_t)n);
+}
+
+/// Get keyhash (return empty hash for keyless types)
+static void raw_cdr_serdata_get_keyhash(
+    const struct ddsi_serdata *d,
+    struct ddsi_keyhash *buf,
+    bool force_md5)
+{
+    (void)d;
+    (void)force_md5;
+    // Return zero keyhash for keyless types
+    memset(buf->value, 0, sizeof(buf->value));
+}
+
+// =============================================================================
+// MARK: - Operations Tables
+// =============================================================================
+
+const struct ddsi_sertype_ops raw_cdr_sertype_ops = {
+    .version = ddsi_sertype_v0,
+    .arg = NULL,
+    .free = raw_cdr_sertype_free,
+    .zero_samples = raw_cdr_sertype_zero_samples,
+    .realloc_samples = raw_cdr_sertype_realloc_samples,
+    .free_samples = raw_cdr_sertype_free_samples,
+    .equal = raw_cdr_sertype_equal,
+    .hash = raw_cdr_sertype_hash,
+    .type_id = NULL,           // No XTypes support
+    .type_map = NULL,          // No XTypes support
+    .type_info = NULL,         // No XTypes support
+    .derive_sertype = NULL,    // No derived sertypes
+    .get_serialized_size = NULL,
+    .serialize_into = NULL
+};
+
+const struct ddsi_serdata_ops raw_cdr_serdata_ops = {
+    .eqkey = raw_cdr_serdata_eqkey,
+    .get_size = raw_cdr_serdata_get_size,
+    .from_ser = raw_cdr_serdata_from_ser,
+    .from_ser_iov = raw_cdr_serdata_from_ser_iov,
+    .from_keyhash = raw_cdr_serdata_from_keyhash,
+    .from_sample = raw_cdr_serdata_from_sample,
+    .to_ser = raw_cdr_serdata_to_ser,
+    .to_ser_ref = raw_cdr_serdata_to_ser_ref,
+    .to_ser_unref = raw_cdr_serdata_to_ser_unref,
+    .to_sample = raw_cdr_serdata_to_sample,
+    .to_untyped = raw_cdr_serdata_to_untyped,
+    .untyped_to_sample = raw_cdr_serdata_untyped_to_sample,
+    .free = raw_cdr_serdata_free,
+    .print = raw_cdr_serdata_print,
+    .get_keyhash = raw_cdr_serdata_get_keyhash
+};
+
+// =============================================================================
+// MARK: - Factory Functions Implementation
+// =============================================================================
+
+struct ddsi_sertype *raw_cdr_sertype_new(const char *type_name)
+{
+    if (!type_name || strlen(type_name) == 0) {
+        return NULL;
+    }
+
+    struct raw_cdr_sertype *st = ddsrt_malloc(sizeof(struct raw_cdr_sertype));
+    if (!st) {
+        return NULL;
+    }
+
+    if (!raw_cdr_sertype_init(st, type_name)) {
+        ddsrt_free(st);
+        return NULL;
+    }
+
+    return &st->c;
+}
+
+bool raw_cdr_sertype_init(struct raw_cdr_sertype *st, const char *type_name)
+{
+    if (!st || !type_name) {
+        return false;
+    }
+
+    // Initialize with TOPICKIND_NO_KEY flag (keyless type)
+    ddsi_sertype_init_flags(
+        &st->c,
+        type_name,
+        &raw_cdr_sertype_ops,
+        &raw_cdr_serdata_ops,
+        DDSI_SERTYPE_FLAG_TOPICKIND_NO_KEY
+    );
+
+    return true;
+}
+
+void raw_cdr_sertype_fini(struct raw_cdr_sertype *st)
+{
+    if (st) {
+        ddsi_sertype_fini(&st->c);
+    }
+}
+
+struct ddsi_serdata *raw_cdr_serdata_new(
+    const struct ddsi_sertype *type,
+    const uint8_t *cdr_data,
+    size_t cdr_len,
+    dds_time_t timestamp)
+{
+    if (!type || !cdr_data || cdr_len < 4) {
+        return NULL;
+    }
+
+    // Allocate serdata with space for CDR data + 3 bytes padding.
+    // CycloneDDS requests 4-byte aligned fragment sizes (align4u) when
+    // reading fragment payloads via to_ser_ref. The last fragment's aligned
+    // size may exceed cdr_len by up to 3 bytes. The extra padding ensures
+    // the aligned read is safe and returns zeros for the padding bytes.
+    size_t alloc_size = sizeof(struct raw_cdr_serdata) + cdr_len + 3;
+    struct raw_cdr_serdata *rd = ddsrt_malloc(alloc_size);
+    if (!rd) {
+        return NULL;
+    }
+
+    // Initialize base serdata
+    ddsi_serdata_init(&rd->c, type, SDK_DATA);
+
+    // For keyless types, all serdatas should have the same hash (the sertype's basehash)
+    rd->c.hash = type->serdata_basehash;
+
+    // Set timestamp
+    rd->c.timestamp.v = timestamp;
+    rd->c.statusinfo = 0;
+
+    // Copy CDR data and zero the padding bytes
+    rd->cdr_size = cdr_len;
+    memcpy(rd->cdr_data, cdr_data, cdr_len);
+    memset(rd->cdr_data + cdr_len, 0, 3);
+
+    return &rd->c;
+}
+
+#endif // DDS_AVAILABLE

--- a/Sources/CZenohBridge/include/module.modulemap
+++ b/Sources/CZenohBridge/include/module.modulemap
@@ -1,0 +1,5 @@
+module CZenohBridge {
+    header "zenoh_bridge.h"
+    link "zenohpico"
+    export *
+}

--- a/Sources/CZenohBridge/include/zenoh_bridge.h
+++ b/Sources/CZenohBridge/include/zenoh_bridge.h
@@ -1,0 +1,192 @@
+//
+// zenoh_bridge.h
+// C-FFI bridge for zenoh-pico to Swift
+//
+// Provides simplified C API wrapping zenoh-pico for use in Swift
+//
+
+#ifndef ZENOH_BRIDGE_H
+#define ZENOH_BRIDGE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Opaque handles for zenoh types (exposed as pointers to Swift)
+// ============================================================================
+
+typedef struct zenoh_session_t zenoh_session_t;
+typedef struct zenoh_keyexpr_t zenoh_keyexpr_t;
+typedef struct zenoh_subscriber_t zenoh_subscriber_t;
+typedef struct zenoh_liveliness_token_t zenoh_liveliness_token_t;
+
+// ============================================================================
+// Error handling
+// ============================================================================
+
+// Returns 0 on success, negative error code on failure
+typedef int8_t zenoh_result_t;
+
+// Error codes
+#define ZENOH_ERROR_SESSION_CLOSED -2
+
+// ============================================================================
+// Session management
+// ============================================================================
+
+/// Opens a zenoh session with the given locator string
+/// @param locator Connection string (e.g., "tcp/127.0.0.1:7447")
+/// @param out_session Output parameter for the created session handle
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_open_session(const char* locator, zenoh_session_t** out_session);
+
+/// Closes a zenoh session and frees all associated resources
+/// @param session Session handle to close (will be set to NULL)
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_close_session(zenoh_session_t** session);
+
+/// Gets the session ID as a hex string
+/// @param session The zenoh session
+/// @param out_buffer Buffer to store the session ID (must be at least 33 bytes: 32 hex chars + null terminator)
+/// @param buffer_size Size of the output buffer
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_get_session_id(zenoh_session_t* session, char* out_buffer, size_t buffer_size);
+
+/// Checks if the session is healthy and can safely publish
+/// This is more comprehensive than z_session_is_closed() - it verifies
+/// the session is not in a stale/zombie state after sleep/wake cycles
+/// @param session The zenoh session to check
+/// @return true if session is healthy, false if stale or closed
+bool zenoh_is_session_healthy(zenoh_session_t* session);
+
+// ============================================================================
+// Key expression management
+// ============================================================================
+
+/// Declares a key expression for efficient repeated use
+/// @param session The zenoh session
+/// @param keyexpr_str The key expression string
+/// @param out_keyexpr Output parameter for the declared key expression handle
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_declare_keyexpr(zenoh_session_t* session,
+                                      const char* keyexpr_str,
+                                      zenoh_keyexpr_t** out_keyexpr);
+
+/// Undeclares and frees a key expression
+/// @param session The zenoh session
+/// @param keyexpr Key expression handle to undeclare (will be set to NULL)
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_undeclare_keyexpr(zenoh_session_t* session,
+                                        zenoh_keyexpr_t** keyexpr);
+
+// ============================================================================
+// Publishing
+// ============================================================================
+
+/// Puts data to a key expression with optional attachment
+/// @param session The zenoh session
+/// @param keyexpr The key expression to publish to
+/// @param payload Pointer to the payload data
+/// @param payload_len Length of the payload in bytes
+/// @param attachment_data Pointer to attachment data (can be NULL)
+/// @param attachment_len Length of attachment data in bytes (0 if no attachment)
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_put(zenoh_session_t* session,
+                         zenoh_keyexpr_t* keyexpr,
+                         const uint8_t* payload,
+                         size_t payload_len,
+                         const uint8_t* attachment_data,
+                         size_t attachment_len);
+
+/// Puts data to a key expression string (non-declared) with optional attachment
+/// @param session The zenoh session
+/// @param keyexpr_str The key expression string to publish to
+/// @param payload Pointer to the payload data
+/// @param payload_len Length of the payload in bytes
+/// @param attachment_data Pointer to attachment data (can be NULL)
+/// @param attachment_len Length of attachment data in bytes (0 if no attachment)
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_put_str(zenoh_session_t* session,
+                             const char* keyexpr_str,
+                             const uint8_t* payload,
+                             size_t payload_len,
+                             const uint8_t* attachment_data,
+                             size_t attachment_len);
+
+// ============================================================================
+// Subscription (callback-based)
+// ============================================================================
+
+/// Callback function type for subscribers
+/// @param keyexpr_str The key expression that matched
+/// @param payload Pointer to received payload data
+/// @param payload_len Length of received payload
+/// @param attachment Pointer to received attachment data (can be NULL)
+/// @param attachment_len Length of received attachment (0 if no attachment)
+/// @param context User-provided context pointer
+typedef void (*zenoh_subscriber_callback_t)(const char* keyexpr_str,
+                                             const uint8_t* payload,
+                                             size_t payload_len,
+                                             const uint8_t* attachment,
+                                             size_t attachment_len,
+                                             void* context);
+
+/// Declares a subscriber with a callback
+/// @param session The zenoh session
+/// @param keyexpr_str The key expression to subscribe to
+/// @param callback The callback function to invoke on received samples
+/// @param context User context pointer passed to callback
+/// @param out_subscriber Output parameter for the subscriber handle
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_declare_subscriber(zenoh_session_t* session,
+                                        const char* keyexpr_str,
+                                        zenoh_subscriber_callback_t callback,
+                                        void* context,
+                                        zenoh_subscriber_t** out_subscriber);
+
+/// Undeclares and frees a subscriber
+/// @param session The zenoh session
+/// @param subscriber Subscriber handle to undeclare (will be set to NULL)
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_undeclare_subscriber(zenoh_session_t* session,
+                                          zenoh_subscriber_t** subscriber);
+
+// ============================================================================
+// Liveliness tokens (for ROS 2 discovery)
+// ============================================================================
+
+/// Declares a liveliness token for ROS 2 entity discovery
+/// @param session The zenoh session
+/// @param key_expr The liveliness token key expression (e.g., "@ros2_lv/0/...")
+/// @param out_token Output parameter for the liveliness token handle
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_declare_liveliness_token(zenoh_session_t* session,
+                                              const char* key_expr,
+                                              zenoh_liveliness_token_t** out_token);
+
+/// Undeclares and frees a liveliness token
+/// @param session The zenoh session
+/// @param token Liveliness token handle to undeclare (will be set to NULL)
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_undeclare_liveliness_token(zenoh_session_t* session,
+                                                zenoh_liveliness_token_t** token);
+
+// ============================================================================
+// Utility functions
+// ============================================================================
+
+/// Gets a human-readable error message for a result code
+/// @param result The result code
+/// @return String description of the error
+const char* zenoh_result_str(zenoh_result_t result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ZENOH_BRIDGE_H

--- a/Sources/CZenohBridge/zenoh_bridge.c
+++ b/Sources/CZenohBridge/zenoh_bridge.c
@@ -39,7 +39,7 @@ struct zenoh_liveliness_token_t {
 // ============================================================================
 
 zenoh_result_t zenoh_open_session(const char* locator, zenoh_session_t** out_session) {
-    os_log_t log = os_log_create("jp.youtalk.conduit", "zenoh");
+    os_log_t log = os_log_create("com.youtalk.swift-ros2", "zenoh");
 
     if (!locator || !out_session) {
         os_log_error(log, "[zenoh_bridge] ERROR: Invalid parameters");
@@ -143,7 +143,7 @@ zenoh_result_t zenoh_get_session_id(zenoh_session_t* session, char* out_buffer, 
 }
 
 bool zenoh_is_session_healthy(zenoh_session_t* session) {
-    os_log_t log = os_log_create("jp.youtalk.conduit", "zenoh");
+    os_log_t log = os_log_create("com.youtalk.swift-ros2", "zenoh");
 
     if (!session) {
         os_log_error(log, "[zenoh_bridge] is_session_healthy: session is NULL");
@@ -185,7 +185,7 @@ bool zenoh_is_session_healthy(zenoh_session_t* session) {
 zenoh_result_t zenoh_declare_keyexpr(zenoh_session_t* session,
                                       const char* keyexpr_str,
                                       zenoh_keyexpr_t** out_keyexpr) {
-    os_log_t log = os_log_create("jp.youtalk.conduit", "zenoh");
+    os_log_t log = os_log_create("com.youtalk.swift-ros2", "zenoh");
 
     if (!session || !keyexpr_str || !out_keyexpr) {
         os_log_error(log, "[zenoh_bridge] declare_keyexpr: Invalid parameters");
@@ -464,7 +464,7 @@ zenoh_result_t zenoh_undeclare_subscriber(zenoh_session_t* session,
 zenoh_result_t zenoh_declare_liveliness_token(zenoh_session_t* session,
                                               const char* key_expr,
                                               zenoh_liveliness_token_t** out_token) {
-    os_log_t log = os_log_create("jp.youtalk.conduit", "zenoh");
+    os_log_t log = os_log_create("com.youtalk.swift-ros2", "zenoh");
 
     if (!session || !key_expr || !out_token) {
         os_log_error(log, "[zenoh_bridge] declare_liveliness_token: Invalid parameters");

--- a/Sources/CZenohBridge/zenoh_bridge.c
+++ b/Sources/CZenohBridge/zenoh_bridge.c
@@ -1,0 +1,543 @@
+//
+// zenoh_bridge.c
+// C-FFI bridge implementation for zenoh-pico
+//
+
+#include "zenoh_bridge.h"
+#include <zenoh-pico.h>
+#include <zenoh-pico/api/liveliness.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <os/log.h>
+
+// ============================================================================
+// Internal structures
+// ============================================================================
+
+struct zenoh_session_t {
+    z_owned_session_t session;
+};
+
+struct zenoh_keyexpr_t {
+    z_owned_keyexpr_t keyexpr;
+};
+
+struct zenoh_subscriber_t {
+    z_owned_subscriber_t subscriber;
+    zenoh_subscriber_callback_t callback;
+    void* context;
+};
+
+struct zenoh_liveliness_token_t {
+    z_owned_liveliness_token_t token;
+};
+
+// ============================================================================
+// Session management
+// ============================================================================
+
+zenoh_result_t zenoh_open_session(const char* locator, zenoh_session_t** out_session) {
+    os_log_t log = os_log_create("jp.youtalk.conduit", "zenoh");
+
+    if (!locator || !out_session) {
+        os_log_error(log, "[zenoh_bridge] ERROR: Invalid parameters");
+        return -1;
+    }
+
+    os_log_info(log, "[zenoh_bridge] Opening session with locator: %{public}s", locator);
+
+    // Allocate session wrapper
+    zenoh_session_t* session = (zenoh_session_t*)malloc(sizeof(zenoh_session_t));
+    if (!session) {
+        os_log_error(log, "[zenoh_bridge] ERROR: Failed to allocate session");
+        return -1;
+    }
+
+    // Create config
+    z_owned_config_t config;
+    int ret = z_config_default(&config);
+    os_log_info(log, "[zenoh_bridge] z_config_default returned: %d", ret);
+    if (ret < 0) {
+        free(session);
+        return -1;
+    }
+
+    // Set the connect mode and locator
+    ret = zp_config_insert(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, locator);
+    os_log_info(log, "[zenoh_bridge] zp_config_insert returned: %d", ret);
+    if (ret < 0) {
+        z_drop(z_move(config));
+        free(session);
+        return -1;
+    }
+
+    // Open the session
+    z_open_options_t options;
+    options.__dummy = 0;
+
+    os_log_info(log, "[zenoh_bridge] Calling z_open...");
+    os_log_info(log, "[zenoh_bridge] Using locator: %{public}s", locator);
+
+    ret = z_open(&session->session, z_move(config), &options);
+    os_log_info(log, "[zenoh_bridge] z_open returned: %d", ret);
+    if (ret < 0) {
+        os_log_error(log, "[zenoh_bridge] ERROR: z_open failed with code %d", ret);
+        os_log_error(log, "[zenoh_bridge] Possible causes: network unreachable, router not running, or firewall blocking");
+        os_log_error(log, "[zenoh_bridge] errno: %d (%{public}s)", errno, strerror(errno));
+        free(session);
+        return -1;
+    }
+
+    // Start read and lease tasks for background processing (required for pico)
+    os_log_info(log, "[zenoh_bridge] Starting read and lease tasks...");
+    zp_start_read_task(z_loan_mut(session->session), NULL);
+    zp_start_lease_task(z_loan_mut(session->session), NULL);
+
+    os_log_info(log, "[zenoh_bridge] Session opened successfully");
+    *out_session = session;
+    return 0;
+}
+
+zenoh_result_t zenoh_close_session(zenoh_session_t** session) {
+    if (!session || !*session) {
+        return -1;
+    }
+
+    zenoh_session_t* s = *session;
+
+    // Stop background tasks
+    zp_stop_read_task(z_loan_mut(s->session));
+    zp_stop_lease_task(z_loan_mut(s->session));
+
+    // Close the session
+    z_close_options_t options;
+    options.__dummy = 0;
+    z_close(z_loan_mut(s->session), &options);
+
+    // Drop the session
+    z_drop(z_move(s->session));
+
+    free(s);
+    *session = NULL;
+
+    return 0;
+}
+
+zenoh_result_t zenoh_get_session_id(zenoh_session_t* session, char* out_buffer, size_t buffer_size) {
+    if (!session || !out_buffer || buffer_size < 33) {
+        return -1;
+    }
+
+    // Get the session ID
+    z_id_t id = z_info_zid(z_loan(session->session));
+
+    // Convert to hex string (16 bytes = 32 hex chars + null terminator)
+    for (size_t i = 0; i < 16; i++) {
+        snprintf(out_buffer + (i * 2), 3, "%02x", id.id[i]);
+    }
+    out_buffer[32] = '\0';
+
+    return 0;
+}
+
+bool zenoh_is_session_healthy(zenoh_session_t* session) {
+    os_log_t log = os_log_create("jp.youtalk.conduit", "zenoh");
+
+    if (!session) {
+        os_log_error(log, "[zenoh_bridge] is_session_healthy: session is NULL");
+        return false;
+    }
+
+    // Check 1: Session is not explicitly closed
+    if (z_session_is_closed(z_loan(session->session))) {
+        os_log_info(log, "[zenoh_bridge] Session is closed");
+        return false;
+    }
+
+    // Check 2: Try to get session ID - this validates internal state
+    // If the session is in a zombie state, this may fail or return zero ID
+    z_id_t id = z_info_zid(z_loan(session->session));
+
+    // A valid session should have a non-zero ID
+    bool has_valid_id = false;
+    for (size_t i = 0; i < 16; i++) {
+        if (id.id[i] != 0) {
+            has_valid_id = true;
+            break;
+        }
+    }
+
+    if (!has_valid_id) {
+        os_log_info(log, "[zenoh_bridge] Session has invalid/zero ID - likely stale");
+        return false;
+    }
+
+    os_log_info(log, "[zenoh_bridge] Session health check passed");
+    return true;
+}
+
+// ============================================================================
+// Key expression management
+// ============================================================================
+
+zenoh_result_t zenoh_declare_keyexpr(zenoh_session_t* session,
+                                      const char* keyexpr_str,
+                                      zenoh_keyexpr_t** out_keyexpr) {
+    os_log_t log = os_log_create("jp.youtalk.conduit", "zenoh");
+
+    if (!session || !keyexpr_str || !out_keyexpr) {
+        os_log_error(log, "[zenoh_bridge] declare_keyexpr: Invalid parameters");
+        return -1;
+    }
+
+    os_log_info(log, "[zenoh_bridge] Declaring keyexpr: %{public}s", keyexpr_str);
+
+    zenoh_keyexpr_t* kexpr = (zenoh_keyexpr_t*)malloc(sizeof(zenoh_keyexpr_t));
+    if (!kexpr) {
+        os_log_error(log, "[zenoh_bridge] Failed to allocate keyexpr");
+        return -1;
+    }
+
+    // Create a view keyexpr from string
+    os_log_info(log, "[zenoh_bridge] Creating view keyexpr...");
+    z_view_keyexpr_t view_ke;
+    int ret = z_view_keyexpr_from_str(&view_ke, keyexpr_str);
+    os_log_info(log, "[zenoh_bridge] z_view_keyexpr_from_str returned: %d", ret);
+    if (ret < 0) {
+        free(kexpr);
+        return -1;
+    }
+
+    // Declare the keyexpr
+    os_log_info(log, "[zenoh_bridge] Calling z_declare_keyexpr...");
+    ret = z_declare_keyexpr(z_loan(session->session), &kexpr->keyexpr, z_loan(view_ke));
+    os_log_info(log, "[zenoh_bridge] z_declare_keyexpr returned: %d", ret);
+    if (ret < 0) {
+        os_log_error(log, "[zenoh_bridge] z_declare_keyexpr failed with code: %d", ret);
+        free(kexpr);
+        return -1;
+    }
+
+    os_log_info(log, "[zenoh_bridge] Keyexpr declared successfully");
+    *out_keyexpr = kexpr;
+    return 0;
+}
+
+zenoh_result_t zenoh_undeclare_keyexpr(zenoh_session_t* session,
+                                        zenoh_keyexpr_t** keyexpr) {
+    if (!session || !keyexpr || !*keyexpr) {
+        return -1;
+    }
+
+    zenoh_keyexpr_t* ke = *keyexpr;
+
+    // Undeclare the keyexpr
+    z_undeclare_keyexpr(z_loan(session->session), z_move(ke->keyexpr));
+
+    free(ke);
+    *keyexpr = NULL;
+
+    return 0;
+}
+
+// ============================================================================
+// Publishing
+// ============================================================================
+
+zenoh_result_t zenoh_put(zenoh_session_t* session,
+                         zenoh_keyexpr_t* keyexpr,
+                         const uint8_t* payload,
+                         size_t payload_len,
+                         const uint8_t* attachment_data,
+                         size_t attachment_len) {
+    if (!session || !keyexpr || !payload) {
+        return -1;
+    }
+
+    // Check if session is closed (router disconnected)
+    if (z_session_is_closed(z_loan(session->session))) {
+        return ZENOH_ERROR_SESSION_CLOSED;
+    }
+
+    // Create bytes for payload
+    z_owned_bytes_t bytes;
+    if (z_bytes_from_buf(&bytes, (uint8_t*)payload, payload_len, NULL, NULL) < 0) {
+        return -1;
+    }
+
+    // Prepare put options
+    z_put_options_t options;
+    z_put_options_default(&options);
+
+    // Add attachment if provided
+    z_owned_bytes_t attachment;
+    if (attachment_data && attachment_len > 0) {
+        if (z_bytes_from_buf(&attachment, (uint8_t*)attachment_data, attachment_len, NULL, NULL) < 0) {
+            z_drop(z_move(bytes));
+            return -1;
+        }
+        options.attachment = z_move(attachment);
+    }
+
+    // Perform the put
+    int result = z_put(z_loan(session->session), z_loan(keyexpr->keyexpr),
+                       z_move(bytes), &options);
+
+    return (zenoh_result_t)result;
+}
+
+zenoh_result_t zenoh_put_str(zenoh_session_t* session,
+                             const char* keyexpr_str,
+                             const uint8_t* payload,
+                             size_t payload_len,
+                             const uint8_t* attachment_data,
+                             size_t attachment_len) {
+    if (!session || !keyexpr_str || !payload) {
+        return -1;
+    }
+
+    // Check if session is closed (router disconnected)
+    if (z_session_is_closed(z_loan(session->session))) {
+        return ZENOH_ERROR_SESSION_CLOSED;
+    }
+
+    // Create a view keyexpr from string
+    z_view_keyexpr_t view_ke;
+    if (z_view_keyexpr_from_str(&view_ke, keyexpr_str) < 0) {
+        return -1;
+    }
+
+    // Create bytes for payload
+    z_owned_bytes_t bytes;
+    if (z_bytes_from_buf(&bytes, (uint8_t*)payload, payload_len, NULL, NULL) < 0) {
+        return -1;
+    }
+
+    // Prepare put options
+    z_put_options_t options;
+    z_put_options_default(&options);
+
+    // Add attachment if provided
+    z_owned_bytes_t attachment;
+    if (attachment_data && attachment_len > 0) {
+        if (z_bytes_from_buf(&attachment, (uint8_t*)attachment_data, attachment_len, NULL, NULL) < 0) {
+            z_drop(z_move(bytes));
+            return -1;
+        }
+        options.attachment = z_move(attachment);
+    }
+
+    // Perform the put
+    int result = z_put(z_loan(session->session), z_loan(view_ke),
+                       z_move(bytes), &options);
+
+    return (zenoh_result_t)result;
+}
+
+// ============================================================================
+// Subscription
+// ============================================================================
+
+// Internal callback wrapper that converts zenoh sample to our callback format
+static void zenoh_sample_handler(z_loaned_sample_t* sample, void* context) {
+    zenoh_subscriber_t* sub = (zenoh_subscriber_t*)context;
+    if (!sub || !sub->callback) {
+        return;
+    }
+
+    // Extract keyexpr as string
+    const z_loaned_keyexpr_t* keyexpr = z_sample_keyexpr(sample);
+    z_view_string_t keyexpr_str;
+    z_keyexpr_as_view_string(keyexpr, &keyexpr_str);
+    const char* ke_cstr = z_string_data(z_loan(keyexpr_str));
+
+    // Extract payload
+    const z_loaned_bytes_t* payload_bytes = z_sample_payload(sample);
+    z_bytes_reader_t reader = z_bytes_get_reader(payload_bytes);
+
+    // Get payload length and data
+    size_t payload_len = z_bytes_len(payload_bytes);
+    uint8_t* payload_data = NULL;
+
+    if (payload_len > 0) {
+        payload_data = (uint8_t*)malloc(payload_len);
+        if (!payload_data) {
+            // Memory allocation failed, skip callback
+            return;
+        }
+        z_bytes_reader_read(&reader, payload_data, payload_len);
+    }
+
+    // Extract attachment if present
+    const z_loaned_bytes_t* attachment_bytes = z_sample_attachment(sample);
+    uint8_t* attachment_data = NULL;
+    size_t attachment_len = 0;
+
+    if (attachment_bytes) {
+        attachment_len = z_bytes_len(attachment_bytes);
+        if (attachment_len > 0) {
+            attachment_data = (uint8_t*)malloc(attachment_len);
+            if (!attachment_data) {
+                // Attachment malloc failed, but we can still invoke callback without attachment
+                attachment_len = 0;
+            } else {
+                z_bytes_reader_t att_reader = z_bytes_get_reader(attachment_bytes);
+                z_bytes_reader_read(&att_reader, attachment_data, attachment_len);
+            }
+        }
+    }
+
+    // Invoke user callback
+    sub->callback(ke_cstr, payload_data, payload_len,
+                  attachment_data, attachment_len, sub->context);
+
+    // Cleanup
+    if (payload_data) free(payload_data);
+    if (attachment_data) free(attachment_data);
+}
+
+zenoh_result_t zenoh_declare_subscriber(zenoh_session_t* session,
+                                        const char* keyexpr_str,
+                                        zenoh_subscriber_callback_t callback,
+                                        void* context,
+                                        zenoh_subscriber_t** out_subscriber) {
+    if (!session || !keyexpr_str || !callback || !out_subscriber) {
+        return -1;
+    }
+
+    zenoh_subscriber_t* sub = (zenoh_subscriber_t*)malloc(sizeof(zenoh_subscriber_t));
+    if (!sub) {
+        return -1;
+    }
+
+    sub->callback = callback;
+    sub->context = context;
+
+    // Create a view keyexpr from string
+    z_view_keyexpr_t view_ke;
+    if (z_view_keyexpr_from_str(&view_ke, keyexpr_str) < 0) {
+        free(sub);
+        return -1;
+    }
+
+    // Create closure for the callback
+    z_owned_closure_sample_t closure;
+    z_closure(&closure, zenoh_sample_handler, NULL, sub);
+
+    // Declare subscriber
+    z_subscriber_options_t options;
+    z_subscriber_options_default(&options);
+
+    if (z_declare_subscriber(z_loan(session->session), &sub->subscriber,
+                             z_loan(view_ke), z_move(closure), &options) < 0) {
+        free(sub);
+        return -1;
+    }
+
+    *out_subscriber = sub;
+    return 0;
+}
+
+zenoh_result_t zenoh_undeclare_subscriber(zenoh_session_t* session,
+                                          zenoh_subscriber_t** subscriber) {
+    if (!session || !subscriber || !*subscriber) {
+        return -1;
+    }
+
+    zenoh_subscriber_t* sub = *subscriber;
+
+    // Undeclare the subscriber
+    z_undeclare_subscriber(z_move(sub->subscriber));
+
+    free(sub);
+    *subscriber = NULL;
+
+    return 0;
+}
+
+// ============================================================================
+// Liveliness tokens (for ROS 2 discovery)
+// ============================================================================
+
+zenoh_result_t zenoh_declare_liveliness_token(zenoh_session_t* session,
+                                              const char* key_expr,
+                                              zenoh_liveliness_token_t** out_token) {
+    os_log_t log = os_log_create("jp.youtalk.conduit", "zenoh");
+
+    if (!session || !key_expr || !out_token) {
+        os_log_error(log, "[zenoh_bridge] declare_liveliness_token: Invalid parameters");
+        return -1;
+    }
+
+    os_log_info(log, "[zenoh_bridge] Declaring liveliness token: %{public}s", key_expr);
+
+    // Allocate token wrapper
+    zenoh_liveliness_token_t* token = (zenoh_liveliness_token_t*)malloc(sizeof(zenoh_liveliness_token_t));
+    if (!token) {
+        os_log_error(log, "[zenoh_bridge] ERROR: Failed to allocate liveliness token");
+        return -1;
+    }
+
+    // Create key expression view
+    z_view_keyexpr_t view_ke;
+    int ret = z_view_keyexpr_from_str(&view_ke, key_expr);
+    if (ret < 0) {
+        os_log_error(log, "[zenoh_bridge] ERROR: Invalid key expression, ret=%d", ret);
+        free(token);
+        return -1;
+    }
+
+    // Declare liveliness token using proper API
+    z_liveliness_token_options_t options;
+    z_liveliness_token_options_default(&options);
+
+    ret = z_liveliness_declare_token(
+        z_loan(session->session),
+        &token->token,
+        z_loan(view_ke),
+        &options
+    );
+
+    if (ret < 0) {
+        os_log_error(log, "[zenoh_bridge] ERROR: Failed to declare liveliness token, ret=%d", ret);
+        free(token);
+        return -1;
+    }
+
+    os_log_info(log, "[zenoh_bridge] Liveliness token declared successfully");
+    *out_token = token;
+    return 0;
+}
+
+zenoh_result_t zenoh_undeclare_liveliness_token(zenoh_session_t* session,
+                                                zenoh_liveliness_token_t** token) {
+    if (!session || !token || !*token) {
+        return -1;
+    }
+
+    zenoh_liveliness_token_t* t = *token;
+
+    // Undeclare the liveliness token
+    z_liveliness_undeclare_token(z_move(t->token));
+
+    free(t);
+    *token = NULL;
+
+    return 0;
+}
+
+// ============================================================================
+// Utility functions
+// ============================================================================
+
+const char* zenoh_result_str(zenoh_result_t result) {
+    if (result == 0) {
+        return "Success";
+    } else if (result == -1) {
+        return "Generic error";
+    } else {
+        return "Unknown error";
+    }
+}

--- a/Sources/CZenohPico/module.modulemap
+++ b/Sources/CZenohPico/module.modulemap
@@ -1,0 +1,5 @@
+module CZenohPico [system] {
+    header "shim.h"
+    link "zenohpico"
+    export *
+}

--- a/Sources/CZenohPico/shim.h
+++ b/Sources/CZenohPico/shim.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "zenoh-pico.h"

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -2,10 +2,10 @@
 // ROS 2 Context: entry point for the swift-ros2 library
 
 import Foundation
+import SwiftROS2DDS
 import SwiftROS2Transport
 import SwiftROS2Wire
 import SwiftROS2Zenoh
-import SwiftROS2DDS
 
 /// ROS 2 context — the entry point for creating nodes
 ///

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -4,6 +4,8 @@
 import Foundation
 import SwiftROS2Transport
 import SwiftROS2Wire
+import SwiftROS2Zenoh
+import SwiftROS2DDS
 
 /// ROS 2 context — the entry point for creating nodes
 ///
@@ -47,9 +49,7 @@ public final class ROS2Context: @unchecked Sendable {
         if let session = session {
             self.session = session
         } else {
-            throw TransportError.unsupportedFeature(
-                "Transport session must be provided. Built-in Zenoh/DDS sessions require their respective modules."
-            )
+            self.session = try Self.makeDefaultSession(for: transport)
         }
 
         if !self.session.isConnected {
@@ -106,5 +106,18 @@ public final class ROS2Context: @unchecked Sendable {
     /// Whether the session is connected
     public var isConnected: Bool {
         session.isConnected
+    }
+}
+
+// MARK: - Default Session Factory
+
+extension ROS2Context {
+    static func makeDefaultSession(for config: TransportConfig) throws -> any TransportSession {
+        switch config.type {
+        case .zenoh:
+            return ZenohTransportSession(client: DefaultZenohClient())
+        case .dds:
+            return DDSTransportSession(client: DefaultDDSClient())
+        }
     }
 }

--- a/Sources/SwiftROS2DDS/DefaultDDSClient.swift
+++ b/Sources/SwiftROS2DDS/DefaultDDSClient.swift
@@ -1,0 +1,192 @@
+// DefaultDDSClient.swift
+// Default implementation of DDSClientProtocol using the CDDSBridge C FFI.
+
+import Foundation
+import CDDSBridge
+import SwiftROS2Transport
+
+// MARK: - Writer handle
+
+private final class DDSWriterHandleBox: DDSWriterHandle {
+    private var writer: OpaquePointer?
+
+    var isActive: Bool {
+        guard let w = writer else { return false }
+        return dds_bridge_writer_is_active(w)
+    }
+
+    init(_ writer: OpaquePointer) {
+        self.writer = writer
+    }
+
+    func close() {
+        if let w = writer {
+            dds_bridge_destroy_writer(w)
+            writer = nil
+        }
+    }
+
+    var raw: OpaquePointer? { writer }
+}
+
+// MARK: - DefaultDDSClient
+
+/// Thread-safety: internal `NSLock` serializes `createSession` / `destroySession` /
+/// `isConnected` / `getSessionId` / `createRawWriter`. `writeRawCDR` and
+/// `destroyWriter` are intentionally lock-free — CycloneDDS writer operations are
+/// thread-safe, and taking the lock on the publish hot path would serialize all
+/// writers. Callers must ensure writers outlive the session.
+public final class DefaultDDSClient: DDSClientProtocol {
+    private var session: OpaquePointer?
+    private let lock = NSLock()
+
+    public init() {}
+
+    public var isAvailable: Bool {
+        dds_bridge_is_available()
+    }
+
+    public func createSession(
+        domainId: Int32,
+        discoveryConfig: DDSBridgeDiscoveryConfig
+    ) throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard session == nil else {
+            throw DDSError.sessionCreationFailed("session already exists")
+        }
+
+        guard dds_bridge_is_available() else {
+            throw DDSError.notAvailable
+        }
+
+        var cConfig = bridge_discovery_config_t()
+        switch discoveryConfig.mode {
+        case .multicast: cConfig.mode = BRIDGE_DISCOVERY_MULTICAST
+        case .unicast:   cConfig.mode = BRIDGE_DISCOVERY_UNICAST
+        case .hybrid:    cConfig.mode = BRIDGE_DISCOVERY_HYBRID
+        }
+
+        // Build peer C-string array
+        var peerCStrings: [UnsafeMutablePointer<CChar>?] = discoveryConfig.unicastPeers.map { strdup($0) }
+        peerCStrings.append(nil) // NULL-terminator for C array
+
+        let peersPtr = UnsafeMutablePointer<UnsafePointer<CChar>?>.allocate(capacity: peerCStrings.count)
+        defer {
+            // Free peer strings + pointer array once dds_bridge_create_session returns
+            for s in peerCStrings where s != nil {
+                free(s)
+            }
+            peersPtr.deallocate()
+        }
+        for (i, s) in peerCStrings.enumerated() {
+            peersPtr[i] = s.map { UnsafePointer($0) }
+        }
+        if !discoveryConfig.unicastPeers.isEmpty {
+            cConfig.unicast_peers = peersPtr
+            cConfig.peer_count = Int32(discoveryConfig.unicastPeers.count)
+        }
+
+        var interfaceCString: UnsafeMutablePointer<CChar>?
+        if let ifaceName = discoveryConfig.networkInterface {
+            interfaceCString = strdup(ifaceName)
+            cConfig.network_interface = UnsafePointer(interfaceCString)
+        }
+        defer {
+            if let s = interfaceCString { free(s) }
+        }
+
+        guard let newSession = dds_bridge_create_session(domainId, &cConfig) else {
+            let msg = String(cString: dds_bridge_get_last_error())
+            throw DDSError.sessionCreationFailed(msg)
+        }
+        session = newSession
+    }
+
+    public func destroySession() throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let s = session else { return }
+        dds_bridge_destroy_session(s)
+        session = nil
+    }
+
+    public func isConnected() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let s = session else { return false }
+        return dds_bridge_session_is_connected(s)
+    }
+
+    public func getSessionId() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let s = session else { return nil }
+        var buf = [CChar](repeating: 0, count: 33)
+        guard dds_bridge_get_session_id(s, &buf, 33) == 0 else { return nil }
+        return String(cString: buf)
+    }
+
+    public func createRawWriter(
+        topicName: String,
+        typeName: String,
+        qos: DDSBridgeQoSConfig,
+        userData: String?
+    ) throws -> any DDSWriterHandle {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let s = session else {
+            throw DDSError.notConnected
+        }
+
+        var cQos = bridge_qos_config_t()
+        cQos.reliability = qos.reliability == .reliable ? BRIDGE_RELIABILITY_RELIABLE : BRIDGE_RELIABILITY_BEST_EFFORT
+        cQos.durability = qos.durability == .transientLocal ? BRIDGE_DURABILITY_TRANSIENT_LOCAL : BRIDGE_DURABILITY_VOLATILE
+        cQos.history_kind = qos.historyKind == .keepAll ? BRIDGE_HISTORY_KEEP_ALL : BRIDGE_HISTORY_KEEP_LAST
+        cQos.history_depth = qos.historyDepth
+
+        let writerOrNil: OpaquePointer? = topicName.withCString { topicCStr in
+            typeName.withCString { typeCStr in
+                if let userData = userData {
+                    return userData.withCString { userDataCStr in
+                        dds_bridge_create_raw_writer(s, topicCStr, typeCStr, &cQos, userDataCStr)
+                    }
+                } else {
+                    return dds_bridge_create_raw_writer(s, topicCStr, typeCStr, &cQos, nil)
+                }
+            }
+        }
+
+        guard let writer = writerOrNil else {
+            let msg = String(cString: dds_bridge_get_last_error())
+            throw DDSError.writerCreationFailed(msg)
+        }
+        return DDSWriterHandleBox(writer)
+    }
+
+    public func writeRawCDR(
+        writer: any DDSWriterHandle,
+        data: Data,
+        timestamp: UInt64
+    ) throws {
+        guard let box = writer as? DDSWriterHandleBox, let raw = box.raw else {
+            throw DDSError.writeFailed("foreign or closed DDS writer handle")
+        }
+        let result: Int32 = data.withUnsafeBytes { buf -> Int32 in
+            guard let ptr = buf.bindMemory(to: UInt8.self).baseAddress else { return -1 }
+            return dds_bridge_write_raw_cdr(raw, ptr, data.count, timestamp)
+        }
+        if result != 0 {
+            let msg = String(cString: dds_bridge_get_last_error())
+            throw DDSError.writeFailed("dds_bridge_write_raw_cdr=\(result): \(msg)")
+        }
+    }
+
+    public func destroyWriter(_ writer: any DDSWriterHandle) {
+        guard let box = writer as? DDSWriterHandleBox else { return }
+        box.close()
+    }
+}

--- a/Sources/SwiftROS2DDS/DefaultDDSClient.swift
+++ b/Sources/SwiftROS2DDS/DefaultDDSClient.swift
@@ -7,10 +7,17 @@ import SwiftROS2Transport
 
 // MARK: - Writer handle
 
+/// Per-box lock serializes destroy vs. publish for the same writer so callers
+/// can use writers from multiple threads without racing destroy/write on a
+/// freed pointer. Different writers hold different locks, so parallel writes
+/// across writers stay lock-free.
 private final class DDSWriterHandleBox: DDSWriterHandle {
     private var writer: OpaquePointer?
+    private let lock = NSLock()
 
     var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
         guard let w = writer else { return false }
         return dds_bridge_writer_is_active(w)
     }
@@ -20,22 +27,35 @@ private final class DDSWriterHandleBox: DDSWriterHandle {
     }
 
     func close() {
+        lock.lock()
+        defer { lock.unlock() }
         if let w = writer {
             dds_bridge_destroy_writer(w)
             writer = nil
         }
     }
 
-    var raw: OpaquePointer? { writer }
+    /// Invokes `body` with the live writer pointer while holding the per-box
+    /// lock so concurrent `close()` cannot free it mid-call. Returns nil if
+    /// the writer has already been closed.
+    func withWriter<T>(_ body: (OpaquePointer) -> T) -> T? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let w = writer else { return nil }
+        return body(w)
+    }
 }
 
 // MARK: - DefaultDDSClient
 
-/// Thread-safety: internal `NSLock` serializes `createSession` / `destroySession` /
-/// `isConnected` / `getSessionId` / `createRawWriter`. `writeRawCDR` and
-/// `destroyWriter` are intentionally lock-free — CycloneDDS writer operations are
-/// thread-safe, and taking the lock on the publish hot path would serialize all
-/// writers. Callers must ensure writers outlive the session.
+/// Thread-safety: the client-level `NSLock` serializes `createSession` /
+/// `destroySession` / `isConnected` / `getSessionId` / `createRawWriter`.
+/// `writeRawCDR` and `destroyWriter` do not take the client-level lock so
+/// parallel writes across different writers stay unserialized, but each
+/// writer carries its own per-`DDSWriterHandleBox` lock that serializes
+/// `writeRawCDR` against `destroyWriter` for the *same* writer (preventing
+/// use-after-free on the underlying CycloneDDS writer pointer). Callers must
+/// still ensure writers outlive the session.
 public final class DefaultDDSClient: DDSClientProtocol {
     private var session: OpaquePointer?
     private let lock = NSLock()
@@ -173,16 +193,21 @@ public final class DefaultDDSClient: DDSClientProtocol {
         data: Data,
         timestamp: UInt64
     ) throws {
-        guard let box = writer as? DDSWriterHandleBox, let raw = box.raw else {
-            throw DDSError.writeFailed("foreign or closed DDS writer handle")
+        guard let box = writer as? DDSWriterHandleBox else {
+            throw DDSError.writeFailed("foreign DDS writer handle")
         }
-        let result: Int32 = data.withUnsafeBytes { buf -> Int32 in
+        let result: Int32? = data.withUnsafeBytes { buf -> Int32? in
             guard let ptr = buf.bindMemory(to: UInt8.self).baseAddress else { return -1 }
-            return dds_bridge_write_raw_cdr(raw, ptr, data.count, timestamp)
+            return box.withWriter { raw in
+                dds_bridge_write_raw_cdr(raw, ptr, data.count, timestamp)
+            }
         }
-        if result != 0 {
+        guard let code = result else {
+            throw DDSError.writeFailed("DDS writer handle has been closed")
+        }
+        if code != 0 {
             let msg = String(cString: dds_bridge_get_last_error())
-            throw DDSError.writeFailed("dds_bridge_write_raw_cdr=\(result): \(msg)")
+            throw DDSError.writeFailed("dds_bridge_write_raw_cdr=\(code): \(msg)")
         }
     }
 

--- a/Sources/SwiftROS2DDS/DefaultDDSClient.swift
+++ b/Sources/SwiftROS2DDS/DefaultDDSClient.swift
@@ -1,8 +1,8 @@
 // DefaultDDSClient.swift
 // Default implementation of DDSClientProtocol using the CDDSBridge C FFI.
 
-import Foundation
 import CDDSBridge
+import Foundation
 import SwiftROS2Transport
 
 // MARK: - Writer handle
@@ -64,13 +64,13 @@ public final class DefaultDDSClient: DDSClientProtocol {
         var cConfig = bridge_discovery_config_t()
         switch discoveryConfig.mode {
         case .multicast: cConfig.mode = BRIDGE_DISCOVERY_MULTICAST
-        case .unicast:   cConfig.mode = BRIDGE_DISCOVERY_UNICAST
-        case .hybrid:    cConfig.mode = BRIDGE_DISCOVERY_HYBRID
+        case .unicast: cConfig.mode = BRIDGE_DISCOVERY_UNICAST
+        case .hybrid: cConfig.mode = BRIDGE_DISCOVERY_HYBRID
         }
 
         // Build peer C-string array
         var peerCStrings: [UnsafeMutablePointer<CChar>?] = discoveryConfig.unicastPeers.map { strdup($0) }
-        peerCStrings.append(nil) // NULL-terminator for C array
+        peerCStrings.append(nil)  // NULL-terminator for C array
 
         let peersPtr = UnsafeMutablePointer<UnsafePointer<CChar>?>.allocate(capacity: peerCStrings.count)
         defer {
@@ -144,7 +144,8 @@ public final class DefaultDDSClient: DDSClientProtocol {
 
         var cQos = bridge_qos_config_t()
         cQos.reliability = qos.reliability == .reliable ? BRIDGE_RELIABILITY_RELIABLE : BRIDGE_RELIABILITY_BEST_EFFORT
-        cQos.durability = qos.durability == .transientLocal ? BRIDGE_DURABILITY_TRANSIENT_LOCAL : BRIDGE_DURABILITY_VOLATILE
+        cQos.durability =
+            qos.durability == .transientLocal ? BRIDGE_DURABILITY_TRANSIENT_LOCAL : BRIDGE_DURABILITY_VOLATILE
         cQos.history_kind = qos.historyKind == .keepAll ? BRIDGE_HISTORY_KEEP_ALL : BRIDGE_HISTORY_KEEP_LAST
         cQos.history_depth = qos.historyDepth
 

--- a/Sources/SwiftROS2DDS/Exports.swift
+++ b/Sources/SwiftROS2DDS/Exports.swift
@@ -1,0 +1,5 @@
+// Re-export the Swift transport symbols so a caller that imports SwiftROS2DDS
+// can reach the shared protocol types (DDSClientProtocol, DDSBridgeQoSConfig,
+// DDSError) without adding SwiftROS2Transport to its own import list. The
+// actual DefaultDDSClient is added in a follow-up task.
+@_exported import SwiftROS2Transport

--- a/Sources/SwiftROS2DDS/Exports.swift
+++ b/Sources/SwiftROS2DDS/Exports.swift
@@ -1,5 +1,5 @@
 // Re-export the Swift transport symbols so a caller that imports SwiftROS2DDS
-// can reach the shared protocol types (DDSClientProtocol, DDSBridgeQoSConfig,
-// DDSError) without adding SwiftROS2Transport to its own import list. The
-// actual DefaultDDSClient is added in a follow-up task.
+// can reach the shared transport types (DDSClientProtocol, DDSBridgeQoSConfig,
+// DDSError, DefaultDDSClient) without adding SwiftROS2Transport to its own
+// import list.
 @_exported import SwiftROS2Transport

--- a/Sources/SwiftROS2Zenoh/DefaultZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/DefaultZenohClient.swift
@@ -131,6 +131,11 @@ public class LivelinessToken {
 
 /// Main Zenoh client for iOS, conforming to ZenohClientProtocol.
 /// Manages a Zenoh session and provides methods for publishing and subscribing.
+///
+/// Thread-safety: `DefaultZenohClient` is NOT safe for concurrent calls to `open` / `close` /
+/// `put` / `subscribe` across multiple threads. Callers must serialize these calls themselves
+/// (e.g., via `ZenohTransportSession` or an actor). The internal `resourceLock` only protects
+/// the tracked-resource arrays, not the `session` pointer itself.
 public class DefaultZenohClient: ZenohClientProtocol {
     private let log = Logger(subsystem: "com.youtalk.swift-ros2", category: "Zenoh")
 

--- a/Sources/SwiftROS2Zenoh/DefaultZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/DefaultZenohClient.swift
@@ -7,10 +7,10 @@
 // SwiftROS2Transport can drive the session without a C dependency.
 //
 
-import Foundation
-import os.log
 import CZenohBridge
+import Foundation
 import SwiftROS2Transport
+import os.log
 
 // MARK: - Declared Key Expression
 
@@ -176,9 +176,9 @@ public class DefaultZenohClient: ZenohClientProtocol {
             log.error("Session creation failed with code \(result)")
             throw ZenohError.sessionCreationFailed(
                 "Connection failed (error code: \(result)). Please verify:\n"
-                + "• Router address and port\n"
-                + "• Network connectivity\n"
-                + "• Local Network permission is enabled in Settings"
+                    + "• Router address and port\n"
+                    + "• Network connectivity\n"
+                    + "• Local Network permission is enabled in Settings"
             )
         }
 

--- a/Sources/SwiftROS2Zenoh/DefaultZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/DefaultZenohClient.swift
@@ -1,0 +1,512 @@
+//
+// DefaultZenohClient.swift
+// Swift wrapper for zenoh-pico C-FFI bridge
+//
+// Provides a Swift-friendly API for Zenoh operations with proper error handling,
+// resource management, and type safety. Conforms to ZenohClientProtocol so that
+// SwiftROS2Transport can drive the session without a C dependency.
+//
+
+import Foundation
+import os.log
+import CZenohBridge
+import SwiftROS2Transport
+
+// MARK: - Declared Key Expression
+
+/// Represents a declared key expression for efficient reuse
+public class DeclaredKeyExpr {
+    private var handle: OpaquePointer?
+    private weak var session: DefaultZenohClient?
+
+    fileprivate init(handle: OpaquePointer, session: DefaultZenohClient) {
+        self.handle = handle
+        self.session = session
+    }
+
+    fileprivate var opaqueHandle: OpaquePointer? {
+        return handle
+    }
+
+    deinit {
+        // Undeclare keyexpr on deallocation
+        if let h = handle, let sess = session, let sessionHandle = sess.sessionHandle {
+            var mutableHandle: OpaquePointer? = h
+            _ = zenoh_undeclare_keyexpr(sessionHandle, &mutableHandle)
+            handle = nil
+        }
+    }
+}
+
+// MARK: - Subscriber
+
+/// Represents an active subscription
+public class ZenohSubscriber {
+    private var handle: OpaquePointer?
+    private weak var session: DefaultZenohClient?
+    private var handler: (ZenohSample) -> Void
+    private var contextBox: Unmanaged<SubscriberContext>?
+
+    fileprivate init(
+        handle: OpaquePointer,
+        session: DefaultZenohClient,
+        handler: @escaping (ZenohSample) -> Void,
+        contextBox: Unmanaged<SubscriberContext>
+    ) {
+        self.handle = handle
+        self.session = session
+        self.handler = handler
+        self.contextBox = contextBox
+    }
+
+    /// Closes the subscription
+    public func close() throws {
+        guard let h = handle else {
+            throw ZenohError.internalError("Subscriber already closed")
+        }
+
+        guard let sess = session, let sessionHandle = sess.sessionHandle else {
+            throw ZenohError.internalError("Session is no longer valid")
+        }
+
+        var mutableHandle: OpaquePointer? = h
+        let result = zenoh_undeclare_subscriber(sessionHandle, &mutableHandle)
+
+        if result < 0 {
+            throw ZenohError.unsubscribeFailed("Error code: \(result)")
+        }
+
+        handle = nil
+
+        // Release the retained context to prevent memory leak
+        contextBox?.release()
+        contextBox = nil
+    }
+
+    deinit {
+        // Try to close on deallocation
+        try? close()
+    }
+}
+
+// MARK: - Liveliness Token
+
+/// Represents an active liveliness token for ROS 2 discovery
+public class LivelinessToken {
+    private var handle: OpaquePointer?
+    private weak var session: DefaultZenohClient?
+
+    fileprivate init(handle: OpaquePointer, session: DefaultZenohClient) {
+        self.handle = handle
+        self.session = session
+    }
+
+    /// Closes the liveliness token
+    public func close() throws {
+        guard let h = handle else {
+            throw ZenohError.internalError("Liveliness token already closed")
+        }
+
+        guard let sess = session, let sessionHandle = sess.sessionHandle else {
+            throw ZenohError.internalError("Session is no longer valid")
+        }
+
+        var mutableHandle: OpaquePointer? = h
+        let result = zenoh_undeclare_liveliness_token(sessionHandle, &mutableHandle)
+
+        if result < 0 {
+            throw ZenohError.internalError("Failed to undeclare liveliness token: error code \(result)")
+        }
+
+        handle = nil
+    }
+
+    deinit {
+        // Try to close on deallocation
+        try? close()
+    }
+}
+
+// MARK: - Default Zenoh Client
+
+/// Main Zenoh client for iOS, conforming to ZenohClientProtocol.
+/// Manages a Zenoh session and provides methods for publishing and subscribing.
+public class DefaultZenohClient: ZenohClientProtocol {
+    private let log = Logger(subsystem: "com.youtalk.swift-ros2", category: "Zenoh")
+
+    private var session: OpaquePointer?
+    private var declaredKeyExprs: [DeclaredKeyExpr] = []
+    private var subscribers: [ZenohSubscriber] = []
+    private var livelinessTokens: [LivelinessToken] = []
+    private let resourceLock = NSLock()
+
+    // Internal access for nested types
+    fileprivate var sessionHandle: OpaquePointer? {
+        return session
+    }
+
+    /// Initializes the Zenoh client (session not yet opened)
+    public init() {
+        // Empty init - call open() to connect
+    }
+
+    // MARK: - Session Management
+
+    /// Opens a Zenoh session
+    /// - Parameter locator: Connection string (e.g., "tcp/127.0.0.1:7447")
+    /// - Throws: ZenohError if the session cannot be opened
+    public func open(locator: String) throws {
+        guard session == nil else {
+            throw ZenohError.sessionCreationFailed("Session already open")
+        }
+
+        log.debug("Opening session with locator: \(locator)")
+
+        var sessionPtr: OpaquePointer?
+        let result = locator.withCString { locatorPtr in
+            return zenoh_open_session(locatorPtr, &sessionPtr)
+        }
+
+        if result < 0 || sessionPtr == nil {
+            log.error("Session creation failed with code \(result)")
+            throw ZenohError.sessionCreationFailed(
+                "Connection failed (error code: \(result)). Please verify:\n"
+                + "• Router address and port\n"
+                + "• Network connectivity\n"
+                + "• Local Network permission is enabled in Settings"
+            )
+        }
+
+        log.info("Session opened successfully")
+        session = sessionPtr
+    }
+
+    /// Closes the Zenoh session and cleans up all resources
+    /// - Throws: ZenohError if the session cannot be closed
+    public func close() throws {
+        guard let sess = session else {
+            throw ZenohError.sessionCloseFailed("Session not open")
+        }
+
+        // Copy resources under lock, then close outside lock to avoid deadlock
+        let tokensToClose: [LivelinessToken]
+        let subscribersToClose: [ZenohSubscriber]
+        resourceLock.lock()
+        tokensToClose = livelinessTokens
+        subscribersToClose = subscribers
+        livelinessTokens.removeAll()
+        subscribers.removeAll()
+        declaredKeyExprs.removeAll()
+        resourceLock.unlock()
+
+        // Clean up liveliness tokens
+        for token in tokensToClose {
+            try? token.close()
+        }
+
+        // Clean up subscribers
+        for subscriber in subscribersToClose {
+            try? subscriber.close()
+        }
+
+        // Close the session
+        var mutableSess: OpaquePointer? = sess
+        let result = zenoh_close_session(&mutableSess)
+
+        if result < 0 {
+            throw ZenohError.sessionCloseFailed("Error code: \(result)")
+        }
+
+        session = nil
+    }
+
+    /// Gets the Zenoh session ID as a hex string
+    /// - Returns: The session ID (32 hex characters)
+    /// - Throws: ZenohError if the session is not open or if getting the ID fails
+    public func getSessionId() throws -> String {
+        guard let sess = session else {
+            throw ZenohError.internalError("Session not open")
+        }
+
+        var buffer = [CChar](repeating: 0, count: 33)  // 32 hex chars + null terminator
+        let result = zenoh_get_session_id(sess, &buffer, 33)
+
+        if result < 0 {
+            throw ZenohError.internalError("Failed to get session ID: error code \(result)")
+        }
+
+        return String(cString: buffer)
+    }
+
+    /// Checks if the Zenoh session is healthy and can safely publish.
+    /// This performs a lightweight health check to detect stale sessions
+    /// after sleep/wake cycles.
+    /// - Returns: true if session is healthy, false if stale or not connected
+    public func isSessionHealthy() -> Bool {
+        guard let sess = session else {
+            return false
+        }
+        return zenoh_is_session_healthy(sess)
+    }
+
+    // MARK: - Key Expression Management
+
+    /// Declares a key expression for efficient reuse
+    /// - Parameter keyExpr: The key expression string to declare
+    /// - Returns: A handle conforming to ZenohKeyExprHandle
+    /// - Throws: ZenohError if declaration fails
+    public func declareKeyExpr(_ keyExpr: String) throws -> any ZenohKeyExprHandle {
+        guard let sess = session else {
+            throw ZenohError.keyExprDeclarationFailed("Session not open")
+        }
+
+        var keyExprPtr: OpaquePointer?
+        let result = keyExpr.withCString { keyExprCStr in
+            zenoh_declare_keyexpr(sess, keyExprCStr, &keyExprPtr)
+        }
+
+        guard result >= 0, let keyExprHandle = keyExprPtr else {
+            throw ZenohError.keyExprDeclarationFailed("Error code: \(result)")
+        }
+
+        let declared = DeclaredKeyExpr(handle: keyExprHandle, session: self)
+        resourceLock.lock()
+        declaredKeyExprs.append(declared)
+        resourceLock.unlock()
+        return declared
+    }
+
+    // MARK: - Publishing
+
+    /// Publishes data to a declared key expression handle (protocol method).
+    /// - Parameters:
+    ///   - keyExpr: A ZenohKeyExprHandle (must be a DeclaredKeyExpr from this client)
+    ///   - payload: The data to publish
+    ///   - attachment: Optional attachment data (for ROS 2 metadata)
+    /// - Throws: ZenohError if the put operation fails or the handle type is foreign
+    public func put(keyExpr: any ZenohKeyExprHandle, payload: Data, attachment: Data?) throws {
+        guard let declared = keyExpr as? DeclaredKeyExpr else {
+            throw ZenohError.invalidParameter("foreign key-expression handle")
+        }
+        try putDeclared(keyExpr: declared, payload: payload, attachment: attachment)
+    }
+
+    /// Publishes data to a key expression string (without prior declaration)
+    /// - Parameters:
+    ///   - keyExpr: The key expression string
+    ///   - payload: The data to publish
+    ///   - attachment: Optional attachment data (for ROS 2 metadata)
+    /// - Throws: ZenohError if the put operation fails
+    public func put(keyExpr: String, payload: Data, attachment: Data?) throws {
+        guard let sess = session else {
+            throw ZenohError.putFailed("Session not open")
+        }
+
+        let result = keyExpr.withCString { keyExprPtr in
+            payload.withUnsafeBytes { payloadPtr in
+                if let attachment = attachment {
+                    return attachment.withUnsafeBytes { attachmentPtr in
+                        zenoh_put_str(
+                            sess,
+                            keyExprPtr,
+                            payloadPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                            payload.count,
+                            attachmentPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                            attachment.count
+                        )
+                    }
+                } else {
+                    return zenoh_put_str(
+                        sess,
+                        keyExprPtr,
+                        payloadPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        payload.count,
+                        nil,
+                        0
+                    )
+                }
+            }
+        }
+
+        if result == -2 {
+            // Session disconnected - router connection lost
+            session = nil
+            throw ZenohError.sessionDisconnected("Router connection lost")
+        } else if result < 0 {
+            throw ZenohError.putFailed("Error code: \(result)")
+        }
+    }
+
+    // MARK: - Subscription
+
+    /// Subscribes to a key expression with a callback handler
+    /// - Parameters:
+    ///   - keyExpr: The key expression to subscribe to
+    ///   - handler: Callback to invoke when samples are received
+    /// - Returns: A handle conforming to ZenohSubscriberHandle
+    /// - Throws: ZenohError if subscription fails
+    public func subscribe(
+        keyExpr: String,
+        handler: @escaping (ZenohSample) -> Void
+    ) throws -> any ZenohSubscriberHandle {
+        guard let sess = session else {
+            throw ZenohError.subscribeFailed("Session not open")
+        }
+
+        // Create a boxed handler that Swift can pass to C
+        let contextBox = Unmanaged.passRetained(SubscriberContext(handler: handler))
+        let context = UnsafeMutableRawPointer(contextBox.toOpaque())
+
+        var subscriberPtr: OpaquePointer?
+        let result = keyExpr.withCString { keyExprCStr in
+            zenoh_declare_subscriber(sess, keyExprCStr, subscriberCallbackBridge, context, &subscriberPtr)
+        }
+
+        guard result >= 0, let subHandle = subscriberPtr else {
+            contextBox.release()
+            throw ZenohError.subscribeFailed("Error code: \(result)")
+        }
+
+        let subscriber = ZenohSubscriber(
+            handle: subHandle,
+            session: self,
+            handler: handler,
+            contextBox: contextBox
+        )
+        resourceLock.lock()
+        subscribers.append(subscriber)
+        resourceLock.unlock()
+        return subscriber
+    }
+
+    // MARK: - Liveliness Tokens
+
+    /// Declares a liveliness token for ROS 2 entity discovery
+    /// - Parameter keyExpr: The liveliness token key expression (e.g., "@ros2_lv/0/...")
+    /// - Returns: A handle conforming to ZenohLivelinessTokenHandle
+    /// - Throws: ZenohError if declaration fails
+    public func declareLivelinessToken(_ keyExpr: String) throws -> any ZenohLivelinessTokenHandle {
+        guard let sess = session else {
+            throw ZenohError.internalError("Session not open")
+        }
+
+        var tokenPtr: OpaquePointer?
+        let result = keyExpr.withCString { keyExprCStr in
+            zenoh_declare_liveliness_token(sess, keyExprCStr, &tokenPtr)
+        }
+
+        guard result >= 0, let tokenHandle = tokenPtr else {
+            throw ZenohError.internalError("Failed to declare liveliness token: error code \(result)")
+        }
+
+        let token = LivelinessToken(handle: tokenHandle, session: self)
+        resourceLock.lock()
+        livelinessTokens.append(token)
+        resourceLock.unlock()
+        return token
+    }
+
+    deinit {
+        // Clean up session on deallocation
+        try? close()
+    }
+
+    // MARK: - Internal typed put (for DeclaredKeyExpr)
+
+    private func putDeclared(keyExpr: DeclaredKeyExpr, payload: Data, attachment: Data?) throws {
+        guard let sess = session else {
+            throw ZenohError.putFailed("Session not open")
+        }
+
+        guard let keyExprHandle = keyExpr.opaqueHandle else {
+            throw ZenohError.putFailed("Invalid key expression")
+        }
+
+        let result = payload.withUnsafeBytes { payloadPtr in
+            if let attachment = attachment {
+                return attachment.withUnsafeBytes { attachmentPtr in
+                    zenoh_put(
+                        sess,
+                        keyExprHandle,
+                        payloadPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        payload.count,
+                        attachmentPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        attachment.count
+                    )
+                }
+            } else {
+                return zenoh_put(
+                    sess,
+                    keyExprHandle,
+                    payloadPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                    payload.count,
+                    nil,
+                    0
+                )
+            }
+        }
+
+        if result == -2 {
+            // Session disconnected - router connection lost
+            session = nil
+            throw ZenohError.sessionDisconnected("Router connection lost")
+        } else if result < 0 {
+            throw ZenohError.putFailed("Error code: \(result)")
+        }
+    }
+}
+
+// MARK: - Internal Subscriber Context
+
+/// Internal context for passing Swift closures to C callbacks
+private class SubscriberContext {
+    let handler: (ZenohSample) -> Void
+
+    init(handler: @escaping (ZenohSample) -> Void) {
+        self.handler = handler
+    }
+}
+
+/// C callback bridge that converts C callback to Swift closure
+private func subscriberCallbackBridge(
+    keyExpr: UnsafePointer<CChar>?,
+    payload: UnsafePointer<UInt8>?,
+    payloadLen: Int,
+    attachment: UnsafePointer<UInt8>?,
+    attachmentLen: Int,
+    context: UnsafeMutableRawPointer?
+) {
+    guard let context = context else { return }
+
+    let contextBox = Unmanaged<SubscriberContext>.fromOpaque(context)
+    let subscriberContext = contextBox.takeUnretainedValue()
+
+    // Convert C strings and data to Swift types
+    let keyExprString = keyExpr.flatMap { String(cString: $0) } ?? ""
+
+    let payloadData: Data
+    if let payload = payload, payloadLen > 0 {
+        payloadData = Data(bytes: payload, count: payloadLen)
+    } else {
+        payloadData = Data()
+    }
+
+    let attachmentData: Data?
+    if let attachment = attachment, attachmentLen > 0 {
+        attachmentData = Data(bytes: attachment, count: attachmentLen)
+    } else {
+        attachmentData = nil
+    }
+
+    // ZenohSample is the SwiftROS2Transport canonical type
+    let sample = ZenohSample(keyExpr: keyExprString, payload: payloadData, attachment: attachmentData)
+
+    // Invoke Swift handler
+    subscriberContext.handler(sample)
+}
+
+// MARK: - Protocol Conformance Extensions
+
+extension DeclaredKeyExpr: ZenohKeyExprHandle {}
+extension ZenohSubscriber: ZenohSubscriberHandle {}
+extension LivelinessToken: ZenohLivelinessTokenHandle {}

--- a/Sources/SwiftROS2Zenoh/DefaultZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/DefaultZenohClient.swift
@@ -65,6 +65,15 @@ public class ZenohSubscriber {
             throw ZenohError.internalError("Subscriber already closed")
         }
 
+        // Release Swift-side resources regardless of the C-side outcome so a
+        // failed undeclare does not leak the retained context or leave the
+        // handle pointing at freed state for a subsequent close() attempt.
+        defer {
+            handle = nil
+            contextBox?.release()
+            contextBox = nil
+        }
+
         guard let sess = session, let sessionHandle = sess.sessionHandle else {
             throw ZenohError.internalError("Session is no longer valid")
         }
@@ -75,12 +84,6 @@ public class ZenohSubscriber {
         if result < 0 {
             throw ZenohError.unsubscribeFailed("Error code: \(result)")
         }
-
-        handle = nil
-
-        // Release the retained context to prevent memory leak
-        contextBox?.release()
-        contextBox = nil
     }
 
     deinit {
@@ -193,12 +196,19 @@ public class DefaultZenohClient: ZenohClientProtocol {
             throw ZenohError.sessionCloseFailed("Session not open")
         }
 
-        // Copy resources under lock, then close outside lock to avoid deadlock
+        // Copy resources under lock, then close/release outside lock so that
+        // DeclaredKeyExpr / ZenohSubscriber / LivelinessToken deinits — which
+        // call back into zenoh_undeclare_* — do not run while we hold
+        // resourceLock. `keyExprsToRelease` keeps the declared-keyexpr refs
+        // alive across the unlock so their deinits fire when it goes out of
+        // scope at the end of this method.
         let tokensToClose: [LivelinessToken]
         let subscribersToClose: [ZenohSubscriber]
+        let keyExprsToRelease: [DeclaredKeyExpr]
         resourceLock.lock()
         tokensToClose = livelinessTokens
         subscribersToClose = subscribers
+        keyExprsToRelease = declaredKeyExprs
         livelinessTokens.removeAll()
         subscribers.removeAll()
         declaredKeyExprs.removeAll()
@@ -213,6 +223,9 @@ public class DefaultZenohClient: ZenohClientProtocol {
         for subscriber in subscribersToClose {
             try? subscriber.close()
         }
+
+        // keyExprsToRelease is intentionally kept alive until method exit.
+        _ = keyExprsToRelease
 
         // Close the session
         var mutableSess: OpaquePointer? = sess

--- a/Sources/SwiftROS2Zenoh/Exports.swift
+++ b/Sources/SwiftROS2Zenoh/Exports.swift
@@ -1,5 +1,4 @@
 // Re-export the Swift transport symbols so a caller that imports SwiftROS2Zenoh
 // can reach the shared protocol types (ZenohClientProtocol, ZenohSample, ZenohError)
-// without adding SwiftROS2Transport to its own import list. The actual
-// DefaultZenohClient is added in a follow-up task.
+// without adding SwiftROS2Transport to its own import list.
 @_exported import SwiftROS2Transport

--- a/Sources/SwiftROS2Zenoh/Exports.swift
+++ b/Sources/SwiftROS2Zenoh/Exports.swift
@@ -1,0 +1,5 @@
+// Re-export the Swift transport symbols so a caller that imports SwiftROS2Zenoh
+// can reach the shared protocol types (ZenohClientProtocol, ZenohSample, ZenohError)
+// without adding SwiftROS2Transport to its own import list. The actual
+// DefaultZenohClient is added in a follow-up task.
+@_exported import SwiftROS2Transport

--- a/Tests/SwiftROS2DDSTests/DefaultDDSClientSmokeTests.swift
+++ b/Tests/SwiftROS2DDSTests/DefaultDDSClientSmokeTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import SwiftROS2DDS
 
 final class DefaultDDSClientSmokeTests: XCTestCase {
@@ -14,8 +15,9 @@ final class DefaultDDSClientSmokeTests: XCTestCase {
     func testWriteWithForeignHandleThrows() throws {
         let client = DefaultDDSClient()
         let foreign = ForeignWriterHandle()
-        XCTAssertThrowsError(try client.writeRawCDR(
-            writer: foreign, data: Data([0x00, 0x01, 0x00, 0x00]), timestamp: 0)
+        XCTAssertThrowsError(
+            try client.writeRawCDR(
+                writer: foreign, data: Data([0x00, 0x01, 0x00, 0x00]), timestamp: 0)
         ) { error in
             guard let e = error as? DDSError else {
                 XCTFail("Expected DDSError, got \(type(of: error))")

--- a/Tests/SwiftROS2DDSTests/DefaultDDSClientSmokeTests.swift
+++ b/Tests/SwiftROS2DDSTests/DefaultDDSClientSmokeTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import SwiftROS2DDS
+
+final class DefaultDDSClientSmokeTests: XCTestCase {
+    func testAvailabilityFlag() {
+        let client = DefaultDDSClient()
+        XCTAssertTrue(client.isAvailable)
+    }
+
+    func testInitializationDoesNotCrash() {
+        _ = DefaultDDSClient()
+    }
+
+    func testWriteWithForeignHandleThrows() throws {
+        let client = DefaultDDSClient()
+        let foreign = ForeignWriterHandle()
+        XCTAssertThrowsError(try client.writeRawCDR(
+            writer: foreign, data: Data([0x00, 0x01, 0x00, 0x00]), timestamp: 0)
+        ) { error in
+            guard let e = error as? DDSError else {
+                XCTFail("Expected DDSError, got \(type(of: error))")
+                return
+            }
+            if case .writeFailed = e {
+                // ok
+            } else {
+                XCTFail("Expected .writeFailed, got \(e)")
+            }
+        }
+    }
+}
+
+private final class ForeignWriterHandle: DDSWriterHandle {
+    var isActive: Bool { false }
+    func close() {}
+}

--- a/Tests/SwiftROS2IntegrationTests/DDSRoundTripTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/DDSRoundTripTests.swift
@@ -1,7 +1,7 @@
-import XCTest
 import SwiftROS2
 import SwiftROS2Messages
 import SwiftROS2Transport
+import XCTest
 
 /// Round-trip integration test over CycloneDDS. Requires:
 /// - `LINUX_IP` env var (the host running a matching-domain ros2 topic echo)
@@ -32,10 +32,11 @@ final class DDSRoundTripTests: XCTestCase {
         try await Task.sleep(nanoseconds: 3_000_000_000)
 
         for i in 0..<10 {
-            try pub.publish(Imu(
-                header: Header.now(frameId: "imu_link"),
-                linearAcceleration: Vector3(x: 0.0, y: 0.0, z: 9.81 + Double(i) * 0.01)
-            ))
+            try pub.publish(
+                Imu(
+                    header: Header.now(frameId: "imu_link"),
+                    linearAcceleration: Vector3(x: 0.0, y: 0.0, z: 9.81 + Double(i) * 0.01)
+                ))
             try await Task.sleep(nanoseconds: 100_000_000)
         }
 

--- a/Tests/SwiftROS2IntegrationTests/DDSRoundTripTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/DDSRoundTripTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import SwiftROS2
+import SwiftROS2Messages
+import SwiftROS2Transport
+
+/// Round-trip integration test over CycloneDDS. Requires:
+/// - `LINUX_IP` env var (the host running a matching-domain ros2 topic echo)
+/// - A running `ros2 topic echo /test/imu` on that host with
+///   `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp` and `ROS_DOMAIN_ID=99`
+///
+/// Uses unicast discovery so the test works across WiFi / Parallels /
+/// environments where DDS multicast may be filtered.
+final class DDSRoundTripTests: XCTestCase {
+    func testImuPublishReceivedByLinuxDDS() async throws {
+        guard let linuxIP = ProcessInfo.processInfo.environment["LINUX_IP"], !linuxIP.isEmpty else {
+            throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)")
+        }
+
+        let domain = 99
+        let ctx = try await ROS2Context(
+            transport: .ddsUnicast(
+                peers: [DDSPeer.peer(address: linuxIP, domainId: domain)],
+                domainId: domain
+            ),
+            distro: .jazzy,
+            domainId: domain
+        )
+        let node = try await ctx.createNode(name: "swift_ros2_it_dds", namespace: "/test")
+        let pub = try await node.createPublisher(Imu.self, topic: "imu")
+
+        // DDS endpoint discovery through SPDP/SEDP is slower than Zenoh.
+        try await Task.sleep(nanoseconds: 3_000_000_000)
+
+        for i in 0..<10 {
+            try pub.publish(Imu(
+                header: Header.now(frameId: "imu_link"),
+                linearAcceleration: Vector3(x: 0.0, y: 0.0, z: 9.81 + Double(i) * 0.01)
+            ))
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        try await Task.sleep(nanoseconds: 500_000_000)
+        await ctx.shutdown()
+    }
+}

--- a/Tests/SwiftROS2IntegrationTests/ZenohRoundTripTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/ZenohRoundTripTests.swift
@@ -1,7 +1,7 @@
-import XCTest
 import SwiftROS2
 import SwiftROS2Messages
 import SwiftROS2Transport
+import XCTest
 
 /// Round-trip integration test: publishes sensor_msgs/Imu via Zenoh to a
 /// ROS 2 Jazzy Zenoh router and confirms the subscriber on the router host
@@ -29,10 +29,11 @@ final class ZenohRoundTripTests: XCTestCase {
         try await Task.sleep(nanoseconds: 500_000_000)
 
         for i in 0..<10 {
-            try pub.publish(Imu(
-                header: Header.now(frameId: "imu_link"),
-                linearAcceleration: Vector3(x: 0.0, y: 0.0, z: 9.81 + Double(i) * 0.01)
-            ))
+            try pub.publish(
+                Imu(
+                    header: Header.now(frameId: "imu_link"),
+                    linearAcceleration: Vector3(x: 0.0, y: 0.0, z: 9.81 + Double(i) * 0.01)
+                ))
             try await Task.sleep(nanoseconds: 100_000_000)
         }
 

--- a/Tests/SwiftROS2IntegrationTests/ZenohRoundTripTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/ZenohRoundTripTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import SwiftROS2
+import SwiftROS2Messages
+import SwiftROS2Transport
+
+/// Round-trip integration test: publishes sensor_msgs/Imu via Zenoh to a
+/// ROS 2 Jazzy Zenoh router and confirms the subscriber on the router host
+/// receives the expected sequence. Requires:
+/// - `LINUX_IP` environment variable set to the router host's IPv4
+/// - A running `rmw_zenohd` on that host (tcp/<LINUX_IP>:7447)
+/// - A running `ros2 topic echo /test/imu` on that host (to capture output)
+///
+/// Skips gracefully when `LINUX_IP` is not set so CI stays deterministic.
+final class ZenohRoundTripTests: XCTestCase {
+    func testImuPublishReceivedByLinux() async throws {
+        guard let linuxIP = ProcessInfo.processInfo.environment["LINUX_IP"], !linuxIP.isEmpty else {
+            throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)")
+        }
+
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/\(linuxIP):7447", domainId: 0, wireMode: .jazzy),
+            distro: .jazzy
+        )
+        let node = try await ctx.createNode(name: "swift_ros2_it", namespace: "/test")
+        let pub = try await node.createPublisher(Imu.self, topic: "imu")
+
+        // rmw_zenoh discovery needs a moment for the liveliness token
+        // to propagate to the subscriber before we start publishing.
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        for i in 0..<10 {
+            try pub.publish(Imu(
+                header: Header.now(frameId: "imu_link"),
+                linearAcceleration: Vector3(x: 0.0, y: 0.0, z: 9.81 + Double(i) * 0.01)
+            ))
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        // Give the last message time to reach Linux before shutting down.
+        try await Task.sleep(nanoseconds: 500_000_000)
+        await ctx.shutdown()
+    }
+}

--- a/Tests/SwiftROS2Tests/ContextFactoryTests.swift
+++ b/Tests/SwiftROS2Tests/ContextFactoryTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import SwiftROS2
+import SwiftROS2Transport
+
+final class ContextFactoryTests: XCTestCase {
+    /// Verifies that ROS2Context can build a default Zenoh session without
+    /// the caller having to construct a transport. The connection itself
+    /// will fail because no router is running at the dummy locator, but the
+    /// factory path must NOT throw `unsupportedFeature`.
+    func testZenohContextBuildsDefaultSession() async {
+        let config = TransportConfig(
+            type: .zenoh,
+            zenohLocator: "tcp/127.0.0.1:17447",  // bogus port, nothing listens
+            connectionTimeout: 1.0
+        )
+
+        do {
+            let ctx = try await ROS2Context(transport: config)
+            _ = ctx
+            XCTFail("Expected connection to fail (no router), but succeeded")
+        } catch TransportError.unsupportedFeature(let msg) {
+            XCTFail("Factory should build a default session, but hit unsupportedFeature: \(msg)")
+        } catch {
+            // Any other error is acceptable — connectionFailed is typical.
+        }
+    }
+
+    /// Same shape for DDS. DDS requires a live discovery environment; on
+    /// macOS (no multicast) we just verify the factory wires a DDSTransportSession
+    /// rather than throwing unsupportedFeature.
+    func testDDSContextBuildsDefaultSession() async {
+        let config = TransportConfig(
+            type: .dds,
+            domainId: 99  // unused domain
+        )
+
+        do {
+            let ctx = try await ROS2Context(transport: config)
+            _ = ctx
+        } catch TransportError.unsupportedFeature(let msg) {
+            XCTFail("Factory should build a default session, but hit unsupportedFeature: \(msg)")
+        } catch {
+            // connectionFailed or similar is acceptable.
+        }
+    }
+}

--- a/Tests/SwiftROS2Tests/ContextFactoryTests.swift
+++ b/Tests/SwiftROS2Tests/ContextFactoryTests.swift
@@ -1,6 +1,6 @@
-import XCTest
 import SwiftROS2
 import SwiftROS2Transport
+import XCTest
 
 final class ContextFactoryTests: XCTestCase {
     /// Verifies that ROS2Context can build a default Zenoh session without

--- a/Tests/SwiftROS2ZenohTests/DefaultZenohClientSmokeTests.swift
+++ b/Tests/SwiftROS2ZenohTests/DefaultZenohClientSmokeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import SwiftROS2Zenoh
+
+final class DefaultZenohClientSmokeTests: XCTestCase {
+    func testInitializationDoesNotCrash() {
+        _ = DefaultZenohClient()
+    }
+}

--- a/Tests/SwiftROS2ZenohTests/DefaultZenohClientSmokeTests.swift
+++ b/Tests/SwiftROS2ZenohTests/DefaultZenohClientSmokeTests.swift
@@ -1,8 +1,50 @@
 import XCTest
 @testable import SwiftROS2Zenoh
+import SwiftROS2Transport
+
+// A foreign key-expression handle that is NOT a DeclaredKeyExpr from DefaultZenohClient.
+// Used to exercise the foreign-handle rejection guard in put(keyExpr:payload:attachment:).
+private final class ForeignKeyExprHandle: ZenohKeyExprHandle {}
 
 final class DefaultZenohClientSmokeTests: XCTestCase {
     func testInitializationDoesNotCrash() {
         _ = DefaultZenohClient()
+    }
+
+    /// Verifies that passing a foreign ZenohKeyExprHandle to put() throws ZenohError.invalidParameter.
+    ///
+    /// The foreign-handle guard in DefaultZenohClient.put(keyExpr:payload:attachment:) runs
+    /// BEFORE the session-open guard, so this test does not need a live Zenoh router.
+    func testForeignKeyExprHandleIsRejected() throws {
+        let client = DefaultZenohClient()
+        let foreign = ForeignKeyExprHandle()
+
+        XCTAssertThrowsError(try client.put(keyExpr: foreign, payload: Data(), attachment: nil)) { error in
+            guard let zErr = error as? ZenohError else {
+                XCTFail("Expected ZenohError, got \(type(of: error))")
+                return
+            }
+            if case .invalidParameter = zErr {
+                // Correct: foreign handle was rejected before any C call ran.
+            } else {
+                XCTFail("Expected .invalidParameter, got \(zErr)")
+            }
+        }
+    }
+
+    /// Verifies that calling close() on a client that was never opened throws ZenohError.sessionCloseFailed.
+    func testDoubleCloseOnFreshClientThrows() throws {
+        let client = DefaultZenohClient()
+        XCTAssertThrowsError(try client.close()) { error in
+            guard let zErr = error as? ZenohError else {
+                XCTFail("Expected ZenohError, got \(type(of: error))")
+                return
+            }
+            if case .sessionCloseFailed = zErr {
+                // Correct: closing a never-opened client is reported as sessionCloseFailed.
+            } else {
+                XCTFail("Expected .sessionCloseFailed, got \(zErr)")
+            }
+        }
     }
 }

--- a/Tests/SwiftROS2ZenohTests/DefaultZenohClientSmokeTests.swift
+++ b/Tests/SwiftROS2ZenohTests/DefaultZenohClientSmokeTests.swift
@@ -1,6 +1,7 @@
-import XCTest
-@testable import SwiftROS2Zenoh
 import SwiftROS2Transport
+import XCTest
+
+@testable import SwiftROS2Zenoh
 
 // A foreign key-expression handle that is NOT a DeclaredKeyExpr from DefaultZenohClient.
 // Used to exercise the foreign-handle rejection guard in put(keyExpr:payload:attachment:).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# Architecture
+
+swift-ros2 publishes and subscribes to ROS 2 topics without the rcl/rclcpp stack.
+It speaks the wire protocols directly:
+
+- **Zenoh path** (rmw_zenoh_cpp compatible): zenoh-pico C library, wrapped by `CZenohBridge`, exposed to Swift via `SwiftROS2Zenoh` module.
+- **DDS path** (rmw_cyclonedds_cpp compatible): CycloneDDS C library, wrapped by `CDDSBridge`, exposed to Swift via `SwiftROS2DDS` module.
+
+Both paths implement `ZenohClientProtocol` / `DDSClientProtocol` which `SwiftROS2Transport`
+uses to drive publishers and subscribers. The protocols remain public so callers can
+inject mocks for unit testing.
+
+## Target graph
+
+    SwiftROS2 (public API: Context, Node, Publisher, Subscription)
+     ├── SwiftROS2Messages
+     ├── SwiftROS2Wire
+     ├── SwiftROS2Transport
+     ├── SwiftROS2Zenoh    ─── CZenohBridge ─── CZenohPico
+     └── SwiftROS2DDS      ─── CDDSBridge   ─── CCycloneDDS
+
+`CZenohPico` and `CCycloneDDS` are binaryTargets on Apple platforms and
+system-library / source targets on Linux.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,5 +19,10 @@ inject mocks for unit testing.
      ├── SwiftROS2Zenoh    ─── CZenohBridge ─── CZenohPico
      └── SwiftROS2DDS      ─── CDDSBridge   ─── CCycloneDDS
 
-`CZenohPico` and `CCycloneDDS` are binaryTargets on Apple platforms and
-system-library / source targets on Linux.
+In the current Phase 1 build, `CZenohPico` and `CCycloneDDS` are exposed as
+`systemLibrary` targets. On Apple platforms, linkage is provided via `pkg-config`
+plus locally staged static `.a` libraries (populated by
+`Scripts/bootstrap-maccatalyst.sh`). On Linux, they resolve against the
+system-installed zenoh-pico / CycloneDDS (or source builds produced by
+`Scripts/build-linux-deps.sh`). A platform-specific `binaryTarget` setup can be
+documented separately if adopted in Phase 2.

--- a/vendor/cyclonedds-patches/ios.patch
+++ b/vendor/cyclonedds-patches/ios.patch
@@ -1,0 +1,73 @@
+diff --git a/src/core/ddsi/src/ddsi_raweth.c b/src/core/ddsi/src/ddsi_raweth.c
+--- a/src/core/ddsi/src/ddsi_raweth.c
++++ b/src/core/ddsi/src/ddsi_raweth.c
+@@ -10,6 +10,10 @@
+
+ #include "dds/ddsrt/atomics.h"
+ #include "dds/ddsrt/heap.h"
++#if __APPLE__
++  #include <TargetConditionals.h>
++#endif
++
+ #include "dds/ddsrt/log.h"
+ #include "dds/ddsrt/sockets.h"
+ #include "dds/ddsi/ddsi_log.h"
+@@ -20,7 +24,7 @@
+ #include "ddsi__mcgroup.h"
+ #include "ddsi__pcap.h"
+
+-#if (defined(__linux) || defined(__FreeBSD__) || defined(__QNXNTO__) || defined(__APPLE__)) && !LWIP_SOCKET
++#if (defined(__linux) || defined(__FreeBSD__) || defined(__QNXNTO__) || (defined(__APPLE__) && !TARGET_OS_IPHONE)) && !LWIP_SOCKET
+ #include <sys/types.h>
+ #include <string.h>
+
+diff --git a/src/ddsrt/src/netstat/darwin/netstat.c b/src/ddsrt/src/netstat/darwin/netstat.c
+--- a/src/ddsrt/src/netstat/darwin/netstat.c
++++ b/src/ddsrt/src/netstat/darwin/netstat.c
+@@ -2,6 +2,40 @@
+ #include <stdlib.h>
+ #include <string.h>
+
++#include <TargetConditionals.h>
++
++#if TARGET_OS_IOS || TARGET_OS_SIMULATOR || TARGET_OS_TV || TARGET_OS_WATCH
++/* iOS/tvOS/watchOS don't have net/if_mib.h - provide stub implementation */
++#include <dds/ddsrt/heap.h>
++#include <dds/ddsrt/string.h>
++#include <dds/ddsrt/netstat.h>
++
++struct ddsrt_netstat_control {
++  char *name;
++};
++
++dds_return_t ddsrt_netstat_new (struct ddsrt_netstat_control **control, const char *device)
++{
++  (void)device;
++  *control = NULL;
++  return DDS_RETCODE_ERROR;
++}
++
++dds_return_t ddsrt_netstat_free (struct ddsrt_netstat_control *control)
++{
++  (void)control;
++  return DDS_RETCODE_OK;
++}
++
++dds_return_t ddsrt_netstat_get (struct ddsrt_netstat_control *control, struct ddsrt_netstat *stats)
++{
++  (void)control;
++  (void)stats;
++  return DDS_RETCODE_ERROR;
++}
++
++#else
++/* macOS implementation with net/if_mib.h */
+ #include <sys/param.h>
+ #include <sys/time.h>
+ #include <sys/types.h>
+@@ -128,3 +162,5 @@ dds_return_t ddsrt_netstat_get (struct ddsrt_netstat_control *control, struct dd
+   else
+     return ddsrt_netstat_get_int (control, stats);
+ }
++
++#endif /* TARGET_OS_IOS */


### PR DESCRIPTION
## Summary

Phase 1 of the multi-phase FFI integration (see [plan](https://github.com/youtalk/conduit/blob/feat/swift-ros2-ffi-migration/docs/superpowers/plans/2026-04-18-swift-ros2-ffi-integration.md)). swift-ros2 can now publish ROS 2 messages standalone over Zenoh + CycloneDDS without requiring a consumer app to supply C bridges.

**What this adds:**

- `vendor/zenoh-pico` (youtalk fork, branch `swift-ros2-main`, pinned 706eb989)
- `vendor/cyclonedds` (youtalk fork, branch `swift-ros2-main`, pinned 7290b22e) + iOS patch
- `Sources/CZenohBridge` — zenoh_bridge C shim moved from Conduit
- `Sources/CDDSBridge` — dds_bridge + raw_cdr_sertype C shim moved from Conduit
- `Sources/CZenohPico` + `Sources/CCycloneDDS` — systemLibrary targets with module maps + pkg-config
- `Sources/SwiftROS2Zenoh.DefaultZenohClient` — ZenohClientProtocol conformance (ported from Conduit's ZenohClient)
- `Sources/SwiftROS2DDS.DefaultDDSClient` — DDSClientProtocol conformance (ported from Conduit's DDSClientAdapter)
- `ROS2Context` auto-wires the default clients when the caller passes a plain `TransportConfig` — no more `unsupportedFeature` throw
- `Scripts/bootstrap-maccatalyst.sh` — stages pre-built static libs under `Vendor/` so `swift build` / `swift test` work during Phase 1 (replaced by xcframework binaryTargets in Phase 2)
- New test targets: `SwiftROS2ZenohTests`, `SwiftROS2DDSTests`, `SwiftROS2IntegrationTests`, `ContextFactoryTests`

## What's NOT in this PR

- No xcframework / binaryTarget yet — Package.swift uses `systemLibrary` + local `.a` files staged by `bootstrap-maccatalyst.sh`. Phase 2 replaces this with hosted xcframeworks on GitHub Releases.
- No Linux build path — Phase 3.
- Conduit itself still uses its own Sources/Zenoh + Sources/DDS — Phase 4 deletes them and depends on this PR's new products.

## Test plan

- [x] `bash Scripts/bootstrap-maccatalyst.sh && PKG_CONFIG_PATH=$(pwd)/Vendor/pkgconfig swift build` completes on macOS 14 / arm64
- [x] `swift test` — 67 unit tests pass (including new DefaultZenohClient / DefaultDDSClient / ContextFactory tests)
- [x] `LINUX_IP=192.168.1.85 swift test --filter SwiftROS2IntegrationTests` — Mac → Ubuntu 24.04 + ROS 2 Jazzy round-trip publishes 10 `sensor_msgs/Imu` messages over Zenoh (`rmw_zenoh_cpp`) and DDS unicast (`rmw_cyclonedds_cpp` domain 99); all 10 received on the Linux subscriber for each transport

## Follow-ups (tracked as separate PRs)

- Phase 2: xcframework packaging + GitHub Actions release workflow
- Phase 3: Linux source-build path
- Phase 4: Conduit migration (delete its local Zenoh/DDS/CDR/Transport sources, depend on SwiftROS2Zenoh/SwiftROS2DDS products)
- Phase 5: Tag v0.2.0 + final cross-linked PRs