### PR TITLE
feat(dds): implement Subscriber (raw CDR reader path)

### DIFF
--- a/Sources/CDDSBridge/dds_bridge.c
+++ b/Sources/CDDSBridge/dds_bridge.c
@@ -111,6 +111,27 @@ struct bridge_dds_writer_s {
 };
 
 // =============================================================================
+// MARK: - Reader Structure
+// =============================================================================
+
+struct bridge_dds_reader_s {
+#ifdef DDS_AVAILABLE
+    dds_entity_t reader;
+    dds_entity_t topic;
+    dds_listener_t* listener;
+    struct ddsi_sertype* raw_sertype;
+#else
+    int dummy_reader;
+    int dummy_topic;
+#endif
+    bridge_dds_session_t* session;
+    dds_bridge_data_callback_t user_callback;
+    void* user_context;
+    char topic_name[256];
+    bool is_active;
+};
+
+// =============================================================================
 // MARK: - Session Management Implementation
 // =============================================================================
 
@@ -820,4 +841,248 @@ int32_t dds_bridge_write_raw_cdr(
     (void)timestamp_ns;
     return 0;
 #endif
+}
+
+// =============================================================================
+// MARK: - Raw CDR Subscribing Implementation
+// =============================================================================
+
+#ifdef DDS_AVAILABLE
+/// Listener callback invoked by CycloneDDS when new data is available on the reader.
+/// Drains the reader with dds_takecdr in batches of 16, matching rmw_cyclonedds_cpp's
+/// default batch size to keep stack usage bounded.
+static void bridge_on_data_available(dds_entity_t reader_entity, void* arg) {
+    bridge_dds_reader_t* reader = (bridge_dds_reader_t*)arg;
+    if (!reader || !reader->is_active || !reader->user_callback) {
+        return;
+    }
+
+    enum { BATCH = 16 };
+    struct ddsi_serdata* sdbuf[BATCH];
+    dds_sample_info_t info[BATCH];
+
+    for (;;) {
+        // Zero the serdata pointers so we don't accidentally unref stale garbage.
+        for (int i = 0; i < BATCH; i++) {
+            sdbuf[i] = NULL;
+        }
+
+        dds_return_t n = dds_takecdr(reader_entity, sdbuf, BATCH, info, DDS_ANY_STATE);
+        if (n <= 0) {
+            break;
+        }
+
+        for (dds_return_t i = 0; i < n; i++) {
+            struct ddsi_serdata* sd = sdbuf[i];
+            if (!sd) {
+                continue;
+            }
+            if (info[i].valid_data) {
+                // sd is our raw_cdr_serdata (we own the type); safe to downcast.
+                const struct raw_cdr_serdata* rd = (const struct raw_cdr_serdata*)sd;
+                uint64_t ts_ns = (info[i].source_timestamp == DDS_TIME_INVALID)
+                    ? 0
+                    : (uint64_t)info[i].source_timestamp;
+                reader->user_callback(rd->cdr_data, rd->cdr_size, ts_ns, reader->user_context);
+            }
+            ddsi_serdata_unref(sd);
+        }
+
+        if ((uint32_t)n < (uint32_t)BATCH) {
+            // Likely drained - avoid an extra syscall next iteration.
+            break;
+        }
+    }
+}
+#endif
+
+bridge_dds_reader_t* dds_bridge_create_raw_reader(
+    bridge_dds_session_t* session,
+    const char* topic_name,
+    const char* type_name,
+    const bridge_qos_config_t* qos,
+    const char* user_data,
+    dds_bridge_data_callback_t callback,
+    void* context
+) {
+    if (!session || !topic_name || !type_name || !callback) {
+        set_error("Invalid parameters for dds_bridge_create_raw_reader");
+        return NULL;
+    }
+
+    if (!session->is_connected) {
+        set_error("Session is not connected");
+        return NULL;
+    }
+
+    // Allocate reader structure
+    bridge_dds_reader_t* reader = calloc(1, sizeof(bridge_dds_reader_t));
+    if (!reader) {
+        set_error("Failed to allocate reader structure");
+        return NULL;
+    }
+
+    reader->session = session;
+    reader->user_callback = callback;
+    reader->user_context = context;
+    strncpy(reader->topic_name, topic_name, sizeof(reader->topic_name) - 1);
+    reader->is_active = false;
+
+#ifdef DDS_AVAILABLE
+    // Use default QoS if not specified
+    const bridge_qos_config_t* effective_qos = qos ? qos : &BRIDGE_QOS_SENSOR_DATA;
+
+    // Create raw CDR sertype (same pattern as create_raw_writer)
+    reader->raw_sertype = raw_cdr_sertype_new(type_name);
+    if (!reader->raw_sertype) {
+        set_error("Failed to create raw CDR sertype for '%s'", type_name);
+        free(reader);
+        return NULL;
+    }
+
+    // Create topic using raw CDR sertype.
+    // Note: dds_create_topic_sertype takes ownership of sertype reference,
+    // and may replace the sertype pointer with an existing compatible one.
+    struct ddsi_sertype* sertype_for_topic = ddsi_sertype_ref(reader->raw_sertype);
+    reader->topic = dds_create_topic_sertype(
+        session->participant,
+        topic_name,
+        &sertype_for_topic,
+        NULL,  // qos
+        NULL,  // listener
+        NULL   // sedp_plist
+    );
+
+    if (reader->topic < 0) {
+        set_error("Failed to create raw CDR topic '%s': %s",
+                  topic_name, dds_strretcode(reader->topic));
+        ddsi_sertype_unref(reader->raw_sertype);
+        free(reader);
+        return NULL;
+    }
+
+    // If dds_create_topic_sertype returned a different sertype (because a matching
+    // one was already registered), use that one going forward.
+    if (sertype_for_topic != reader->raw_sertype) {
+        ddsi_sertype_unref(reader->raw_sertype);
+        reader->raw_sertype = ddsi_sertype_ref(sertype_for_topic);
+    }
+
+    // Create reader QoS
+    dds_qos_t* reader_qos = dds_create_qos();
+    if (!reader_qos) {
+        set_error("Failed to create reader QoS");
+        dds_delete(reader->topic);
+        ddsi_sertype_unref(reader->raw_sertype);
+        free(reader);
+        return NULL;
+    }
+
+    // Set reliability
+    if (effective_qos->reliability == BRIDGE_RELIABILITY_RELIABLE) {
+        dds_qset_reliability(reader_qos, DDS_RELIABILITY_RELIABLE, DDS_MSECS(100));
+    } else {
+        dds_qset_reliability(reader_qos, DDS_RELIABILITY_BEST_EFFORT, 0);
+    }
+
+    // Set durability
+    if (effective_qos->durability == BRIDGE_DURABILITY_TRANSIENT_LOCAL) {
+        dds_qset_durability(reader_qos, DDS_DURABILITY_TRANSIENT_LOCAL);
+    } else {
+        dds_qset_durability(reader_qos, DDS_DURABILITY_VOLATILE);
+    }
+
+    // Set history
+    if (effective_qos->history_kind == BRIDGE_HISTORY_KEEP_ALL) {
+        dds_qset_history(reader_qos, DDS_HISTORY_KEEP_ALL, 0);
+    } else {
+        dds_qset_history(reader_qos, DDS_HISTORY_KEEP_LAST, effective_qos->history_depth);
+    }
+
+    // Set USER_DATA QoS (type hash for rmw_cyclonedds_cpp discovery)
+    if (user_data && strlen(user_data) > 0) {
+        dds_qset_userdata(reader_qos, user_data, strlen(user_data));
+    }
+
+    // Create listener with the bridge reader as the arg pointer, then install
+    // the data_available callback. Use the plain _arg-less dds_lset_data_available
+    // to remain compatible with older CycloneDDS (Ubuntu Humble's 0.9) which
+    // predates dds_lset_data_available_arg.
+    reader->listener = dds_create_listener(reader);
+    if (!reader->listener) {
+        set_error("Failed to create reader listener");
+        dds_delete_qos(reader_qos);
+        dds_delete(reader->topic);
+        ddsi_sertype_unref(reader->raw_sertype);
+        free(reader);
+        return NULL;
+    }
+    dds_lset_data_available(reader->listener, bridge_on_data_available);
+
+    // Create reader directly under the participant (CycloneDDS auto-creates an
+    // implicit subscriber). This mirrors rmw_cyclonedds_cpp.
+    reader->reader = dds_create_reader(
+        session->participant, reader->topic, reader_qos, reader->listener);
+    dds_delete_qos(reader_qos);
+
+    if (reader->reader < 0) {
+        set_error("Failed to create raw CDR reader for topic '%s': %s",
+                  topic_name, dds_strretcode(reader->reader));
+        dds_delete_listener(reader->listener);
+        dds_delete(reader->topic);
+        ddsi_sertype_unref(reader->raw_sertype);
+        free(reader);
+        return NULL;
+    }
+
+    reader->is_active = true;
+#else
+    // Stub implementation
+    (void)qos;
+    (void)user_data;
+    reader->dummy_reader = 1;
+    reader->dummy_topic = 1;
+    reader->is_active = true;
+#endif
+
+    return reader;
+}
+
+void dds_bridge_destroy_reader(bridge_dds_reader_t* reader) {
+    if (!reader) {
+        return;
+    }
+
+    reader->is_active = false;
+
+#ifdef DDS_AVAILABLE
+    // dds_delete on the reader blocks until any in-flight listener callback
+    // completes (CycloneDDS contract), so after this returns the callback will
+    // never fire again.
+    if (reader->reader > 0) {
+        dds_delete(reader->reader);
+        reader->reader = 0;
+    }
+    if (reader->topic > 0) {
+        dds_delete(reader->topic);
+        reader->topic = 0;
+    }
+    if (reader->listener) {
+        dds_delete_listener(reader->listener);
+        reader->listener = NULL;
+    }
+    if (reader->raw_sertype) {
+        ddsi_sertype_unref(reader->raw_sertype);
+        reader->raw_sertype = NULL;
+    }
+#endif
+
+    free(reader);
+}
+
+bool dds_bridge_reader_is_active(const bridge_dds_reader_t* reader) {
+    if (!reader) {
+        return false;
+    }
+    return reader->is_active;
 }

--- a/Sources/CDDSBridge/include/dds_bridge.h
+++ b/Sources/CDDSBridge/include/dds_bridge.h
@@ -30,6 +30,9 @@ typedef struct bridge_dds_session_s bridge_dds_session_t;
 /// Opaque handle to a DDS data writer
 typedef struct bridge_dds_writer_s bridge_dds_writer_t;
 
+/// Opaque handle to a DDS data reader (raw CDR receive path)
+typedef struct bridge_dds_reader_s bridge_dds_reader_t;
+
 // =============================================================================
 // MARK: - Discovery Configuration
 // =============================================================================
@@ -236,6 +239,65 @@ int32_t dds_bridge_write_raw_cdr(
     size_t cdr_len,
     uint64_t timestamp_ns
 );
+
+// =============================================================================
+// MARK: - Raw CDR Subscribing (Custom Sertype)
+// =============================================================================
+
+/// Callback fired for each received sample.
+///
+/// @param cdr_data     CDR-serialized payload including 4-byte encapsulation header
+///                     (owned by bridge; valid only during the call).
+/// @param cdr_len      Length of cdr_data in bytes.
+/// @param timestamp_ns Source timestamp in nanoseconds since Unix epoch
+///                     (from dds_sample_info_t.source_timestamp; 0 if invalid).
+/// @param context      Opaque user pointer supplied to dds_bridge_create_raw_reader.
+typedef void (*dds_bridge_data_callback_t)(
+    const uint8_t* cdr_data,
+    size_t cdr_len,
+    uint64_t timestamp_ns,
+    void* context
+);
+
+/// Create a DDS data reader using the raw CDR sertype.
+///
+/// Parallel to dds_bridge_create_raw_writer. Reuses the participant from the session
+/// (the reader is created directly under the participant; CycloneDDS provides an
+/// implicit subscriber internally).
+///
+/// @param session Active DDS session
+/// @param topic_name Full topic name (e.g., "rt/chatter")
+/// @param type_name DDS type name in ::msg::dds_:: form (e.g., "std_msgs::msg::dds_::String_")
+/// @param qos QoS configuration (NULL for sensor data defaults)
+/// @param user_data USER_DATA QoS string for reader (e.g., "typehash=RIHS01_...;"), NULL to omit
+/// @param callback Callback invoked on each received valid sample (must be non-NULL)
+/// @param context Opaque user pointer passed to each callback invocation (may be NULL)
+/// @return Reader handle, or NULL on failure (check dds_bridge_get_last_error())
+bridge_dds_reader_t* dds_bridge_create_raw_reader(
+    bridge_dds_session_t* session,
+    const char* topic_name,
+    const char* type_name,
+    const bridge_qos_config_t* qos,
+    const char* user_data,
+    dds_bridge_data_callback_t callback,
+    void* context
+);
+
+/// Destroy a DDS data reader. Safe to pass NULL.
+///
+/// Calls dds_delete on the reader entity, which blocks until any in-flight listener
+/// callback returns (CycloneDDS contract). After this returns the callback will
+/// never fire again, so the caller can safely release resources associated with
+/// `context`.
+///
+/// @param reader Reader to destroy
+void dds_bridge_destroy_reader(bridge_dds_reader_t* reader);
+
+/// Check if a reader is active
+///
+/// @param reader Reader to check
+/// @return true if reader is active, false otherwise
+bool dds_bridge_reader_is_active(const bridge_dds_reader_t* reader);
 
 // =============================================================================
 // MARK: - Error Handling

--- a/Sources/CDDSBridge/raw_cdr_sertype.c
+++ b/Sources/CDDSBridge/raw_cdr_sertype.c
@@ -15,6 +15,7 @@
 #include <assert.h>
 #include <dds/ddsrt/heap.h>
 #include <dds/ddsrt/md5.h>
+#include <dds/ddsi/q_radmin.h>
 
 // =============================================================================
 // MARK: - Sertype Operations Implementation
@@ -148,12 +149,49 @@ static struct ddsi_serdata *raw_cdr_serdata_from_ser(
     const struct nn_rdata *fragchain,
     size_t size)
 {
-    (void)type;
-    (void)kind;
-    (void)fragchain;
-    (void)size;
-    // Not implemented for publish-only use case
-    return NULL;
+    // Must have at least the 4-byte XCDR encapsulation header.
+    if (size < 4) {
+        return NULL;
+    }
+
+    // Allocate serdata with flexible array + 3 bytes trailing padding.
+    // The +3 mirrors raw_cdr_serdata_new: CycloneDDS's align4u(cdr_size)
+    // may read up to 3 bytes past the end when slicing fragments via
+    // to_ser_ref on the transmit side. Keeping the layout identical
+    // between transmit- and receive-constructed serdatas avoids surprises
+    // if the received sample is ever re-published.
+    struct raw_cdr_serdata *rd = ddsrt_malloc(sizeof(struct raw_cdr_serdata) + size + 3);
+    if (!rd) {
+        return NULL;
+    }
+
+    ddsi_serdata_init(&rd->c, type, kind);
+    // For keyless types, all serdatas share the sertype's basehash.
+    rd->c.hash = type->serdata_basehash;
+    rd->cdr_size = size;
+
+    // Walk the fragment chain, copying each fragment's new region into
+    // rd->cdr_data. Mirrors the canonical walk in CycloneDDS's
+    // serdata_default_from_ser_common but starts at off=0 so the 4-byte
+    // encapsulation header is preserved verbatim in rd->cdr_data.
+    size_t off = 0;
+    while (fragchain) {
+        assert(fragchain->min <= off);
+        assert(fragchain->maxp1 <= size);
+        if (fragchain->maxp1 > off) {
+            const unsigned char *payload =
+                NN_RMSG_PAYLOADOFF(fragchain->rmsg, NN_RDATA_PAYLOAD_OFF(fragchain));
+            memcpy(rd->cdr_data + off, payload + off - fragchain->min, fragchain->maxp1 - off);
+            off = fragchain->maxp1;
+        }
+        fragchain = fragchain->nextfrag;
+    }
+
+    // Zero the trailing 3 bytes of padding so an align4u overread returns
+    // well-defined zero bytes (matches raw_cdr_serdata_new).
+    memset(rd->cdr_data + size, 0, 3);
+
+    return &rd->c;
 }
 
 /// Create serdata from keyhash (for tkmap lookups)

--- a/Sources/Examples/Listener/main.swift
+++ b/Sources/Examples/Listener/main.swift
@@ -3,10 +3,7 @@
 //
 // Usage:
 //   swift run listener zenoh [tcp/<host>:7447] [domain_id]
-//
-// Note: DDS subscribe is not implemented in swift-ros2 yet (the transport
-// layer throws "DDS subscriber not yet implemented"), so `dds` is rejected
-// up front here. Use zenoh for now.
+//   swift run listener dds   [domain_id]
 
 import Foundation
 import SwiftROS2
@@ -21,10 +18,10 @@ case "zenoh":
     let domainId = args.dropFirst(2).first.flatMap(Int.init) ?? 0
     transport = .zenoh(locator: locator, domainId: domainId)
 case "dds":
-    FileHandle.standardError.write(Data("DDS subscribe is not yet supported by swift-ros2; use zenoh.\n".utf8))
-    exit(2)
+    let domainId = args.dropFirst().first.flatMap(Int.init) ?? 0
+    transport = .ddsMulticast(domainId: domainId)
 default:
-    FileHandle.standardError.write(Data("Unknown transport '\(transportName)'. Use 'zenoh'.\n".utf8))
+    FileHandle.standardError.write(Data("Unknown transport '\(transportName)'. Use 'zenoh' or 'dds'.\n".utf8))
     exit(2)
 }
 

--- a/Sources/Examples/README.md
+++ b/Sources/Examples/README.md
@@ -5,18 +5,17 @@ Two minimal executables that mirror [`demo_nodes_cpp`](https://github.com/ros2/d
 | Target     | Zenoh | DDS | What it does                                      |
 |------------|:-----:|:---:|---------------------------------------------------|
 | `talker`   | ✅    | ✅  | Publishes `std_msgs/String` on `/chatter` at 1 Hz |
-| `listener` | ✅    | ❌  | Subscribes to `/chatter` and prints each message  |
+| `listener` | ✅    | ✅  | Subscribes to `/chatter` and prints each message  |
 
 Message type is `std_msgs/msg/String`, payload is `"Hello World: N"`. Default QoS is `.sensorData` (best-effort, keep-last-10).
-
-> DDS subscribe is not yet implemented in swift-ros2, so `swift run listener dds …` exits with an error. For a `ROS 2 → Swift` round trip, use Zenoh.
 
 ## Invocation
 
 ```bash
 swift run talker    zenoh [tcp/<host>:7447] [domain_id]   # defaults: tcp/127.0.0.1:7447 and 0
 swift run talker    dds   [domain_id]                     # default domain_id: 0
-swift run listener  zenoh [tcp/<host>:7447] [domain_id]   # dds subcommand is rejected (see note above)
+swift run listener  zenoh [tcp/<host>:7447] [domain_id]
+swift run listener  dds   [domain_id]
 ```
 
 The first argument selects the transport (`zenoh` or `dds`). Remaining arguments are transport-specific:
@@ -119,9 +118,36 @@ export ROS_DOMAIN_ID=0
 ros2 topic echo /chatter std_msgs/msg/String
 ```
 
-### 2. ROS 2 talker → Swift listener — not supported over DDS
+### 2. ROS 2 talker → Swift listener
 
-The Swift `listener` binary is Zenoh-only today (see the note at the top of this file). For this direction, use the Zenoh path (section 3 in the Zenoh tutorial above).
+Terminal A (ROS 2 publisher):
+
+```bash
+source /opt/ros/jazzy/setup.bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+export ROS_DOMAIN_ID=0
+ros2 run demo_nodes_cpp talker
+```
+
+Terminal B (Swift subscriber):
+
+```bash
+swift run listener dds 0
+# Listening on /chatter...
+# I heard: 'Hello World: 1'
+```
+
+### 3. Swift ↔ Swift
+
+Two Swift processes on the same LAN + `ROS_DOMAIN_ID`, no router, no ROS 2 install:
+
+```bash
+# Terminal A
+swift run talker   dds 0
+
+# Terminal B
+swift run listener dds 0
+```
 
 ### Wi-Fi (no multicast)
 

--- a/Sources/SwiftROS2DDS/DDSClient.swift
+++ b/Sources/SwiftROS2DDS/DDSClient.swift
@@ -46,16 +46,97 @@ private final class DDSWriterHandleBox: DDSWriterHandle {
     }
 }
 
+// MARK: - Reader handle
+
+/// Retained by `DDSReaderHandleBox.contextBox` while the reader is alive.
+/// The `@unchecked Sendable` is justified: the class holds an immutable
+/// `@Sendable` closure reference; the closure captures are the only
+/// state shared across threads, and Swift's concurrency model already
+/// requires those to be Sendable.
+private final class DDSReaderContext: @unchecked Sendable {
+    let handler: @Sendable (Data, UInt64) -> Void
+    init(handler: @escaping @Sendable (Data, UInt64) -> Void) {
+        self.handler = handler
+    }
+}
+
+/// C-callable bridge matching `dds_bridge_data_callback_t`.
+/// The `context` pointer is an `Unmanaged<DDSReaderContext>` opaque pointer
+/// created via `passRetained` in `createRawReader`; here we only borrow it
+/// (`takeUnretainedValue`) — retention is released in `DDSReaderHandleBox.close()`.
+private func ddsReaderCallbackBridge(
+    cdrData: UnsafePointer<UInt8>?,
+    cdrLen: Int,
+    timestampNs: UInt64,
+    context: UnsafeMutableRawPointer?
+) {
+    guard let context = context else { return }
+    let readerContext = Unmanaged<DDSReaderContext>.fromOpaque(context).takeUnretainedValue()
+
+    let payload: Data
+    if let cdrData = cdrData, cdrLen > 0 {
+        payload = Data(bytes: cdrData, count: cdrLen)
+    } else {
+        payload = Data()
+    }
+
+    readerContext.handler(payload, timestampNs)
+}
+
+/// Per-box lock serializes destroy vs. isActive checks for the same reader.
+/// Different readers hold different locks, so parallel reads stay lock-free.
+private final class DDSReaderHandleBox: DDSReaderHandle {
+    private var reader: OpaquePointer?
+    private var contextBox: Unmanaged<DDSReaderContext>?
+    private let lock = NSLock()
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let r = reader else { return false }
+        return dds_bridge_reader_is_active(r)
+    }
+
+    init(_ reader: OpaquePointer, contextBox: Unmanaged<DDSReaderContext>) {
+        self.reader = reader
+        self.contextBox = contextBox
+    }
+
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        if let r = reader {
+            // dds_bridge_destroy_reader blocks until any in-flight callback
+            // returns. Only after it returns is it safe to release the retained
+            // closure context, because no further callback invocations will
+            // dereference it.
+            dds_bridge_destroy_reader(r)
+            reader = nil
+        }
+        if let box = contextBox {
+            box.release()
+            contextBox = nil
+        }
+    }
+}
+
 // MARK: - DDSClient
 
 /// Thread-safety: the client-level `NSLock` serializes `createSession` /
-/// `destroySession` / `isConnected` / `getSessionId` / `createRawWriter`.
-/// `writeRawCDR` and `destroyWriter` do not take the client-level lock so
-/// parallel writes across different writers stay unserialized, but each
-/// writer carries its own per-`DDSWriterHandleBox` lock that serializes
-/// `writeRawCDR` against `destroyWriter` for the *same* writer (preventing
-/// use-after-free on the underlying CycloneDDS writer pointer). Callers must
-/// still ensure writers outlive the session.
+/// `destroySession` / `isConnected` / `getSessionId` / `createRawWriter` /
+/// `createRawReader`. `writeRawCDR` and `destroyWriter` do not take the
+/// client-level lock so parallel writes across different writers stay
+/// unserialized, but each writer carries its own per-`DDSWriterHandleBox`
+/// lock that serializes `writeRawCDR` against `destroyWriter` for the *same*
+/// writer (preventing use-after-free on the underlying CycloneDDS writer
+/// pointer). Callers must still ensure writers outlive the session.
+/// Readers follow the same per-box lock discipline: each reader carries its
+/// own `DDSReaderHandleBox` lock that serializes `close()` against
+/// `isActive`, and the retained `Unmanaged<DDSReaderContext>` holding the
+/// user handler is released only *after* `dds_bridge_destroy_reader`
+/// returns — CycloneDDS contracts that call to block until any in-flight
+/// listener callback has returned, so a racing callback thread can never
+/// dereference a freed closure context.
 public final class DDSClient: DDSClientProtocol {
     private var session: OpaquePointer?
     private let lock = NSLock()
@@ -213,6 +294,64 @@ public final class DDSClient: DDSClientProtocol {
 
     public func destroyWriter(_ writer: any DDSWriterHandle) {
         guard let box = writer as? DDSWriterHandleBox else { return }
+        box.close()
+    }
+
+    public func createRawReader(
+        topicName: String,
+        typeName: String,
+        qos: DDSBridgeQoSConfig,
+        userData: String?,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any DDSReaderHandle {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let s = session else {
+            throw DDSError.notConnected
+        }
+
+        var cQos = bridge_qos_config_t()
+        cQos.reliability =
+            qos.reliability == .reliable ? BRIDGE_RELIABILITY_RELIABLE : BRIDGE_RELIABILITY_BEST_EFFORT
+        cQos.durability =
+            qos.durability == .transientLocal ? BRIDGE_DURABILITY_TRANSIENT_LOCAL : BRIDGE_DURABILITY_VOLATILE
+        cQos.history_kind =
+            qos.historyKind == .keepAll ? BRIDGE_HISTORY_KEEP_ALL : BRIDGE_HISTORY_KEEP_LAST
+        cQos.history_depth = qos.historyDepth
+
+        let contextBox = Unmanaged.passRetained(DDSReaderContext(handler: handler))
+        let contextPtr = UnsafeMutableRawPointer(contextBox.toOpaque())
+
+        let readerOrNil: OpaquePointer? = topicName.withCString { topicCStr in
+            typeName.withCString { typeCStr in
+                if let userData = userData {
+                    return userData.withCString { userDataCStr in
+                        dds_bridge_create_raw_reader(
+                            s, topicCStr, typeCStr, &cQos, userDataCStr,
+                            ddsReaderCallbackBridge, contextPtr
+                        )
+                    }
+                } else {
+                    return dds_bridge_create_raw_reader(
+                        s, topicCStr, typeCStr, &cQos, nil,
+                        ddsReaderCallbackBridge, contextPtr
+                    )
+                }
+            }
+        }
+
+        guard let reader = readerOrNil else {
+            contextBox.release()
+            let msg = String(cString: dds_bridge_get_last_error())
+            throw DDSError.readerCreationFailed(msg)
+        }
+
+        return DDSReaderHandleBox(reader, contextBox: contextBox)
+    }
+
+    public func destroyReader(_ reader: any DDSReaderHandle) {
+        guard let box = reader as? DDSReaderHandleBox else { return }
         box.close()
     }
 }

--- a/Sources/SwiftROS2Transport/DDSClientProtocol.swift
+++ b/Sources/SwiftROS2Transport/DDSClientProtocol.swift
@@ -15,6 +15,12 @@ public protocol DDSWriterHandle: AnyObject {
     func close()
 }
 
+/// Handle to a DDS reader
+public protocol DDSReaderHandle: AnyObject {
+    var isActive: Bool { get }
+    func close()
+}
+
 // MARK: - DDS Configuration Types
 
 /// DDS discovery mode
@@ -79,6 +85,7 @@ public enum DDSError: Error, LocalizedError {
     case sessionCreationFailed(String)
     case sessionDestructionFailed(String)
     case writerCreationFailed(String)
+    case readerCreationFailed(String)
     case writeFailed(String)
     case notConnected
     case notAvailable
@@ -88,6 +95,7 @@ public enum DDSError: Error, LocalizedError {
         case .sessionCreationFailed(let msg): return "DDS session creation failed: \(msg)"
         case .sessionDestructionFailed(let msg): return "DDS session destruction failed: \(msg)"
         case .writerCreationFailed(let msg): return "DDS writer creation failed: \(msg)"
+        case .readerCreationFailed(let msg): return "DDS reader creation failed: \(msg)"
         case .writeFailed(let msg): return "DDS write failed: \(msg)"
         case .notConnected: return "DDS session not connected"
         case .notAvailable: return "DDS transport not available"
@@ -135,4 +143,26 @@ public protocol DDSClientProtocol: AnyObject {
 
     /// Destroy a writer
     func destroyWriter(_ writer: any DDSWriterHandle)
+
+    /// Create a raw CDR reader for a topic with a per-sample callback.
+    ///
+    /// - Parameters:
+    ///   - topicName: Full DDS topic name (e.g. "rt/chatter").
+    ///   - typeName: DDS type name in `::msg::dds_::Type_` form.
+    ///   - qos: Reader QoS.
+    ///   - userData: USER_DATA QoS string (e.g. "typehash=RIHS01_...;"), or `nil`.
+    ///   - handler: Called with the raw CDR payload (including 4-byte XCDR header)
+    ///     and the sample source timestamp (nanoseconds since Unix epoch; 0 if the
+    ///     publisher did not supply one). Invoked on a CycloneDDS-owned background
+    ///     thread — do not block or reentrantly destroy the reader from inside it.
+    func createRawReader(
+        topicName: String,
+        typeName: String,
+        qos: DDSBridgeQoSConfig,
+        userData: String?,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any DDSReaderHandle
+
+    /// Destroy a reader. Blocks until any in-flight handler invocation completes.
+    func destroyReader(_ reader: any DDSReaderHandle)
 }

--- a/Sources/SwiftROS2Transport/DDSTransportSession.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession.swift
@@ -17,6 +17,7 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
     private let client: any DDSClientProtocol
     private var config: TransportConfig?
     private var publishers: [String: DDSTransportPublisherImpl] = [:]
+    private var subscribers: [DDSTransportSubscriberImpl] = []
     private let lock = NSLock()
     private var _sessionId: String = ""
     private var _isOpen = false
@@ -81,6 +82,11 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
             try? pub.close()
         }
 
+        let subs = takeAllSubscribers()
+        for sub in subs {
+            try? sub.close()
+        }
+
         lock.lock()
         _isOpen = false
         _sessionId = ""
@@ -123,27 +129,12 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
         let userData = ddsCodec.userDataString(typeHash: typeHash)
 
         // Build QoS
-        let bridgeQoS = DDSBridgeQoSConfig(
-            reliability: qos.reliability == .reliable ? .reliable : .bestEffort,
-            durability: qos.durability == .transientLocal ? .transientLocal : .volatile,
-            historyKind: {
-                switch qos.history {
-                case .keepLast: return .keepLast
-                case .keepAll: return .keepAll
-                }
-            }(),
-            historyDepth: {
-                switch qos.history {
-                case .keepLast(let n): return Int32(n)
-                case .keepAll: return 0
-                }
-            }()
-        )
+        let cfg = bridgeQoS(from: qos)
 
         let writerHandle = try client.createRawWriter(
             topicName: ddsTopicName,
             typeName: ddsTypeName,
-            qos: bridgeQoS,
+            qos: cfg,
             userData: userData
         )
 
@@ -164,8 +155,49 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
         qos: TransportQoS,
         handler: @escaping @Sendable (Data, UInt64) -> Void
     ) throws -> any TransportSubscriber {
-        // DDS subscriber support will be added in Phase 2
-        throw TransportError.unsupportedFeature("DDS subscriber not yet implemented")
+        guard !topic.isEmpty else {
+            throw TransportError.invalidConfiguration("Topic name cannot be empty")
+        }
+        guard !typeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Type name cannot be empty")
+        }
+
+        lock.lock()
+        guard _isOpen else {
+            lock.unlock()
+            throw TransportError.notConnected
+        }
+        lock.unlock()
+
+        // Convert ROS 2 names to DDS names
+        let ddsCodec = DDSWireCodec()
+        let ddsTopicName = ddsCodec.ddsTopic(from: topic)
+        let ddsTypeName = ddsCodec.ddsTypeName(from: typeName)
+        let userData = ddsCodec.userDataString(typeHash: typeHash)
+
+        // Build QoS
+        let cfg = bridgeQoS(from: qos)
+
+        let readerHandle: any DDSReaderHandle
+        do {
+            readerHandle = try client.createRawReader(
+                topicName: ddsTopicName,
+                typeName: ddsTypeName,
+                qos: cfg,
+                userData: userData,
+                handler: handler
+            )
+        } catch let e as DDSError {
+            throw TransportError.subscriberCreationFailed(e.errorDescription ?? "\(e)")
+        }
+
+        let subscriber = DDSTransportSubscriberImpl(
+            client: client,
+            reader: readerHandle,
+            topic: topic
+        )
+        appendSubscriber(subscriber)
+        return subscriber
     }
 
     public func checkHealth() -> Bool {
@@ -186,6 +218,39 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
         publishers.removeAll()
         lock.unlock()
         return pubs
+    }
+
+    private func appendSubscriber(_ subscriber: DDSTransportSubscriberImpl) {
+        lock.lock()
+        subscribers.append(subscriber)
+        lock.unlock()
+    }
+
+    private func takeAllSubscribers() -> [DDSTransportSubscriberImpl] {
+        lock.lock()
+        let subs = subscribers
+        subscribers.removeAll()
+        lock.unlock()
+        return subs
+    }
+
+    private func bridgeQoS(from qos: TransportQoS) -> DDSBridgeQoSConfig {
+        DDSBridgeQoSConfig(
+            reliability: qos.reliability == .reliable ? .reliable : .bestEffort,
+            durability: qos.durability == .transientLocal ? .transientLocal : .volatile,
+            historyKind: {
+                switch qos.history {
+                case .keepLast: return .keepLast
+                case .keepAll: return .keepAll
+                }
+            }(),
+            historyDepth: {
+                switch qos.history {
+                case .keepLast(let n): return Int32(n)
+                case .keepAll: return 0
+                }
+            }()
+        )
     }
 
     private func generateFallbackSessionId() -> String {
@@ -247,6 +312,45 @@ final class DDSTransportPublisherImpl: TransportPublisher, @unchecked Sendable {
 
         if let w = w {
             client.destroyWriter(w)
+        }
+    }
+}
+
+// MARK: - DDS Transport Subscriber
+
+final class DDSTransportSubscriberImpl: TransportSubscriber, @unchecked Sendable {
+    private let client: any DDSClientProtocol
+    private var reader: (any DDSReaderHandle)?
+    public let topic: String
+    private let lock = NSLock()
+    private var closed = false
+
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if closed { return false }
+        return reader?.isActive ?? false
+    }
+
+    init(client: any DDSClientProtocol, reader: any DDSReaderHandle, topic: String) {
+        self.client = client
+        self.reader = reader
+        self.topic = topic
+    }
+
+    public func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let r = reader
+        reader = nil
+        lock.unlock()
+
+        if let r = r {
+            client.destroyReader(r)
         }
     }
 }

--- a/Tests/SwiftROS2DDSTests/DDSClientSmokeTests.swift
+++ b/Tests/SwiftROS2DDSTests/DDSClientSmokeTests.swift
@@ -30,9 +30,45 @@ final class DDSClientSmokeTests: XCTestCase {
             }
         }
     }
+
+    func testDestroyReaderWithForeignHandleIsNoOp() {
+        let client = DDSClient()
+        let foreign = ForeignReaderHandle()
+        // destroyReader is non-throwing; the client must silently no-op on a
+        // handle it didn't create rather than force-cast into its private box.
+        client.destroyReader(foreign)
+    }
+
+    func testCreateReaderWithoutSessionThrows() throws {
+        let client = DDSClient()
+        XCTAssertThrowsError(
+            try client.createRawReader(
+                topicName: "rt/test",
+                typeName: "std_msgs::msg::dds_::String_",
+                qos: DDSBridgeQoSConfig(),
+                userData: nil,
+                handler: { _, _ in }
+            )
+        ) { error in
+            guard let e = error as? DDSError else {
+                XCTFail("Expected DDSError, got \(type(of: error))")
+                return
+            }
+            if case .notConnected = e {
+                // ok
+            } else {
+                XCTFail("Expected .notConnected, got \(e)")
+            }
+        }
+    }
 }
 
 private final class ForeignWriterHandle: DDSWriterHandle {
+    var isActive: Bool { false }
+    func close() {}
+}
+
+private final class ForeignReaderHandle: DDSReaderHandle {
     var isActive: Bool { false }
     func close() {}
 }

--- a/Tests/SwiftROS2IntegrationTests/DDSRoundTripTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/DDSRoundTripTests.swift
@@ -43,4 +43,64 @@ final class DDSRoundTripTests: XCTestCase {
         try await Task.sleep(nanoseconds: 500_000_000)
         await ctx.shutdown()
     }
+
+    /// Same-process publisher to subscriber over DDS multicast on the loopback
+    /// interface. No LINUX_IP required — runs anywhere CycloneDDS loopback
+    /// works, which is every Darwin / Linux machine. Uses domain 42 (distinct
+    /// from the remote-host test at domain 99 so the two cannot interfere if
+    /// both run).
+    func testLoopbackPubSubSameProcess() async throws {
+        let domain = 42
+        let ctx = try await ROS2Context(
+            transport: .ddsMulticast(domainId: domain),
+            distro: .jazzy,
+            domainId: domain
+        )
+        let node = try await ctx.createNode(name: "dds_loopback", namespace: "/loopback")
+
+        // Bind the subscriber first so SEDP can advertise the reader before
+        // the writer starts sending.
+        let sub = try await node.createSubscription(StringMsg.self, topic: "chatter")
+        let pub = try await node.createPublisher(StringMsg.self, topic: "chatter")
+
+        // DDS endpoint discovery (SPDP/SEDP) is slower than Zenoh; give both
+        // sides time to match before the first publish.
+        try await Task.sleep(nanoseconds: 2_000_000_000)
+
+        let expectation = XCTestExpectation(description: "receive at least 3 chatter messages")
+        expectation.expectedFulfillmentCount = 3
+        expectation.assertForOverFulfill = false
+
+        let buf = LoopbackReceivedBuffer()
+        let consumer = Task {
+            for await msg in sub.messages {
+                await buf.append(msg.data)
+                expectation.fulfill()
+            }
+        }
+
+        for i in 0..<5 {
+            try pub.publish(StringMsg(data: "hello-\(i)"))
+            // 200 ms between publishes gives RTPS reliability acknowledgements
+            // time to fire on the loopback interface.
+            try await Task.sleep(nanoseconds: 200_000_000)
+        }
+
+        await fulfillment(of: [expectation], timeout: 10.0)
+        consumer.cancel()
+
+        let items = await buf.items
+        XCTAssertGreaterThanOrEqual(
+            items.count, 3, "expected at least 3 messages; got \(items)")
+        for item in items {
+            XCTAssertTrue(item.starts(with: "hello-"), "unexpected payload: \(item)")
+        }
+
+        await ctx.shutdown()
+    }
+}
+
+private actor LoopbackReceivedBuffer {
+    private(set) var items: [String] = []
+    func append(_ s: String) { items.append(s) }
 }

--- a/Tests/SwiftROS2IntegrationTests/DDSSubscriberTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/DDSSubscriberTests.swift
@@ -1,0 +1,60 @@
+import SwiftROS2
+import SwiftROS2Messages
+import SwiftROS2Transport
+import XCTest
+
+/// Receive-side integration test over CycloneDDS. Requires:
+/// - `LINUX_IP` env var pointing at a host reachable from this machine.
+/// - A running `ros2 run demo_nodes_cpp talker` on that host with
+///   `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp` and `ROS_DOMAIN_ID=99`.
+///
+/// Uses unicast discovery so the test works across WiFi / Parallels /
+/// environments where DDS multicast may be filtered.
+final class DDSSubscriberTests: XCTestCase {
+    func testChatterReceivedFromLinuxDDS() async throws {
+        guard let linuxIP = ProcessInfo.processInfo.environment["LINUX_IP"], !linuxIP.isEmpty else {
+            throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)")
+        }
+
+        let domain = 99
+        let ctx = try await ROS2Context(
+            transport: .ddsUnicast(
+                peers: [DDSPeer.peer(address: linuxIP, domainId: domain)],
+                domainId: domain
+            ),
+            distro: .jazzy,
+            domainId: domain
+        )
+        let node = try await ctx.createNode(name: "swift_ros2_it_sub")
+        let sub = try await node.createSubscription(StringMsg.self, topic: "chatter")
+
+        // Wait for SEDP + at least one publish cycle
+        // (demo_nodes_cpp/talker publishes at 1 Hz).
+        let expectation = XCTestExpectation(description: "receive at least one chatter message")
+        let buf = SubscriberReceivedBuffer()
+        let consumer = Task {
+            for await msg in sub.messages {
+                await buf.append(msg.data)
+                expectation.fulfill()
+                break
+            }
+        }
+
+        await fulfillment(of: [expectation], timeout: 10.0)
+        consumer.cancel()
+
+        let items = await buf.items
+        XCTAssertGreaterThanOrEqual(items.count, 1)
+        XCTAssertTrue(
+            items.first?.starts(with: "Hello World:") ?? false,
+            "expected demo_nodes_cpp/talker phrasing, got \(items)"
+        )
+
+        await ctx.shutdown()
+    }
+}
+
+private actor SubscriberReceivedBuffer {
+    private(set) var items: [String] = []
+    func append(_ s: String) { items.append(s) }
+}


### PR DESCRIPTION
## Summary

- Fix the long-standing `raw_cdr_serdata_from_ser` NULL stub that was causing CycloneDDS to silently drop every incoming DATA submessage. The new fragchain walk mirrors the canonical CycloneDDS implementation so raw-CDR receive has parity with transmit (`+3` alignment-safe padding, etc.).
- Add DDS subscriber end-to-end: new `bridge_dds_reader_t` C API with batched `dds_takecdr` listener callback, `DDSReaderHandle` protocol + `DDSClient.createRawReader` Swift implementation, `DDSTransportSession.createSubscriber` wired through, and `swift run listener dds 0` enabled.
- Lifetime-safe `Unmanaged<DDSReaderContext>` handling: retained across the C callback boundary, released only after `dds_bridge_destroy_reader` returns (which blocks until in-flight listener callbacks complete per CycloneDDS's `dds_delete` contract).

Implementation notes:

- Uses the plain `dds_lset_data_available` + `dds_create_listener(arg)` pair for compatibility with CycloneDDS 0.9.x (Ubuntu Humble's `ros-humble-cyclonedds`), avoiding the newer `_arg` variant.
- Subscribers are tracked in a session-owned array (DDS permits multiple readers per topic). Publishers remain dict-keyed on topic to preserve the existing duplicate-publisher check.
- `TransportQoS → DDSBridgeQoSConfig` conversion is factored into a private `bridgeQoS(from:)` helper, shared by publisher and subscriber paths.

## Test plan

- [x] `swift build` on macOS 15 / arm64
- [x] `swift format lint --strict --configuration .swift-format Package.swift Sources Tests` — clean
- [x] `swift test --parallel` — 88 tests, 0 failures (3 skipped, all LINUX_IP-gated)
- [x] `DDSClientSmokeTests` — 5 tests including new `testDestroyReaderWithForeignHandleIsNoOp` and `testCreateReaderWithoutSessionThrows`
- [x] `DDSRoundTripTests.testLoopbackPubSubSameProcess` — same-process DDS multicast pub→sub on domain 42 (first CI-friendly guardrail for the full receive path); ran 3 consecutive times without flake
- [ ] `LINUX_IP=<host> swift test --filter DDSSubscriberTests` against a running `ros2 run demo_nodes_cpp talker` with `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp` and `ROS_DOMAIN_ID=99`
- [ ] Manual: `swift run talker dds 0` + `swift run listener dds 0` in two terminals; confirm "I heard: 'Hello World: N'" on both sides of a LAN talker
- [ ] CI Linux matrix (Humble/Jazzy/Rolling × x86_64/aarch64) — especially Humble, because `#include <dds/ddsi/q_radmin.h>` resolves through the apt-packaged `CycloneDDS.pc` include path; the header has been stable across 0.9→0.11 but the matrix is the authoritative check

## Breaking changes

`DDSClientProtocol` gains two required methods (`createRawReader`, `destroyReader`) and one associated handle protocol (`DDSReaderHandle`). Source-breaking for any third-party implementer of `DDSClientProtocol`. swift-ros2 is pre-1.0 at the time of this branch, so this is acceptable.