### PR TITLE
chore: bump binaryTarget URLs to v0.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 // GitHub Releases. Linux: compile the C sources directly via SPM (+ a
 // system-installed libddsc via pkg-config). See Scripts/build-xcframework.sh
 // for the macOS build helper that produces the Apple artifacts.
-let xcframeworkBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/v0.2.0-rc.1"
+let xcframeworkBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/v0.2.0"
 
 let cZenohPico: Target = {
     #if os(Linux)
@@ -43,7 +43,7 @@ let cZenohPico: Target = {
         return .binaryTarget(
             name: "CZenohPico",
             url: "\(xcframeworkBaseURL)/CZenohPico.xcframework.zip",
-            checksum: "631adffee3823f81d99791ffc0173d04936c0f33d8dd6309c5acd47154de6040"
+            checksum: "1ce8a58e9b1f0de59ad7ffb423ba9be75bec4c79495bba13bb533f1e27a748f3"
         )
     #endif
 }()
@@ -59,7 +59,7 @@ let cCycloneDDS: Target = {
         return .binaryTarget(
             name: "CCycloneDDS",
             url: "\(xcframeworkBaseURL)/CCycloneDDS.xcframework.zip",
-            checksum: "6db94bcb1c9303069490324cd057a19ff900e33466ecb18145cffc09785c14c5"
+            checksum: "f87eb6eedaf90a182b51f68438a6461d52f033b28cab0f6478c686cfacd01dad"
         )
     #endif
 }()


### PR DESCRIPTION
## Summary

Promotes the Apple xcframework artifacts from the `v0.2.0-rc.1` prerelease to the stable [`v0.2.0`](https://github.com/youtalk/swift-ros2/releases/tag/v0.2.0) release. Mechanical change: one URL + two checksums.

- `xcframeworkBaseURL`: `v0.2.0-rc.1` → `v0.2.0`
- `CZenohPico.xcframework.zip` checksum: `631adff…` → `1ce8a58…`
- `CCycloneDDS.xcframework.zip` checksum: `6db94bc…` → `f87eb6e…`

Checksums were recomputed against the zip GitHub actually serves via the `releases/download/` URL — the Release workflow repacks on upload, so locally-computed checksums don't match. The release assets now have their own `.checksum` files attached for traceability.

## Test plan

- [x] `rm -rf .build && swift build` — both xcframeworks download and resolve cleanly
- [x] `swift test` — 69/69 pass, 2 `LINUX_IP`-gated integration tests skipped
- [x] `swift format lint --recursive --strict --configuration .swift-format Package.swift` passes