### PR TITLE
fix(ios): define ZENOH_MACOS for iOS and visionOS builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -123,7 +123,7 @@ let package = Package(
             sources: ["zenoh_bridge.c"],
             publicHeadersPath: "include",
             cSettings: [
-                .define("ZENOH_MACOS", to: "1", .when(platforms: [.macOS, .macCatalyst])),
+                .define("ZENOH_MACOS", to: "1", .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS])),
                 .define("ZENOH_LINUX", to: "1", .when(platforms: [.linux])),
                 .define("Z_FEATURE_LINK_TCP", to: "1"),
                 .define("Z_FEATURE_LIVELINESS", to: "1"),


### PR DESCRIPTION
## Summary
- `CZenohBridge` only defined `ZENOH_MACOS` on `.macOS` and `.macCatalyst`; iOS / visionOS builds then tripped zenoh-pico's `#error "Unknown platform"` and missed the `_z_sys_net_socket_t` / `_z_sys_net_endpoint_t` typedefs.
- zenoh-pico does not fall back on `__APPLE__` / `TARGET_OS_IPHONE` for platform selection, so the define is mandatory on every Darwin slice that compiles `zenoh_bridge.c`.
- CI only runs `swift build` on a macOS host, so this never surfaced in the existing matrix.

## Change
- Extend the `.when(platforms:)` clause to cover `.iOS` and `.visionOS` so the same POSIX-socket backend that already works for macOS / Mac Catalyst is also selected on the mobile slices.

## Test plan
- [x] `xcodebuild -sdk iphoneos -arch arm64` build of the downstream Conduit app now succeeds (previously failed with "too many errors emitted, stopping now" from `zenoh_bridge.c`).
- [ ] macOS `swift build` still green (unchanged `.when(platforms:)` keeps existing Darwin paths untouched).