### PR TITLE
chore: ship 0.3.1 (binaryTarget bump + README refresh)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 // GitHub Releases. Linux: compile the C sources directly via SPM (+ a
 // system-installed libddsc via pkg-config). See Scripts/build-xcframework.sh
 // for the macOS build helper that produces the Apple artifacts.
-let xcframeworkBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.3.0"
+let xcframeworkBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.3.1"
 
 let cZenohPico: Target = {
     #if os(Linux)
@@ -43,7 +43,7 @@ let cZenohPico: Target = {
         return .binaryTarget(
             name: "CZenohPico",
             url: "\(xcframeworkBaseURL)/CZenohPico.xcframework.zip",
-            checksum: "1761546bbe18d04b83e5fea28a803c453b2d74bd3a5d6abe93fc014016333022"
+            checksum: "05a0735f448f0f0b189d8dcb5a5e305a4129af1a6963359cc393bf19457c23b2"
         )
     #endif
 }()
@@ -59,7 +59,7 @@ let cCycloneDDS: Target = {
         return .binaryTarget(
             name: "CCycloneDDS",
             url: "\(xcframeworkBaseURL)/CCycloneDDS.xcframework.zip",
-            checksum: "3d3418bf7c9e2a2eed84d1696e3b45436112657410a9a9db09150d409d9b3a79"
+            checksum: "5d83fca379bc7440d4679e1b861cd6f8c136988a74e5748cb32e1bb860814629"
         )
     #endif
 }()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Native Swift client library for ROS 2. Publishes and subscribes over **Zenoh** (via zenoh-pico) or **DDS** (via CycloneDDS) without a bridge, without pulling in the full ROS 2 stack.
 
-Shipping as **0.3.0** — pre-built xcframeworks on every Apple platform, source build on Linux.
+Shipping as **0.3.1** — pre-built xcframeworks on every Apple platform, source build on Linux.
 
 ## Features
 
@@ -33,7 +33,7 @@ Swift 5.9+ everywhere. CI runs `macos-15` (Apple Silicon, Xcode 16.2) plus a Swi
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.3.0"),
+    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.3.1"),
 ],
 targets: [
     .target(
@@ -45,7 +45,7 @@ targets: [
 ]
 ```
 
-That's it — `swift build` downloads the xcframeworks from the 0.3.0 release assets. `SwiftROS2` already links `SwiftROS2Zenoh` + `SwiftROS2DDS` transitively, so the high-level `ROS2Context` / `ROS2Node` API works out of the box. Add the transport-specific products only if you need `ZenohClient` / `DDSClient` directly (e.g. for custom session configuration or testing).
+That's it — `swift build` downloads the xcframeworks from the 0.3.1 release assets. `SwiftROS2` already links `SwiftROS2Zenoh` + `SwiftROS2DDS` transitively, so the high-level `ROS2Context` / `ROS2Node` API works out of the box. Add the transport-specific products only if you need `ZenohClient` / `DDSClient` directly (e.g. for custom session configuration or testing).
 
 ### Linux
 
@@ -169,6 +169,7 @@ PRs welcome. The wire format fixtures in `Tests/SwiftROS2WireTests/` and the gol
 ## Roadmap
 
 - [x] 0.2.0: Publisher + Subscriber core, pure-Swift CDR, Jazzy/Humble wire codecs, Apple xcframework + Linux source build, dual-transport (Zenoh + DDS) FFI
+- [x] 0.3.1: CDR decoder bounds + string null-terminator validation — rejects untrusted length prefixes before `reserveCapacity`, fails fast on malformed strings instead of silently dropping bytes.
 - [ ] Services (request/reply) and Actions (goal/feedback/result)
 - [ ] `swift-ros2-gen` code generator for `.msg` / `.srv` / `.action` files
 - [ ] Expanded message catalog (nav_msgs, visualization_msgs, …)


### PR DESCRIPTION
Ship PR for the 0.3.1 tag — follows the same shape as #16 for 0.3.0.

## Changes
- `Package.swift`:
  - `xcframeworkBaseURL`: `0.3.0` → `0.3.1`
  - `CZenohPico` checksum: `1761546b…` → `05a0735f…`
  - `CCycloneDDS` checksum: `3d3418bf…` → `5d83fca3…`
- `README.md`: version label, `from:` dependency example, roadmap adds a 0.3.1 entry summarizing the CDR bounds + null-terminator work.

Checksums were re-computed locally via `swift package compute-checksum` on the zips downloaded from the 0.3.1 GitHub Release (GitHub re-zips on upload, so server-side `.checksum` assets don't match the `binaryTarget` expectation — always re-compute).

## What's in 0.3.1
Only Swift-level changes; zenoh-pico and CycloneDDS vendor code is unchanged, so the xcframeworks are effectively identical to 0.3.0's but rebuilt from the 0.3.1 commit for release-notes continuity.
- #17 — cap untrusted CDR sequence / byte-sequence / string lengths before `reserveCapacity` to block allocation DoS.
- 20e1bf5 (Copilot review follow-up on #17) — validate the trailing null byte in `readString`; throw `CDRDecodingError.missingStringNullTerminator` when absent instead of silently dropping the last payload byte.

## Test plan
- [x] `swift build` against the new checksums — Build complete
- [x] `swift test --filter SwiftROS2CDRTests` — 34 tests pass
- [ ] Linux CI runs on PR open