### PR TITLE
ci: accept bare x.y.z tags in release workflow

### DIFF
--- a/.github/workflows/release-xcframework.yml
+++ b/.github/workflows/release-xcframework.yml
@@ -3,7 +3,9 @@ name: Release xcframeworks
 on:
   push:
     tags:
-      - "v*"
+      # Bare-semver tags (Apple-style): 1.2.3, 1.2.3-beta1, etc.
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-*"
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release-xcframework.yml
+++ b/.github/workflows/release-xcframework.yml
@@ -4,8 +4,8 @@ on:
   push:
     tags:
       # Bare-semver tags (Apple-style): 1.2.3, 1.2.3-beta1, etc.
-      - "[0-9]+.[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+.[0-9]+-*"
+      - "[0-9]*.[0-9]*.[0-9]*"
+      - "[0-9]*.[0-9]*.[0-9]*-*"
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary

Switch the release workflow trigger from `"v*"` to bare Apple-style semver patterns so tags like `0.2.0` / `1.0.0-rc.1` fire it. Nothing else changes.

```yaml
on:
  push:
    tags:
      - "[0-9]+.[0-9]+.[0-9]+"
      - "[0-9]+.[0-9]+.[0-9]+-*"
```

## Why now

Aligning the repo with the Apple ecosystem convention of bare-semver git tags (SwiftPM, Xcode, and Apple-published repos all use `1.2.3` rather than `v1.2.3`). Needs to land before the first bare-tag release is pushed — GitHub resolves workflow files from the tagged commit, so a bare tag pushed against the old `v*` filter would not trigger the build.

## Follow-ups (separate PRs)

1. Push tag `0.2.0` on `main` → release workflow re-publishes the xcframeworks under `releases/download/0.2.0/…`.
2. Bump `Package.swift` `binaryTarget` URLs to `0.2.0` and drop the `v` prefix.
3. Delete the legacy `v0.2.0` and `v0.2.0-rc.1` tags + releases.

## Test plan

- [x] YAML lint / structural check (no syntax changes)
- [ ] Verified in follow-up: pushing `0.2.0` from a branch containing this workflow triggers the build