### PR TITLE
chore: ship 0.4.0 (binaryTarget bump + README refresh)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 // GitHub Releases. Linux: compile the C sources directly via SPM (+ a
 // system-installed libddsc via pkg-config). See Scripts/build-xcframework.sh
 // for the macOS build helper that produces the Apple artifacts.
-let xcframeworkBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.3.1"
+let xcframeworkBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.4.0"
 
 let cZenohPico: Target = {
     #if os(Linux)
@@ -43,7 +43,7 @@ let cZenohPico: Target = {
         return .binaryTarget(
             name: "CZenohPico",
             url: "\(xcframeworkBaseURL)/CZenohPico.xcframework.zip",
-            checksum: "05a0735f448f0f0b189d8dcb5a5e305a4129af1a6963359cc393bf19457c23b2"
+            checksum: "de7d7a02605234d364a464fb0169bc18efb46440976b8e8a26021eb416386c95"
         )
     #endif
 }()
@@ -59,7 +59,7 @@ let cCycloneDDS: Target = {
         return .binaryTarget(
             name: "CCycloneDDS",
             url: "\(xcframeworkBaseURL)/CCycloneDDS.xcframework.zip",
-            checksum: "5d83fca379bc7440d4679e1b861cd6f8c136988a74e5748cb32e1bb860814629"
+            checksum: "bc72071590791fcb989a69af616c1da771f9c6d79b50de4381d8e95ce33fc8ad"
         )
     #endif
 }()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Native Swift client library for ROS 2. Publishes and subscribes over **Zenoh** (via zenoh-pico) or **DDS** (via CycloneDDS) without a bridge, without pulling in the full ROS 2 stack.
 
-Shipping as **0.3.1** — pre-built xcframeworks on every Apple platform, source build on Linux.
+Shipping as **0.4.0** — pre-built xcframeworks on every Apple platform, source build on Linux.
 
 ## Features
 
@@ -33,7 +33,7 @@ Swift 5.9+ everywhere. CI runs `macos-15` (Apple Silicon, Xcode 16.2) plus a Swi
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.3.1"),
+    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.4.0"),
 ],
 targets: [
     .target(
@@ -45,7 +45,7 @@ targets: [
 ]
 ```
 
-That's it — `swift build` downloads the xcframeworks from the 0.3.1 release assets. `SwiftROS2` already links `SwiftROS2Zenoh` + `SwiftROS2DDS` transitively, so the high-level `ROS2Context` / `ROS2Node` API works out of the box. Add the transport-specific products only if you need `ZenohClient` / `DDSClient` directly (e.g. for custom session configuration or testing).
+That's it — `swift build` downloads the xcframeworks from the 0.4.0 release assets. `SwiftROS2` already links `SwiftROS2Zenoh` + `SwiftROS2DDS` transitively, so the high-level `ROS2Context` / `ROS2Node` API works out of the box. Add the transport-specific products only if you need `ZenohClient` / `DDSClient` directly (e.g. for custom session configuration or testing).
 
 ### Linux
 
@@ -174,6 +174,7 @@ PRs welcome. The wire format fixtures in `Tests/SwiftROS2WireTests/` and the gol
 
 - [x] 0.2.0: Publisher + Subscriber core, pure-Swift CDR, Jazzy/Humble wire codecs, Apple xcframework + Linux source build, dual-transport (Zenoh + DDS) FFI
 - [x] 0.3.1: CDR decoder bounds + string null-terminator validation — rejects untrusted length prefixes before `reserveCapacity`, fails fast on malformed strings instead of silently dropping bytes.
+- [x] 0.4.0: DDS subscriber support — `raw_cdr_serdata_from_ser` fragchain walk, `bridge_dds_reader_t` + listener callback, `DDSReaderHandle` / `createRawReader` / `destroyReader` on `DDSClientProtocol`, `DDSTransportSession.createSubscriber` wired through, `swift run listener dds` enabled.
 - [ ] Services (request/reply) and Actions (goal/feedback/result)
 - [ ] `swift-ros2-gen` code generator for `.msg` / `.srv` / `.action` files
 - [ ] Expanded message catalog (nav_msgs, visualization_msgs, …)


### PR DESCRIPTION
## Summary

- Bump \`xcframeworkBaseURL\` + \`binaryTarget\` checksums to the 0.4.0 release assets.
- Refresh the README headline, installation snippet, and roadmap to point at 0.4.0 (adds a roadmap entry for the DDS subscriber work that landed in #21).

## Test plan

- [x] \`swift build\` — binary targets resolve with new checksums
- [x] \`swift format lint --strict\` — clean
- [ ] Downstream: Conduit \`deps/swift-ros2\` submodule bump lands cleanly via the \`from: "0.4.0"\` constraint