### PR TITLE
Phase 3: Linux build + CI support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,23 +23,65 @@ jobs:
       - name: Lint
         run: swift format lint --recursive --strict --configuration .swift-format Package.swift Sources Tests
 
-  build-test:
-    name: Build & Test
+  build-macos:
+    name: Build & Test (macOS)
     needs: [swift-format]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        swift: ["5.10", "6.0"]
-    container:
-      image: swift:${{ matrix.swift }}-jammy
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
       - name: Swift version
         run: swift --version
-      - name: Resolve dependencies
-        run: swift package resolve
       - name: Build
-        run: swift build -v
+        run: swift build
       - name: Test
         run: swift test --parallel
+
+  build-linux:
+    name: Build & Test (Ubuntu + ROS 2 Jazzy)
+    needs: [swift-format]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake pkg-config curl gnupg lsb-release software-properties-common
+      - name: Install ROS 2 Jazzy CycloneDDS
+        run: |
+          sudo mkdir -p /usr/share/keyrings
+          curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+            | sudo tee /usr/share/keyrings/ros-archive-keyring.gpg > /dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
+            | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y ros-jazzy-cyclonedds
+      - name: Install Swift 6.0.2
+        run: |
+          curl -sSL "https://download.swift.org/swift-6.0.2-release/ubuntu2404/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE-ubuntu24.04.tar.gz" \
+            -o /tmp/swift.tar.gz
+          sudo mkdir -p /opt/swift
+          sudo tar -xzf /tmp/swift.tar.gz -C /opt/swift --strip-components=1
+          echo "/opt/swift/usr/bin" >> "$GITHUB_PATH"
+      - name: Swift version
+        run: swift --version
+      - name: Verify Linux deps
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          export PKG_CONFIG_PATH="/opt/ros/jazzy/lib/x86_64-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
+          bash Scripts/build-linux-deps.sh
+      - name: Build
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          export PKG_CONFIG_PATH="/opt/ros/jazzy/lib/x86_64-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
+          swift build
+      - name: Test
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          export PKG_CONFIG_PATH="/opt/ros/jazzy/lib/x86_64-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
+          swift test --parallel

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,23 @@ let cZenohPico: Target = {
         return .target(
             name: "CZenohPico",
             path: "vendor/zenoh-pico",
-            exclude: ["CMakeLists.txt", "README.md", "LICENSE", "tests", "examples", "docs", "ci"],
+            exclude: [
+                "CMakeLists.txt", "README.md", "LICENSE", "tests", "examples", "docs", "ci",
+                // Non-Linux platform backends. SPM compiles everything under
+                // `sources: ["src"]` unless excluded. zenoh-pico's CMake build
+                // picks the right backend per platform; for SPM + Linux we hand-
+                // pick src/system/unix and drop the rest.
+                "src/system/arduino",
+                "src/system/emscripten",
+                "src/system/espidf",
+                "src/system/freertos_plus_tcp",
+                "src/system/mbed",
+                "src/system/rpi_pico",
+                "src/system/void",
+                "src/system/windows",
+                "src/system/zephyr",
+                "src/system/flipper",
+            ],
             sources: ["src"],
             publicHeadersPath: "include",
             cSettings: [

--- a/Scripts/build-linux-deps.sh
+++ b/Scripts/build-linux-deps.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Prepare Linux native dependencies for swift-ros2.
+#
+# - zenoh-pico: build from the vendored submodule into .build/linux-deps/
+# - CycloneDDS: verified via pkg-config (provided by the host package,
+#   e.g. `apt install ros-jazzy-cyclonedds` for ROS 2 Jazzy).
+#
+# After running, consumers set:
+#   source /opt/ros/jazzy/setup.bash
+#   export PKG_CONFIG_PATH="$PWD/.build/linux-deps/lib/pkgconfig:/opt/ros/jazzy/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
+#   swift build
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD="$ROOT/.build/linux-deps"
+
+case "$(uname -s)" in
+    Linux*) ;;
+    *) echo "error: $0 is Linux-only (use binaryTarget xcframeworks on Apple)." >&2; exit 1 ;;
+esac
+
+command -v cmake >/dev/null || { echo "error: cmake not found"; exit 1; }
+command -v pkg-config >/dev/null || { echo "error: pkg-config not found"; exit 1; }
+
+mkdir -p "$BUILD"
+
+echo "==> building zenoh-pico (static) into $BUILD"
+cd "$ROOT/vendor/zenoh-pico"
+rm -rf build-linux
+mkdir build-linux
+cd build-linux
+cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DZ_FEATURE_LINK_TCP=1 \
+    -DZ_FEATURE_LIVELINESS=1 \
+    -DCMAKE_INSTALL_PREFIX="$BUILD"
+cmake --build . --config Release -- -j"$(nproc)"
+cmake --install .
+
+cat > "$BUILD/lib/pkgconfig/ZenohPico.pc" <<EOF
+prefix=$BUILD
+exec_prefix=\${prefix}
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: ZenohPico
+Description: Zenoh client library, pico version (swift-ros2 vendored build)
+Version: 1.1.0
+Cflags: -I\${includedir}
+Libs: -L\${libdir} -lzenohpico
+EOF
+
+echo ""
+echo "==> verifying CycloneDDS via pkg-config"
+if ! pkg-config --exists CycloneDDS 2>/dev/null; then
+    echo "CycloneDDS.pc not in default PKG_CONFIG_PATH. Trying /opt/ros/jazzy..."
+    export PKG_CONFIG_PATH="/opt/ros/jazzy/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
+    if ! pkg-config --exists CycloneDDS 2>/dev/null; then
+        cat <<MSG >&2
+
+error: CycloneDDS not found via pkg-config.
+
+Install one of:
+  - ROS 2 Jazzy package: sudo apt install ros-jazzy-cyclonedds
+    then: source /opt/ros/jazzy/setup.bash
+  - Eclipse upstream:   sudo apt install libcyclonedds-dev
+  - From source:        https://github.com/eclipse-cyclonedds/cyclonedds
+
+Add its .pc location to PKG_CONFIG_PATH before re-running this script.
+MSG
+        exit 2
+    fi
+fi
+echo "CycloneDDS:"
+pkg-config --cflags --libs CycloneDDS
+
+echo ""
+echo "==> bootstrap complete."
+echo ""
+echo "Before running swift build / swift test:"
+echo "  source /opt/ros/jazzy/setup.bash"
+echo "  export PKG_CONFIG_PATH=\"$BUILD/lib/pkgconfig:/opt/ros/jazzy/lib/$(uname -m)-linux-gnu/pkgconfig:\${PKG_CONFIG_PATH:-}\""
+echo "  swift build"

--- a/Scripts/build-linux-deps.sh
+++ b/Scripts/build-linux-deps.sh
@@ -1,58 +1,24 @@
 #!/usr/bin/env bash
-# Prepare Linux native dependencies for swift-ros2.
+# Verify Linux native dependencies needed by swift-ros2 are reachable.
 #
-# - zenoh-pico: build from the vendored submodule into .build/linux-deps/
-# - CycloneDDS: verified via pkg-config (provided by the host package,
-#   e.g. `apt install ros-jazzy-cyclonedds` for ROS 2 Jazzy).
+# - zenoh-pico: compiled by SPM directly from the vendored submodule
+#   (vendor/zenoh-pico). No action required by this script.
+# - CycloneDDS: provided by the host (e.g. `apt install ros-jazzy-cyclonedds`).
+#   Must be discoverable via pkg-config under the name `CycloneDDS`.
 #
 # After running, consumers set:
 #   source /opt/ros/jazzy/setup.bash
-#   export PKG_CONFIG_PATH="$PWD/.build/linux-deps/lib/pkgconfig:/opt/ros/jazzy/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
+#   export PKG_CONFIG_PATH="/opt/ros/jazzy/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
 #   swift build
 set -euo pipefail
-
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BUILD="$ROOT/.build/linux-deps"
 
 case "$(uname -s)" in
     Linux*) ;;
     *) echo "error: $0 is Linux-only (use binaryTarget xcframeworks on Apple)." >&2; exit 1 ;;
 esac
 
-command -v cmake >/dev/null || { echo "error: cmake not found"; exit 1; }
-command -v pkg-config >/dev/null || { echo "error: pkg-config not found"; exit 1; }
+command -v pkg-config >/dev/null || { echo "error: pkg-config not found. sudo apt install pkg-config" >&2; exit 1; }
 
-mkdir -p "$BUILD"
-
-echo "==> building zenoh-pico (static) into $BUILD"
-cd "$ROOT/vendor/zenoh-pico"
-rm -rf build-linux
-mkdir build-linux
-cd build-linux
-cmake .. \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SHARED_LIBS=OFF \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-    -DZ_FEATURE_LINK_TCP=1 \
-    -DZ_FEATURE_LIVELINESS=1 \
-    -DCMAKE_INSTALL_PREFIX="$BUILD"
-cmake --build . --config Release -- -j"$(nproc)"
-cmake --install .
-
-cat > "$BUILD/lib/pkgconfig/ZenohPico.pc" <<EOF
-prefix=$BUILD
-exec_prefix=\${prefix}
-libdir=\${prefix}/lib
-includedir=\${prefix}/include
-
-Name: ZenohPico
-Description: Zenoh client library, pico version (swift-ros2 vendored build)
-Version: 1.1.0
-Cflags: -I\${includedir}
-Libs: -L\${libdir} -lzenohpico
-EOF
-
-echo ""
 echo "==> verifying CycloneDDS via pkg-config"
 if ! pkg-config --exists CycloneDDS 2>/dev/null; then
     echo "CycloneDDS.pc not in default PKG_CONFIG_PATH. Trying /opt/ros/jazzy..."
@@ -63,23 +29,24 @@ if ! pkg-config --exists CycloneDDS 2>/dev/null; then
 error: CycloneDDS not found via pkg-config.
 
 Install one of:
-  - ROS 2 Jazzy package: sudo apt install ros-jazzy-cyclonedds
-    then: source /opt/ros/jazzy/setup.bash
-  - Eclipse upstream:   sudo apt install libcyclonedds-dev
-  - From source:        https://github.com/eclipse-cyclonedds/cyclonedds
+  - ROS 2 Jazzy:      sudo apt install ros-jazzy-cyclonedds
+                      then: source /opt/ros/jazzy/setup.bash
+  - Eclipse upstream: sudo apt install libcyclonedds-dev
+  - From source:      https://github.com/eclipse-cyclonedds/cyclonedds
 
 Add its .pc location to PKG_CONFIG_PATH before re-running this script.
 MSG
         exit 2
     fi
 fi
-echo "CycloneDDS:"
-pkg-config --cflags --libs CycloneDDS
+echo "CycloneDDS: $(pkg-config --modversion CycloneDDS)"
+echo "  CFLAGS: $(pkg-config --cflags CycloneDDS)"
+echo "  LIBS:   $(pkg-config --libs CycloneDDS)"
 
 echo ""
 echo "==> bootstrap complete."
 echo ""
 echo "Before running swift build / swift test:"
 echo "  source /opt/ros/jazzy/setup.bash"
-echo "  export PKG_CONFIG_PATH=\"$BUILD/lib/pkgconfig:/opt/ros/jazzy/lib/$(uname -m)-linux-gnu/pkgconfig:\${PKG_CONFIG_PATH:-}\""
+echo "  export PKG_CONFIG_PATH=\"/opt/ros/jazzy/lib/$(uname -m)-linux-gnu/pkgconfig:\${PKG_CONFIG_PATH:-}\""
 echo "  swift build"

--- a/Sources/CDDSBridge/include/module.modulemap
+++ b/Sources/CDDSBridge/include/module.modulemap
@@ -2,6 +2,5 @@ module CDDSBridge {
     header "dds_bridge.h"
     header "raw_cdr_sertype.h"
     header "raw_cdr_regression_bridge.h"
-    link "ddsc"
     export *
 }

--- a/Sources/CZenohBridge/include/module.modulemap
+++ b/Sources/CZenohBridge/include/module.modulemap
@@ -1,5 +1,4 @@
 module CZenohBridge {
     header "zenoh_bridge.h"
-    link "zenohpico"
     export *
 }

--- a/Sources/CZenohBridge/zenoh_bridge.c
+++ b/Sources/CZenohBridge/zenoh_bridge.c
@@ -10,7 +10,22 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include <os/log.h>
+
+#ifdef __APPLE__
+  #include <os/log.h>
+#else
+  /* Non-Apple platforms: stub out Apple's unified logging to stderr. */
+  typedef int os_log_t;
+  #define os_log_create(subsystem, category) 0
+  #define os_log_info(log, fmt, ...)  \
+      fprintf(stderr, "[info]  " fmt "\n", ##__VA_ARGS__)
+  #define os_log_error(log, fmt, ...) \
+      fprintf(stderr, "[error] " fmt "\n", ##__VA_ARGS__)
+  #define os_log_debug(log, fmt, ...) \
+      fprintf(stderr, "[debug] " fmt "\n", ##__VA_ARGS__)
+  #define os_log(log, fmt, ...)       \
+      fprintf(stderr, fmt "\n", ##__VA_ARGS__)
+#endif
 
 // ============================================================================
 // Internal structures
@@ -46,7 +61,7 @@ zenoh_result_t zenoh_open_session(const char* locator, zenoh_session_t** out_ses
         return -1;
     }
 
-    os_log_info(log, "[zenoh_bridge] Opening session with locator: %{public}s", locator);
+    os_log_info(log, "[zenoh_bridge] Opening session with locator: %s", locator);
 
     // Allocate session wrapper
     zenoh_session_t* session = (zenoh_session_t*)malloc(sizeof(zenoh_session_t));
@@ -78,14 +93,14 @@ zenoh_result_t zenoh_open_session(const char* locator, zenoh_session_t** out_ses
     options.__dummy = 0;
 
     os_log_info(log, "[zenoh_bridge] Calling z_open...");
-    os_log_info(log, "[zenoh_bridge] Using locator: %{public}s", locator);
+    os_log_info(log, "[zenoh_bridge] Using locator: %s", locator);
 
     ret = z_open(&session->session, z_move(config), &options);
     os_log_info(log, "[zenoh_bridge] z_open returned: %d", ret);
     if (ret < 0) {
         os_log_error(log, "[zenoh_bridge] ERROR: z_open failed with code %d", ret);
         os_log_error(log, "[zenoh_bridge] Possible causes: network unreachable, router not running, or firewall blocking");
-        os_log_error(log, "[zenoh_bridge] errno: %d (%{public}s)", errno, strerror(errno));
+        os_log_error(log, "[zenoh_bridge] errno: %d (%s)", errno, strerror(errno));
         free(session);
         return -1;
     }
@@ -192,7 +207,7 @@ zenoh_result_t zenoh_declare_keyexpr(zenoh_session_t* session,
         return -1;
     }
 
-    os_log_info(log, "[zenoh_bridge] Declaring keyexpr: %{public}s", keyexpr_str);
+    os_log_info(log, "[zenoh_bridge] Declaring keyexpr: %s", keyexpr_str);
 
     zenoh_keyexpr_t* kexpr = (zenoh_keyexpr_t*)malloc(sizeof(zenoh_keyexpr_t));
     if (!kexpr) {
@@ -471,7 +486,7 @@ zenoh_result_t zenoh_declare_liveliness_token(zenoh_session_t* session,
         return -1;
     }
 
-    os_log_info(log, "[zenoh_bridge] Declaring liveliness token: %{public}s", key_expr);
+    os_log_info(log, "[zenoh_bridge] Declaring liveliness token: %s", key_expr);
 
     // Allocate token wrapper
     zenoh_liveliness_token_t* token = (zenoh_liveliness_token_t*)malloc(sizeof(zenoh_liveliness_token_t));

--- a/Sources/SwiftROS2Zenoh/DefaultZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/DefaultZenohClient.swift
@@ -10,7 +10,20 @@
 import CZenohBridge
 import Foundation
 import SwiftROS2Transport
-import os.log
+
+#if canImport(os.log)
+    import os.log
+#else
+    /// Minimal shim so the os.log call sites compile on Linux. Logs are
+    /// discarded — debug output on Linux is currently the C-layer fprintf.
+    public struct Logger {
+        public init(subsystem: String, category: String) {}
+        public func info(_ message: @autoclosure () -> String) {}
+        public func error(_ message: @autoclosure () -> String) {}
+        public func debug(_ message: @autoclosure () -> String) {}
+        public func warning(_ message: @autoclosure () -> String) {}
+    }
+#endif
 
 // MARK: - Declared Key Expression
 


### PR DESCRIPTION
## Summary

Phase 3 of the multi-phase FFI integration. swift-ros2 now builds and tests cleanly on Ubuntu 24.04 + Swift 6.0.2 alongside the existing Apple platforms.

**Stacked on:** #7 (Phase 1) → #8 (Phase 2). Base is `feat/phase2-xcframework`, not `main`.

## What's new

- `Package.swift`: on Linux, `CZenohPico` becomes a source `.target` pointing at the vendored submodule (with non-Linux platform backends excluded); `CCycloneDDS` stays a `.systemLibrary` with `pkgConfig: "CycloneDDS"`.
- `Scripts/build-linux-deps.sh`: verifies `CycloneDDS` is reachable via `pkg-config`. zenoh-pico needs no pre-build — SPM compiles it directly from source.
- `Sources/CZenohBridge/zenoh_bridge.c`: guards `<os/log.h>` with `#ifdef __APPLE__` and adds `os_log_*` shims that fall back to `fprintf(stderr, ...)` on Linux. `%{public}s` / `%{private}s` format specifiers replaced with plain `%s`.
- `Sources/CDDSBridge/dds_bridge.c`: guards the GCD/`dispatch_*` participant-deletion-with-timeout block behind `#ifdef __APPLE__`; Linux calls `dds_delete()` directly (no iOS sleep/wake hang to work around).
- `Sources/SwiftROS2Zenoh/DefaultZenohClient.swift`: gates `import os.log` with `#if canImport(os.log)` and provides a no-op `Logger` shim so call sites compile on Linux.
- `Sources/{CZenohBridge,CDDSBridge}/include/module.modulemap`: drops the `link "zenohpico"` / `link "ddsc"` directives — SPM already links these transitively via the `CZenohPico` / `CCycloneDDS` dependency, and the explicit `link` directive was forcing `-lzenohpico` / `-lddsc` at the test-link step on Linux.
- `.github/workflows/ci.yml`: replaces the Ubuntu-container Swift matrix with a macos-15 job and a ubuntu-24.04 job running Swift 6.0.2 + ROS 2 Jazzy CycloneDDS.

## Test plan

- [x] On macOS (xcframework path): `swift test` — 69 tests pass, 2 skipped
- [x] On Ubuntu 24.04 (source path, via `ssh youtalk@youtalk-desktop.local`):
  - `bash Scripts/build-linux-deps.sh` confirms CycloneDDS 0.10.5 found
  - `swift build` succeeds
  - `swift test` — 69 tests pass, 2 skipped (same as macOS)
- [ ] CI workflow green once merged (not yet triggered — PR targets feat/phase2-xcframework)

## Follow-ups

- Phase 4: Conduit migration to consume `SwiftROS2Zenoh` / `SwiftROS2DDS` SPM products
- Phase 5: Tag v0.2.0 once Phases 1–4 merge and cross-link final PRs