### PR TITLE
refactor!: drop Default prefix from ZenohClient / DDSClient

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -141,7 +141,7 @@ let package = Package(
         ),
 
         // Swift-facing Zenoh / DDS modules. Host ZenohClient / DDSClient,
-        // the standard implementations of the ZenohClientProtocol /
+        // the default implementations of the ZenohClientProtocol /
         // DDSClientProtocol seams defined in SwiftROS2Transport.
         .target(
             name: "SwiftROS2Zenoh",

--- a/Package.swift
+++ b/Package.swift
@@ -140,9 +140,9 @@ let package = Package(
             ]
         ),
 
-        // Swift-facing Zenoh / DDS modules. Host DefaultZenohClient /
-        // DefaultDDSClient, which conform to the ZenohClientProtocol /
-        // DDSClientProtocol defined in SwiftROS2Transport.
+        // Swift-facing Zenoh / DDS modules. Host ZenohClient / DDSClient,
+        // the standard implementations of the ZenohClientProtocol /
+        // DDSClientProtocol seams defined in SwiftROS2Transport.
         .target(
             name: "SwiftROS2Zenoh",
             dependencies: ["CZenohBridge", "SwiftROS2Transport", "SwiftROS2Wire"],

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ targets: [
 ]
 ```
 
-That's it — `swift build` downloads the xcframeworks from the 0.2.0 release assets. `SwiftROS2` already links `SwiftROS2Zenoh` + `SwiftROS2DDS` transitively, so the high-level `ROS2Context` / `ROS2Node` API works out of the box. Add the transport-specific products only if you need `DefaultZenohClient` / `DefaultDDSClient` directly (e.g. for custom session configuration or testing).
+That's it — `swift build` downloads the xcframeworks from the 0.2.0 release assets. `SwiftROS2` already links `SwiftROS2Zenoh` + `SwiftROS2DDS` transitively, so the high-level `ROS2Context` / `ROS2Node` API works out of the box. Add the transport-specific products only if you need `ZenohClient` / `DDSClient` directly (e.g. for custom session configuration or testing).
 
 ### Linux
 
@@ -118,8 +118,8 @@ import SwiftROS2          // re-exports CDR / Messages / Transport / Wire
                               abstractions + TransportConfig
 
 // Transport-specific, opt-in:
-import SwiftROS2Zenoh      — DefaultZenohClient (zenoh-pico-backed)
-import SwiftROS2DDS        — DefaultDDSClient (CycloneDDS-backed)
+import SwiftROS2Zenoh      — ZenohClient (zenoh-pico-backed)
+import SwiftROS2DDS        — DDSClient (CycloneDDS-backed)
 ```
 
 ### Built-in message types

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -115,9 +115,9 @@ extension ROS2Context {
     static func makeDefaultSession(for config: TransportConfig) throws -> any TransportSession {
         switch config.type {
         case .zenoh:
-            return ZenohTransportSession(client: DefaultZenohClient())
+            return ZenohTransportSession(client: ZenohClient())
         case .dds:
-            return DDSTransportSession(client: DefaultDDSClient())
+            return DDSTransportSession(client: DDSClient())
         }
     }
 }

--- a/Sources/SwiftROS2DDS/DDSClient.swift
+++ b/Sources/SwiftROS2DDS/DDSClient.swift
@@ -1,5 +1,5 @@
-// DefaultDDSClient.swift
-// Default implementation of DDSClientProtocol using the CDDSBridge C FFI.
+// DDSClient.swift
+// Standard implementation of DDSClientProtocol using the CDDSBridge C FFI.
 
 import CDDSBridge
 import Foundation
@@ -46,7 +46,7 @@ private final class DDSWriterHandleBox: DDSWriterHandle {
     }
 }
 
-// MARK: - DefaultDDSClient
+// MARK: - DDSClient
 
 /// Thread-safety: the client-level `NSLock` serializes `createSession` /
 /// `destroySession` / `isConnected` / `getSessionId` / `createRawWriter`.
@@ -56,7 +56,7 @@ private final class DDSWriterHandleBox: DDSWriterHandle {
 /// `writeRawCDR` against `destroyWriter` for the *same* writer (preventing
 /// use-after-free on the underlying CycloneDDS writer pointer). Callers must
 /// still ensure writers outlive the session.
-public final class DefaultDDSClient: DDSClientProtocol {
+public final class DDSClient: DDSClientProtocol {
     private var session: OpaquePointer?
     private let lock = NSLock()
 

--- a/Sources/SwiftROS2DDS/DDSClient.swift
+++ b/Sources/SwiftROS2DDS/DDSClient.swift
@@ -1,5 +1,5 @@
 // DDSClient.swift
-// Standard implementation of DDSClientProtocol using the CDDSBridge C FFI.
+// Default implementation of DDSClientProtocol using the CDDSBridge C FFI.
 
 import CDDSBridge
 import Foundation

--- a/Sources/SwiftROS2DDS/Exports.swift
+++ b/Sources/SwiftROS2DDS/Exports.swift
@@ -1,5 +1,5 @@
 // Re-export the Swift transport symbols so a caller that imports SwiftROS2DDS
 // can reach the shared transport types (DDSClientProtocol, DDSBridgeQoSConfig,
-// DDSError, DefaultDDSClient) without adding SwiftROS2Transport to its own
+// DDSError, DDSClient) without adding SwiftROS2Transport to its own
 // import list.
 @_exported import SwiftROS2Transport

--- a/Sources/SwiftROS2Zenoh/ZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/ZenohClient.swift
@@ -145,7 +145,9 @@ public class LivelinessToken {
 
 // MARK: - Zenoh Client
 
-/// Main Zenoh client for iOS, conforming to ZenohClientProtocol.
+/// Default `ZenohClientProtocol` implementation backed by zenoh-pico via `CZenohBridge`.
+/// Runs on every platform the package supports (iOS, iPadOS, macOS, Mac Catalyst,
+/// visionOS, and Linux — the Linux build swaps in a no-op `Logger` shim for `os.log`).
 /// Manages a Zenoh session and provides methods for publishing and subscribing.
 ///
 /// Thread-safety: `ZenohClient` is NOT safe for concurrent calls to `open` / `close` /

--- a/Sources/SwiftROS2Zenoh/ZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/ZenohClient.swift
@@ -1,6 +1,6 @@
 //
-// DefaultZenohClient.swift
-// Swift wrapper for zenoh-pico C-FFI bridge
+// ZenohClient.swift
+// Swift wrapper for zenoh-pico C-FFI bridge, the standard ZenohClientProtocol implementation
 //
 // Provides a Swift-friendly API for Zenoh operations with proper error handling,
 // resource management, and type safety. Conforms to ZenohClientProtocol so that
@@ -30,9 +30,9 @@ import SwiftROS2Transport
 /// Represents a declared key expression for efficient reuse
 public class DeclaredKeyExpr {
     private var handle: OpaquePointer?
-    private weak var session: DefaultZenohClient?
+    private weak var session: ZenohClient?
 
-    fileprivate init(handle: OpaquePointer, session: DefaultZenohClient) {
+    fileprivate init(handle: OpaquePointer, session: ZenohClient) {
         self.handle = handle
         self.session = session
     }
@@ -56,13 +56,13 @@ public class DeclaredKeyExpr {
 /// Represents an active subscription
 public class ZenohSubscriber {
     private var handle: OpaquePointer?
-    private weak var session: DefaultZenohClient?
+    private weak var session: ZenohClient?
     private var handler: (ZenohSample) -> Void
     private var contextBox: Unmanaged<SubscriberContext>?
 
     fileprivate init(
         handle: OpaquePointer,
-        session: DefaultZenohClient,
+        session: ZenohClient,
         handler: @escaping (ZenohSample) -> Void,
         contextBox: Unmanaged<SubscriberContext>
     ) {
@@ -110,9 +110,9 @@ public class ZenohSubscriber {
 /// Represents an active liveliness token for ROS 2 discovery
 public class LivelinessToken {
     private var handle: OpaquePointer?
-    private weak var session: DefaultZenohClient?
+    private weak var session: ZenohClient?
 
-    fileprivate init(handle: OpaquePointer, session: DefaultZenohClient) {
+    fileprivate init(handle: OpaquePointer, session: ZenohClient) {
         self.handle = handle
         self.session = session
     }
@@ -143,16 +143,16 @@ public class LivelinessToken {
     }
 }
 
-// MARK: - Default Zenoh Client
+// MARK: - Zenoh Client
 
 /// Main Zenoh client for iOS, conforming to ZenohClientProtocol.
 /// Manages a Zenoh session and provides methods for publishing and subscribing.
 ///
-/// Thread-safety: `DefaultZenohClient` is NOT safe for concurrent calls to `open` / `close` /
+/// Thread-safety: `ZenohClient` is NOT safe for concurrent calls to `open` / `close` /
 /// `put` / `subscribe` across multiple threads. Callers must serialize these calls themselves
 /// (e.g., via `ZenohTransportSession` or an actor). The internal `resourceLock` only protects
 /// the tracked-resource arrays, not the `session` pointer itself.
-public class DefaultZenohClient: ZenohClientProtocol {
+public class ZenohClient: ZenohClientProtocol {
     private let log = Logger(subsystem: "com.youtalk.swift-ros2", category: "Zenoh")
 
     private var session: OpaquePointer?

--- a/Sources/SwiftROS2Zenoh/ZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/ZenohClient.swift
@@ -1,6 +1,6 @@
 //
 // ZenohClient.swift
-// Swift wrapper for zenoh-pico C-FFI bridge, the standard ZenohClientProtocol implementation
+// Swift wrapper for zenoh-pico C-FFI bridge, the default ZenohClientProtocol implementation
 //
 // Provides a Swift-friendly API for Zenoh operations with proper error handling,
 // resource management, and type safety. Conforms to ZenohClientProtocol so that

--- a/Tests/SwiftROS2DDSTests/DDSClientSmokeTests.swift
+++ b/Tests/SwiftROS2DDSTests/DDSClientSmokeTests.swift
@@ -2,18 +2,18 @@ import XCTest
 
 @testable import SwiftROS2DDS
 
-final class DefaultDDSClientSmokeTests: XCTestCase {
+final class DDSClientSmokeTests: XCTestCase {
     func testAvailabilityFlag() {
-        let client = DefaultDDSClient()
+        let client = DDSClient()
         XCTAssertTrue(client.isAvailable)
     }
 
     func testInitializationDoesNotCrash() {
-        _ = DefaultDDSClient()
+        _ = DDSClient()
     }
 
     func testWriteWithForeignHandleThrows() throws {
-        let client = DefaultDDSClient()
+        let client = DDSClient()
         let foreign = ForeignWriterHandle()
         XCTAssertThrowsError(
             try client.writeRawCDR(

--- a/Tests/SwiftROS2ZenohTests/ZenohClientSmokeTests.swift
+++ b/Tests/SwiftROS2ZenohTests/ZenohClientSmokeTests.swift
@@ -3,21 +3,21 @@ import XCTest
 
 @testable import SwiftROS2Zenoh
 
-// A foreign key-expression handle that is NOT a DeclaredKeyExpr from DefaultZenohClient.
+// A foreign key-expression handle that is NOT a DeclaredKeyExpr from ZenohClient.
 // Used to exercise the foreign-handle rejection guard in put(keyExpr:payload:attachment:).
 private final class ForeignKeyExprHandle: ZenohKeyExprHandle {}
 
-final class DefaultZenohClientSmokeTests: XCTestCase {
+final class ZenohClientSmokeTests: XCTestCase {
     func testInitializationDoesNotCrash() {
-        _ = DefaultZenohClient()
+        _ = ZenohClient()
     }
 
     /// Verifies that passing a foreign ZenohKeyExprHandle to put() throws ZenohError.invalidParameter.
     ///
-    /// The foreign-handle guard in DefaultZenohClient.put(keyExpr:payload:attachment:) runs
+    /// The foreign-handle guard in ZenohClient.put(keyExpr:payload:attachment:) runs
     /// BEFORE the session-open guard, so this test does not need a live Zenoh router.
     func testForeignKeyExprHandleIsRejected() throws {
-        let client = DefaultZenohClient()
+        let client = ZenohClient()
         let foreign = ForeignKeyExprHandle()
 
         XCTAssertThrowsError(try client.put(keyExpr: foreign, payload: Data(), attachment: nil)) { error in
@@ -35,7 +35,7 @@ final class DefaultZenohClientSmokeTests: XCTestCase {
 
     /// Verifies that calling close() on a client that was never opened throws ZenohError.sessionCloseFailed.
     func testDoubleCloseOnFreshClientThrows() throws {
-        let client = DefaultZenohClient()
+        let client = ZenohClient()
         XCTAssertThrowsError(try client.close()) { error in
             guard let zErr = error as? ZenohError else {
                 XCTFail("Expected ZenohError, got \(type(of: error))")


### PR DESCRIPTION
## Summary

- Rename `DefaultZenohClient` → `ZenohClient` and `DefaultDDSClient` → `DDSClient` (plus file + test class names).
- The `Default` prefix is a Java/C# DI transplant that doesn't match Swift conventions. Apple frameworks express "the standard one" via a property (`URLSession.shared`, `FileManager.default`), not a type-name prefix. Since the protocols are already suffixed with `Protocol`, the bare noun is free.
- **Breaking change.** No deprecation typealias: `0.2.0` only just shipped, so downstream consumers (Conduit) can update in the same cycle. Next release will be `0.3.0`.

## Test plan

- [x] `swift build` green.
- [x] `swift test --parallel` — 69 XCTest cases pass (integration tests LAN-gated as usual).
- [x] `swift format lint --recursive --strict` clean.
- [ ] CI matrix (macOS + Linux humble/jazzy/rolling × x86_64/aarch64).
- [ ] Follow-up: tag `0.3.0` on merge, then open the `binaryTarget` URL + checksum bump PR per the release flow in `CLAUDE.md`.