### PR TITLE
chore: ignore Vendor build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ DerivedData/
 .DS_Store
 .claude/
 CLAUDE.md
+
+Vendor/*-arm64/
+Vendor/*-x86_64/
+Vendor/include/
+Vendor/pkgconfig/


### PR DESCRIPTION
## Summary
- Ignore `Vendor/` build outputs produced by the xcframework build scripts: per-SDK-slice staging dirs (`*-arm64/`, `*-x86_64/`), `include/`, and `pkgconfig/`.
- Submodule checkouts (`vendor/zenoh-pico`, `vendor/cyclonedds`) stay tracked — only the generated staging dirs are ignored.
- Patterns are SDK-slice agnostic so adding new slices (e.g. `iphoneos-arm64`, `xros-arm64`) does not require another `.gitignore` bump.

## Test plan
- [x] `git status` is clean after `bash Scripts/build-linux-deps.sh` / xcframework builds populate `Vendor/`.
- [x] `git ls-files vendor/` still shows the submodule entries.