### PR TITLE
ci: add Linux arm64 runners and ROS 2 Rolling to the build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,23 +41,49 @@ jobs:
         run: swift test --parallel
 
   build-linux:
-    name: Build & Test (Ubuntu ${{ matrix.ubuntu_version }} + ROS 2 ${{ matrix.ros_distro }})
+    name: Build & Test (Ubuntu ${{ matrix.ubuntu_version }} ${{ matrix.arch }} + ROS 2 ${{ matrix.ros_distro }})
     needs: [swift-format]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - ros_distro: jazzy
-            ubuntu_version: "24.04"
-            runner: ubuntu-24.04
-            swift_platform_path: ubuntu2404
-            swift_tarball_suffix: ubuntu24.04
           - ros_distro: humble
             ubuntu_version: "22.04"
+            arch: x86_64
             runner: ubuntu-22.04
             swift_platform_path: ubuntu2204
             swift_tarball_suffix: ubuntu22.04
+          - ros_distro: humble
+            ubuntu_version: "22.04"
+            arch: aarch64
+            runner: ubuntu-22.04-arm
+            swift_platform_path: ubuntu2204-aarch64
+            swift_tarball_suffix: ubuntu22.04-aarch64
+          - ros_distro: jazzy
+            ubuntu_version: "24.04"
+            arch: x86_64
+            runner: ubuntu-24.04
+            swift_platform_path: ubuntu2404
+            swift_tarball_suffix: ubuntu24.04
+          - ros_distro: jazzy
+            ubuntu_version: "24.04"
+            arch: aarch64
+            runner: ubuntu-24.04-arm
+            swift_platform_path: ubuntu2404-aarch64
+            swift_tarball_suffix: ubuntu24.04-aarch64
+          - ros_distro: rolling
+            ubuntu_version: "24.04"
+            arch: x86_64
+            runner: ubuntu-24.04
+            swift_platform_path: ubuntu2404
+            swift_tarball_suffix: ubuntu24.04
+          - ros_distro: rolling
+            ubuntu_version: "24.04"
+            arch: aarch64
+            runner: ubuntu-24.04-arm
+            swift_platform_path: ubuntu2404-aarch64
+            swift_tarball_suffix: ubuntu24.04-aarch64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -87,15 +113,15 @@ jobs:
       - name: Verify Linux deps
         run: |
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
-          export PKG_CONFIG_PATH="/opt/ros/${{ matrix.ros_distro }}/lib/x86_64-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
+          export PKG_CONFIG_PATH="/opt/ros/${{ matrix.ros_distro }}/lib/${{ matrix.arch }}-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
           bash Scripts/build-linux-deps.sh
       - name: Build
         run: |
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
-          export PKG_CONFIG_PATH="/opt/ros/${{ matrix.ros_distro }}/lib/x86_64-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
+          export PKG_CONFIG_PATH="/opt/ros/${{ matrix.ros_distro }}/lib/${{ matrix.arch }}-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
           swift build
       - name: Test
         run: |
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
-          export PKG_CONFIG_PATH="/opt/ros/${{ matrix.ros_distro }}/lib/x86_64-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
+          export PKG_CONFIG_PATH="/opt/ros/${{ matrix.ros_distro }}/lib/${{ matrix.arch }}-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
           swift test --parallel

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Shipping as **0.2.0** — pre-built xcframeworks on every Apple platform, source
 | macOS         | 13.0                      | `binaryTarget` xcframework                    |
 | Mac Catalyst  | 16.0                      | `binaryTarget` xcframework                    |
 | visionOS      | 1.0                       | `binaryTarget` xcframework                    |
-| Linux         | Ubuntu 24.04 (x86_64/arm64) | zenoh-pico source build + CycloneDDS via `pkg-config` |
+| Linux         | Ubuntu 22.04 / 24.04 (x86_64, aarch64) | zenoh-pico source build + CycloneDDS via `pkg-config` |
 
-Swift 5.9+ everywhere. CI runs on `macos-15` and `ubuntu-24.04` with Swift 6.0.2 + ROS 2 Jazzy.
+Swift 5.9+ everywhere. CI runs `macos-15` (Apple Silicon, Xcode 16.2) plus a Swift 6.0.2 Linux matrix: Humble on Ubuntu 22.04, Jazzy on Ubuntu 24.04, and Rolling on Ubuntu 24.04 — each exercised on both x86_64 and aarch64.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Expands the Linux CI matrix from 2 jobs to 6: Humble (22.04), Jazzy (24.04), and Rolling (24.04), each built and tested on both x86_64 and aarch64.
- aarch64 coverage uses the public `ubuntu-22.04-arm` / `ubuntu-24.04-arm` GitHub runners and the matching Swift 6.0.2 `*-aarch64` toolchain tarball.
- `PKG_CONFIG_PATH` now derives the multiarch tuple from the matrix `arch`, so the same step works for both x86_64 and aarch64.
- README is refreshed to reflect the broader support matrix.

## Test plan
- [ ] `swift-format` job stays green.
- [ ] `build-macos` still builds + tests on `macos-15`.
- [ ] All six Linux jobs go green (Humble x86_64 / arm64, Jazzy x86_64 / arm64, Rolling x86_64 / arm64).
- [ ] Confirm `ros-rolling-cyclonedds` is available on Noble (24.04); if not, fall back to `libcyclonedds-dev`.