### PR TITLE
feat(cdr): bound untrusted CDR sequence/string lengths

### DIFF
--- a/Sources/SwiftROS2CDR/CDRDecoder.swift
+++ b/Sources/SwiftROS2CDR/CDRDecoder.swift
@@ -12,6 +12,7 @@ public enum CDRDecodingError: Error, LocalizedError {
     case sequenceTooLarge(elements: UInt32, max: Int)
     case byteSequenceTooLarge(bytes: UInt32, max: Int)
     case stringTooLarge(length: UInt32, max: Int)
+    case missingStringNullTerminator
 
     public var errorDescription: String? {
         switch self {
@@ -29,6 +30,8 @@ public enum CDRDecodingError: Error, LocalizedError {
             return "CDR byte sequence declares \(bytes) bytes which exceeds maximum \(max)"
         case .stringTooLarge(let length, let max):
             return "CDR string declares length \(length) which exceeds maximum \(max)"
+        case .missingStringNullTerminator:
+            return "CDR string is missing its trailing null terminator"
         }
     }
 }
@@ -162,6 +165,10 @@ public final class CDRDecoder {
     public func readString() throws -> String {
         let length = try readUInt32()
         guard length > 0 else {
+            // Non-standard but tolerated: length == 0 is treated as an empty
+            // string. `CDREncoder.writeString` always emits length >= 1 with a
+            // trailing null, so this branch only accepts malformed inputs; it
+            // exists purely for backwards tolerance.
             return ""
         }
         guard length <= Self.maxStringLength else {
@@ -170,7 +177,14 @@ public final class CDRDecoder {
         let byteCount = Int(length)
         try ensureAvailable(byteCount)
 
-        // length includes null terminator
+        // `length` includes the trailing null terminator. Validate it is actually
+        // present before slicing so malformed inputs fail fast instead of silently
+        // dropping the final payload byte.
+        let terminator = data[data.startIndex + offset + byteCount - 1]
+        guard terminator == 0x00 else {
+            throw CDRDecodingError.missingStringNullTerminator
+        }
+
         let stringBytes = data[data.startIndex + offset..<data.startIndex + offset + byteCount - 1]
         offset += byteCount
 

--- a/Sources/SwiftROS2CDR/CDRDecoder.swift
+++ b/Sources/SwiftROS2CDR/CDRDecoder.swift
@@ -9,6 +9,9 @@ public enum CDRDecodingError: Error, LocalizedError {
     case unexpectedEndOfData(expected: Int, remaining: Int)
     case invalidStringEncoding
     case invalidArraySize(expected: Int, available: Int)
+    case sequenceTooLarge(elements: UInt32, max: Int)
+    case byteSequenceTooLarge(bytes: UInt32, max: Int)
+    case stringTooLarge(length: UInt32, max: Int)
 
     public var errorDescription: String? {
         switch self {
@@ -20,6 +23,12 @@ public enum CDRDecodingError: Error, LocalizedError {
             return "Invalid UTF-8 string encoding in CDR data"
         case .invalidArraySize(let expected, let available):
             return "Invalid array size: expected \(expected) elements but data has room for \(available)"
+        case .sequenceTooLarge(let elements, let max):
+            return "CDR sequence declares \(elements) elements which exceeds maximum \(max)"
+        case .byteSequenceTooLarge(let bytes, let max):
+            return "CDR byte sequence declares \(bytes) bytes which exceeds maximum \(max)"
+        case .stringTooLarge(let length, let max):
+            return "CDR string declares length \(length) which exceeds maximum \(max)"
         }
     }
 }
@@ -33,6 +42,20 @@ public final class CDRDecoder {
     private var offset: Int
 
     private static let encapsulationHeaderSize = 4
+
+    /// Maximum number of elements allowed in a typed sequence (Float64/Float32/Int32/...).
+    /// Wire-declared counts drive `reserveCapacity`; this cap prevents OOM DoS from a
+    /// malicious length prefix. 64M elements = up to 512 MB for Float64, well above any
+    /// realistic sensor payload.
+    public static let maxSequenceElements: Int = 64 * 1024 * 1024
+
+    /// Maximum byte length allowed for a `uint8[]` sequence (e.g. CompressedImage.data,
+    /// PointCloud2.data). 256 MB accommodates large sensor buffers while bounding DoS.
+    public static let maxByteSequenceLength: Int = 256 * 1024 * 1024
+
+    /// Maximum length (including trailing null) allowed for a CDR string. 64 KB is
+    /// generous for any ROS 2 identifier, topic, frame_id, or status message.
+    public static let maxStringLength: Int = 64 * 1024
 
     /// When true, deserialize the pre-Jazzy schema (omits fields added after Humble,
     /// e.g. `sensor_msgs/Range.variance`). Defaults to false = Jazzy-compatible.
@@ -141,6 +164,9 @@ public final class CDRDecoder {
         guard length > 0 else {
             return ""
         }
+        guard length <= Self.maxStringLength else {
+            throw CDRDecodingError.stringTooLarge(length: length, max: Self.maxStringLength)
+        }
         let byteCount = Int(length)
         try ensureAvailable(byteCount)
 
@@ -177,17 +203,17 @@ public final class CDRDecoder {
     // MARK: - Sequences (variable-length, WITH uint32 length prefix)
 
     public func readFloat64Sequence() throws -> [Double] {
-        let count = Int(try readUInt32())
+        let count = try readBoundedSequenceCount()
         return try readFloat64Array(count: count)
     }
 
     public func readFloat32Sequence() throws -> [Float] {
-        let count = Int(try readUInt32())
+        let count = try readBoundedSequenceCount()
         return try readFloat32Array(count: count)
     }
 
     public func readInt32Sequence() throws -> [Int32] {
-        let count = Int(try readUInt32())
+        let count = try readBoundedSequenceCount()
         var result = [Int32]()
         result.reserveCapacity(count)
         for _ in 0..<count {
@@ -197,11 +223,25 @@ public final class CDRDecoder {
     }
 
     public func readUInt8Sequence() throws -> Data {
-        let count = Int(try readUInt32())
+        let rawCount = try readUInt32()
+        guard rawCount <= Self.maxByteSequenceLength else {
+            throw CDRDecodingError.byteSequenceTooLarge(bytes: rawCount, max: Self.maxByteSequenceLength)
+        }
+        let count = Int(rawCount)
         try ensureAvailable(count)
         let result = data[data.startIndex + offset..<data.startIndex + offset + count]
         offset += count
         return Data(result)
+    }
+
+    /// Read a uint32 sequence length and reject values beyond `maxSequenceElements`.
+    /// Shared by all typed (non-byte) sequences so the cap applies uniformly.
+    private func readBoundedSequenceCount() throws -> Int {
+        let rawCount = try readUInt32()
+        guard rawCount <= Self.maxSequenceElements else {
+            throw CDRDecodingError.sequenceTooLarge(elements: rawCount, max: Self.maxSequenceElements)
+        }
+        return Int(rawCount)
     }
 
     // MARK: - Raw Bytes

--- a/Tests/SwiftROS2CDRTests/CDRBoundsTests.swift
+++ b/Tests/SwiftROS2CDRTests/CDRBoundsTests.swift
@@ -106,7 +106,18 @@ final class CDRBoundsTests: XCTestCase {
         }
     }
 
-    func testStringAllowsEmpty() throws {
+    func testStringAllowsSpecConformantEmpty() throws {
+        // CDR empty string: length = 1 for the lone null terminator.
+        let body: [UInt8] = [0x01, 0x00, 0x00, 0x00, 0x00]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        let result = try decoder.readString()
+        XCTAssertEqual(result, "")
+    }
+
+    func testStringTreatsZeroLengthAsEmpty() throws {
+        // Non-standard: length = 0 with no terminator byte. The decoder
+        // intentionally tolerates this shape for backwards compatibility; this
+        // test pins that behavior so a future change cannot remove it silently.
         let body: [UInt8] = [0x00, 0x00, 0x00, 0x00]
         let decoder = try CDRDecoder(data: cdrBuffer(body))
         let result = try decoder.readString()
@@ -119,6 +130,19 @@ final class CDRBoundsTests: XCTestCase {
         let decoder = try CDRDecoder(data: cdrBuffer(body))
         let result = try decoder.readString()
         XCTAssertEqual(result, "hi")
+    }
+
+    func testStringRejectsMissingNullTerminator() throws {
+        // length = 3, bytes "ABC" (no trailing 0x00). Must fail rather than
+        // silently decode as "AB" and drop the last byte.
+        let body: [UInt8] = [0x03, 0x00, 0x00, 0x00, 0x41, 0x42, 0x43]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        XCTAssertThrowsError(try decoder.readString()) { error in
+            guard case CDRDecodingError.missingStringNullTerminator = error else {
+                XCTFail("Expected missingStringNullTerminator, got \(error)")
+                return
+            }
+        }
     }
 
     // MARK: - Float NaN/Inf preservation (ensure bounds changes did not over-validate)

--- a/Tests/SwiftROS2CDRTests/CDRBoundsTests.swift
+++ b/Tests/SwiftROS2CDRTests/CDRBoundsTests.swift
@@ -1,0 +1,149 @@
+// CDRBoundsTests.swift
+// Verifies CDRDecoder rejects untrusted lengths that would trigger allocation DoS.
+
+import XCTest
+
+@testable import SwiftROS2CDR
+
+final class CDRBoundsTests: XCTestCase {
+
+    private func cdrBuffer(_ body: [UInt8]) -> Data {
+        var bytes: [UInt8] = [0x00, 0x01, 0x00, 0x00]
+        bytes.append(contentsOf: body)
+        return Data(bytes)
+    }
+
+    // MARK: - Typed sequence bounds (S-1)
+
+    func testFloat64SequenceRejectsOversizedLength() throws {
+        let body: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        XCTAssertThrowsError(try decoder.readFloat64Sequence()) { error in
+            guard case CDRDecodingError.sequenceTooLarge(let elements, let max) = error else {
+                XCTFail("Expected sequenceTooLarge, got \(error)")
+                return
+            }
+            XCTAssertEqual(elements, UInt32.max)
+            XCTAssertEqual(max, CDRDecoder.maxSequenceElements)
+        }
+    }
+
+    func testFloat32SequenceRejectsOversizedLength() throws {
+        let body: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        XCTAssertThrowsError(try decoder.readFloat32Sequence()) { error in
+            guard case CDRDecodingError.sequenceTooLarge = error else {
+                XCTFail("Expected sequenceTooLarge, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testInt32SequenceRejectsOversizedLength() throws {
+        let body: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        XCTAssertThrowsError(try decoder.readInt32Sequence()) { error in
+            guard case CDRDecodingError.sequenceTooLarge = error else {
+                XCTFail("Expected sequenceTooLarge, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testSequenceAllowsValidSmallPayload() throws {
+        // Use the encoder to produce a valid stream (alignment handled for us),
+        // then decode with the bounds-checking decoder.
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        encoder.writeFloat64Sequence([1.0, 2.0])
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let result = try decoder.readFloat64Sequence()
+        XCTAssertEqual(result, [1.0, 2.0])
+    }
+
+    func testSequenceAllowsEmpty() throws {
+        let body: [UInt8] = [0x00, 0x00, 0x00, 0x00]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        let result = try decoder.readFloat64Sequence()
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - Byte sequence bounds (S-1)
+
+    func testByteSequenceRejectsOversizedLength() throws {
+        let body: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        XCTAssertThrowsError(try decoder.readUInt8Sequence()) { error in
+            guard case CDRDecodingError.byteSequenceTooLarge(let bytes, let max) = error else {
+                XCTFail("Expected byteSequenceTooLarge, got \(error)")
+                return
+            }
+            XCTAssertEqual(bytes, UInt32.max)
+            XCTAssertEqual(max, CDRDecoder.maxByteSequenceLength)
+        }
+    }
+
+    func testByteSequenceAllowsValidPayload() throws {
+        // count = 3, bytes: [0x41, 0x42, 0x43] ("ABC")
+        let body: [UInt8] = [0x03, 0x00, 0x00, 0x00, 0x41, 0x42, 0x43]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        let result = try decoder.readUInt8Sequence()
+        XCTAssertEqual(Array(result), [0x41, 0x42, 0x43])
+    }
+
+    // MARK: - String bounds (S-2)
+
+    func testStringRejectsOversizedLength() throws {
+        let body: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        XCTAssertThrowsError(try decoder.readString()) { error in
+            guard case CDRDecodingError.stringTooLarge(let length, let max) = error else {
+                XCTFail("Expected stringTooLarge, got \(error)")
+                return
+            }
+            XCTAssertEqual(length, UInt32.max)
+            XCTAssertEqual(max, CDRDecoder.maxStringLength)
+        }
+    }
+
+    func testStringAllowsEmpty() throws {
+        let body: [UInt8] = [0x00, 0x00, 0x00, 0x00]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        let result = try decoder.readString()
+        XCTAssertEqual(result, "")
+    }
+
+    func testStringAllowsShort() throws {
+        // length = 3 ("hi\0"), bytes: 0x68 0x69 0x00
+        let body: [UInt8] = [0x03, 0x00, 0x00, 0x00, 0x68, 0x69, 0x00]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        let result = try decoder.readString()
+        XCTAssertEqual(result, "hi")
+    }
+
+    // MARK: - Float NaN/Inf preservation (ensure bounds changes did not over-validate)
+
+    func testFloat64PreservesQuietNaN() throws {
+        // Quiet NaN: 0x7FF8000000000000 LE
+        let body: [UInt8] = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x7F]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        let value = try decoder.readFloat64()
+        XCTAssertTrue(value.isNaN)
+    }
+
+    func testFloat64PreservesPositiveInfinity() throws {
+        // +Inf: 0x7FF0000000000000 LE
+        let body: [UInt8] = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        let value = try decoder.readFloat64()
+        XCTAssertEqual(value, .infinity)
+    }
+
+    func testFloat64PreservesNegativeInfinity() throws {
+        // -Inf: 0xFFF0000000000000 LE
+        let body: [UInt8] = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xFF]
+        let decoder = try CDRDecoder(data: cdrBuffer(body))
+        let value = try decoder.readFloat64()
+        XCTAssertEqual(value, -.infinity)
+    }
+}


### PR DESCRIPTION
## Summary
- Add hard upper bounds on wire-declared lengths in `CDRDecoder` so untrusted input cannot trigger multi-GB `reserveCapacity` allocations (OOM DoS).
- Three new static caps on the decoder:
  - `maxSequenceElements = 64M` (typed sequences: Float64/Float32/Int32)
  - `maxByteSequenceLength = 256 MB` (`uint8[]` payloads for images / point clouds)
  - `maxStringLength = 64 KB` (CDR strings — identifiers, frame_ids, etc.)
- Three new `CDRDecodingError` cases (`sequenceTooLarge`, `byteSequenceTooLarge`, `stringTooLarge`) so callers can distinguish length-rejection from truncation.
- New `CDRBoundsTests` (13 cases) covers rejection, valid small payloads, empty, NaN / ±Inf preservation.

## Why
A malicious or buggy publisher can send a CDR message whose `uint32` length prefix claims ~4 billion elements. The current decoder forwards that directly to `Array.reserveCapacity(_:)` or `Data` slicing, which attempts to allocate up to tens of GB and gets the process OOM-killed — a trivial remote DoS on any subscriber that accepts untrusted traffic.

The cap values are picked well above any realistic sensor payload (256 MB byte sequences accommodate large uncompressed point clouds or images) so legitimate traffic is unaffected, while rejecting the pathological case immediately.

## Test plan
- [x] `swift build` (macOS, Xcode 16.2)
- [x] `swift test --parallel` — 80 passed + 2 LINUX_IP-gated integration tests skipped, 0 failures
- [x] `swift test --filter SwiftROS2CDRTests` — 32/32 including 13 new `CDRBoundsTests`
- [x] `swift format lint --strict --configuration .swift-format` — clean
- [ ] Linux CI matrix (runs on PR open)