### PR TITLE
chore: ship 0.3.0 (binaryTarget bump + README refresh)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 // GitHub Releases. Linux: compile the C sources directly via SPM (+ a
 // system-installed libddsc via pkg-config). See Scripts/build-xcframework.sh
 // for the macOS build helper that produces the Apple artifacts.
-let xcframeworkBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.2.0"
+let xcframeworkBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.3.0"
 
 let cZenohPico: Target = {
     #if os(Linux)
@@ -43,7 +43,7 @@ let cZenohPico: Target = {
         return .binaryTarget(
             name: "CZenohPico",
             url: "\(xcframeworkBaseURL)/CZenohPico.xcframework.zip",
-            checksum: "df74add84f2506099f4c6a866ed61a6c946b793520f3a37064eee0c61be365f5"
+            checksum: "1761546bbe18d04b83e5fea28a803c453b2d74bd3a5d6abe93fc014016333022"
         )
     #endif
 }()
@@ -59,7 +59,7 @@ let cCycloneDDS: Target = {
         return .binaryTarget(
             name: "CCycloneDDS",
             url: "\(xcframeworkBaseURL)/CCycloneDDS.xcframework.zip",
-            checksum: "68b4f7c822a065e75a545dff4e93831f4c57e3b003b08b0820218dd5212de74d"
+            checksum: "3d3418bf7c9e2a2eed84d1696e3b45436112657410a9a9db09150d409d9b3a79"
         )
     #endif
 }()

--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ PRs welcome. The wire format fixtures in `Tests/SwiftROS2WireTests/` and the gol
 ## Roadmap
 
 - [x] 0.2.0: Publisher + Subscriber core, pure-Swift CDR, Jazzy/Humble wire codecs, Apple xcframework + Linux source build, dual-transport (Zenoh + DDS) FFI
-- [x] 0.3.0: Drop `Default` prefix from `ZenohClient` / `DDSClient` — breaking API rename
 - [ ] Services (request/reply) and Actions (goal/feedback/result)
 - [ ] `swift-ros2-gen` code generator for `.msg` / `.srv` / `.action` files
 - [ ] Expanded message catalog (nav_msgs, visualization_msgs, …)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Native Swift client library for ROS 2. Publishes and subscribes over **Zenoh** (via zenoh-pico) or **DDS** (via CycloneDDS) without a bridge, without pulling in the full ROS 2 stack.
 
-Shipping as **0.2.0** — pre-built xcframeworks on every Apple platform, source build on Linux.
+Shipping as **0.3.0** — pre-built xcframeworks on every Apple platform, source build on Linux.
 
 ## Features
 
@@ -33,7 +33,7 @@ Swift 5.9+ everywhere. CI runs `macos-15` (Apple Silicon, Xcode 16.2) plus a Swi
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.2.0"),
+    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.3.0"),
 ],
 targets: [
     .target(
@@ -45,7 +45,7 @@ targets: [
 ]
 ```
 
-That's it — `swift build` downloads the xcframeworks from the 0.2.0 release assets. `SwiftROS2` already links `SwiftROS2Zenoh` + `SwiftROS2DDS` transitively, so the high-level `ROS2Context` / `ROS2Node` API works out of the box. Add the transport-specific products only if you need `ZenohClient` / `DDSClient` directly (e.g. for custom session configuration or testing).
+That's it — `swift build` downloads the xcframeworks from the 0.3.0 release assets. `SwiftROS2` already links `SwiftROS2Zenoh` + `SwiftROS2DDS` transitively, so the high-level `ROS2Context` / `ROS2Node` API works out of the box. Add the transport-specific products only if you need `ZenohClient` / `DDSClient` directly (e.g. for custom session configuration or testing).
 
 ### Linux
 
@@ -169,6 +169,7 @@ PRs welcome. The wire format fixtures in `Tests/SwiftROS2WireTests/` and the gol
 ## Roadmap
 
 - [x] 0.2.0: Publisher + Subscriber core, pure-Swift CDR, Jazzy/Humble wire codecs, Apple xcframework + Linux source build, dual-transport (Zenoh + DDS) FFI
+- [x] 0.3.0: Drop `Default` prefix from `ZenohClient` / `DDSClient` — breaking API rename
 - [ ] Services (request/reply) and Actions (goal/feedback/result)
 - [ ] `swift-ros2-gen` code generator for `.msg` / `.srv` / `.action` files
 - [ ] Expanded message catalog (nav_msgs, visualization_msgs, …)


### PR DESCRIPTION
## Summary

- Bump `xcframeworkBaseURL` to the 0.3.0 GitHub Release and plug in the server-side checksums re-computed with `swift package compute-checksum`.
- Refresh `0.2.0` → `0.3.0` version references and add a 0.3.0 line to the roadmap.

## Test plan

- [x] Clean `swift build` pulls the new xcframeworks and compiles cleanly.
- [ ] CI matrix (macOS + Linux humble/jazzy/rolling × x86_64/aarch64).