### PR TITLE
build(windows-m2): zenoh-pico source build on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,22 @@ jobs:
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
           export PKG_CONFIG_PATH="/opt/ros/${{ matrix.ros_distro }}/lib/${{ matrix.arch }}-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
           swift test --parallel
+
+  build-windows:
+    name: Build & Test (Windows x86_64, Zenoh only)
+    needs: [swift-format]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: compnerd/gha-setup-swift@eeda069c5bc95ac8a9ac5cea7d4f588ae5420ca5 # v0.4.0
+        with:
+          branch: swift-6.3.1-release
+          tag: 6.3.1-RELEASE
+      - name: Swift version
+        run: swift --version
+      - name: Build
+        run: swift build
+      - name: Test
+        run: swift test --parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,8 @@ jobs:
           submodules: recursive
       - uses: compnerd/gha-setup-swift@eeda069c5bc95ac8a9ac5cea7d4f588ae5420ca5 # v0.4.0
         with:
-          branch: swift-6.3.1-release
-          tag: 6.3.1-RELEASE
+          branch: swift-6.0.2-release
+          tag: 6.0.2-RELEASE
       - name: Swift version
         run: swift --version
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,14 +130,20 @@ jobs:
     name: Build & Test (Windows x86_64, Zenoh only)
     needs: [swift-format]
     runs-on: windows-latest
+    # Pin Swift 6.3.1 here (not 6.0.2 like macOS + Linux) because 6.0.2's
+    # Windows SDK shim assumes older Windows Kits headers than the current
+    # windows-latest runner image ships — it fails with "could not build
+    # module 'ucrt'". 6.3.1 bundles up-to-date shims and works out of the
+    # box. The rest of the matrix stays on 6.0.2: macOS is pinned to
+    # Xcode 16.2 (Swift 6.0.x) and Linux downloads 6.0.2 directly.
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: compnerd/gha-setup-swift@eeda069c5bc95ac8a9ac5cea7d4f588ae5420ca5 # v0.4.0
         with:
-          branch: swift-6.0.2-release
-          tag: 6.0.2-RELEASE
+          branch: swift-6.3.1-release
+          tag: 6.3.1-RELEASE
       - name: Swift version
         run: swift --version
       - name: Build

--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,14 @@
 import PackageDescription
 
 // Apple platforms: pre-built xcframework binaryTargets hosted on
-// GitHub Releases. Linux: compile the C sources directly via SPM (+ a
-// system-installed libddsc via pkg-config). Windows: pre-built
-// .artifactbundle zips hosted on the same GitHub Releases. See
-// Scripts/build-xcframework.sh for the macOS build helper; Windows
-// bundle producers land alongside the M2 release-workflow change.
+// GitHub Releases. Linux and Windows: compile the C sources directly
+// via SPM, using the matching platform backend inside vendor/zenoh-pico.
+// See Scripts/build-xcframework.sh for the macOS build helper.
+//
+// CycloneDDS Linux still resolves through pkg-config; Windows DDS
+// support is not yet in this milestone — the cCycloneDDS Windows arm
+// below is a placeholder that will never be fetched as long as downstream
+// builds stay within the Zenoh / core products.
 let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.4.0"
 
 let cZenohPico: Target = {
@@ -42,10 +45,33 @@ let cZenohPico: Target = {
             ]
         )
     #elseif os(Windows)
-        return .binaryTarget(
+        return .target(
             name: "CZenohPico",
-            url: "\(releaseBaseURL)/CZenohPico-windows-x86_64.artifactbundle.zip",
-            checksum: "0000000000000000000000000000000000000000000000000000000000000000"
+            path: "vendor/zenoh-pico",
+            exclude: [
+                "CMakeLists.txt", "README.md", "LICENSE", "tests", "examples", "docs", "ci",
+                // Non-Windows platform backends — parallel to the Linux arm
+                // above, just with src/system/unix excluded and
+                // src/system/windows kept.
+                "src/system/arduino",
+                "src/system/emscripten",
+                "src/system/espidf",
+                "src/system/freertos_plus_tcp",
+                "src/system/mbed",
+                "src/system/rpi_pico",
+                "src/system/unix",
+                "src/system/void",
+                "src/system/zephyr",
+                "src/system/flipper",
+            ],
+            sources: ["src"],
+            publicHeadersPath: "include",
+            cSettings: [
+                .headerSearchPath("src"),
+                .define("Z_FEATURE_LINK_TCP", to: "1"),
+                .define("Z_FEATURE_LIVELINESS", to: "1"),
+                .define("ZENOH_WINDOWS", to: "1"),
+            ]
         )
     #else
         return .binaryTarget(
@@ -56,18 +82,14 @@ let cZenohPico: Target = {
     #endif
 }()
 
+// Only referenced on non-Windows platforms — the DDS path is entirely
+// compiled out for Windows at the targets-array level below.
 let cCycloneDDS: Target = {
     #if os(Linux)
         return .systemLibrary(
             name: "CCycloneDDS",
             path: "Sources/CCycloneDDS",
             pkgConfig: "CycloneDDS"
-        )
-    #elseif os(Windows)
-        return .binaryTarget(
-            name: "CCycloneDDS",
-            url: "\(releaseBaseURL)/CCycloneDDS-windows-x86_64.artifactbundle.zip",
-            checksum: "0000000000000000000000000000000000000000000000000000000000000000"
         )
     #else
         return .binaryTarget(
@@ -78,77 +100,108 @@ let cCycloneDDS: Target = {
     #endif
 }()
 
-let package = Package(
-    name: "swift-ros2",
-    platforms: [
-        .iOS(.v16),
-        .macOS(.v13),
-        .macCatalyst(.v16),
-        .visionOS(.v1),
-    ],
-    products: [
+// Products and targets common to every supported platform (the Zenoh
+// path and the pure-Swift layers).
+var products: [Product] = [
+    .library(name: "SwiftROS2CDR", targets: ["SwiftROS2CDR"]),
+    .library(name: "SwiftROS2Messages", targets: ["SwiftROS2Messages"]),
+    .library(name: "SwiftROS2Wire", targets: ["SwiftROS2Wire"]),
+    .library(name: "SwiftROS2Transport", targets: ["SwiftROS2Transport"]),
+    .library(name: "SwiftROS2Zenoh", targets: ["SwiftROS2Zenoh"]),
+]
+
+var targets: [Target] = [
+    // CDR serialization (pure Swift, no dependencies)
+    .target(
+        name: "SwiftROS2CDR",
+        path: "Sources/SwiftROS2CDR"
+    ),
+
+    // Wire format codecs (no dependencies)
+    .target(
+        name: "SwiftROS2Wire",
+        path: "Sources/SwiftROS2Wire"
+    ),
+
+    // Message protocols and built-in types
+    .target(
+        name: "SwiftROS2Messages",
+        dependencies: ["SwiftROS2CDR"],
+        path: "Sources/SwiftROS2Messages"
+    ),
+
+    // Transport abstraction layer
+    .target(
+        name: "SwiftROS2Transport",
+        dependencies: ["SwiftROS2CDR", "SwiftROS2Wire"],
+        path: "Sources/SwiftROS2Transport"
+    ),
+
+    // Native C FFI for zenoh-pico. Apple platforms receive the pre-built
+    // xcframework; Linux and Windows compile from source using the matching
+    // platform backend inside vendor/zenoh-pico.
+    cZenohPico,
+
+    // C bridge for zenoh-pico (Conduit-authored FFI shim).
+    .target(
+        name: "CZenohBridge",
+        dependencies: ["CZenohPico"],
+        path: "Sources/CZenohBridge",
+        sources: ["zenoh_bridge.c"],
+        publicHeadersPath: "include",
+        cSettings: [
+            .define("ZENOH_MACOS", to: "1", .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS])),
+            .define("ZENOH_LINUX", to: "1", .when(platforms: [.linux])),
+            .define("ZENOH_WINDOWS", to: "1", .when(platforms: [.windows])),
+            .define("Z_FEATURE_LINK_TCP", to: "1"),
+            .define("Z_FEATURE_LIVELINESS", to: "1"),
+        ],
+        linkerSettings: [
+            .linkedLibrary("Ws2_32", .when(platforms: [.windows])),
+            .linkedLibrary("Iphlpapi", .when(platforms: [.windows])),
+        ]
+    ),
+
+    // Swift-facing Zenoh module — hosts ZenohClient, the default
+    // implementation of ZenohClientProtocol defined in SwiftROS2Transport.
+    .target(
+        name: "SwiftROS2Zenoh",
+        dependencies: ["CZenohBridge", "SwiftROS2Transport", "SwiftROS2Wire"],
+        path: "Sources/SwiftROS2Zenoh"
+    ),
+
+    // Pure-Swift and Zenoh-path tests (available on every platform)
+    .testTarget(
+        name: "SwiftROS2CDRTests",
+        dependencies: ["SwiftROS2CDR"],
+        path: "Tests/SwiftROS2CDRTests"
+    ),
+    .testTarget(
+        name: "SwiftROS2WireTests",
+        dependencies: ["SwiftROS2Wire"],
+        path: "Tests/SwiftROS2WireTests"
+    ),
+    .testTarget(
+        name: "SwiftROS2ZenohTests",
+        dependencies: ["SwiftROS2Zenoh"],
+        path: "Tests/SwiftROS2ZenohTests"
+    ),
+]
+
+// DDS path + the SwiftROS2 umbrella + examples + umbrella-level tests.
+// These are only included on platforms where CycloneDDS is consumable.
+// Windows will join once M3 settles the DDS-on-Windows story; for now,
+// Windows users should import SwiftROS2Zenoh directly instead of the
+// SwiftROS2 umbrella.
+#if !os(Windows)
+    products.append(contentsOf: [
         .library(name: "SwiftROS2", targets: ["SwiftROS2"]),
-        .library(name: "SwiftROS2CDR", targets: ["SwiftROS2CDR"]),
-        .library(name: "SwiftROS2Messages", targets: ["SwiftROS2Messages"]),
-        .library(name: "SwiftROS2Wire", targets: ["SwiftROS2Wire"]),
-        .library(name: "SwiftROS2Transport", targets: ["SwiftROS2Transport"]),
-        .library(name: "SwiftROS2Zenoh", targets: ["SwiftROS2Zenoh"]),
         .library(name: "SwiftROS2DDS", targets: ["SwiftROS2DDS"]),
-    ],
-    targets: [
-        // CDR serialization (pure Swift, no dependencies)
-        .target(
-            name: "SwiftROS2CDR",
-            path: "Sources/SwiftROS2CDR"
-        ),
+    ])
 
-        // Wire format codecs (no dependencies)
-        .target(
-            name: "SwiftROS2Wire",
-            path: "Sources/SwiftROS2Wire"
-        ),
-
-        // Message protocols and built-in types
-        .target(
-            name: "SwiftROS2Messages",
-            dependencies: ["SwiftROS2CDR"],
-            path: "Sources/SwiftROS2Messages"
-        ),
-
-        // Transport abstraction layer
-        .target(
-            name: "SwiftROS2Transport",
-            dependencies: ["SwiftROS2CDR", "SwiftROS2Wire"],
-            path: "Sources/SwiftROS2Transport"
-        ),
-
-        // Native C FFI: zenoh-pico + CycloneDDS. Apple platforms receive
-        // pre-built xcframeworks; Linux compiles from source (zenoh-pico)
-        // and links via pkg-config (CycloneDDS); Windows consumes pre-built
-        // .artifactbundle zips.
-        cZenohPico,
+    targets.append(contentsOf: [
         cCycloneDDS,
 
-        // C bridges (Conduit-authored FFI shims that simplify the zenoh-pico
-        // and CycloneDDS APIs for Swift callers).
-        .target(
-            name: "CZenohBridge",
-            dependencies: ["CZenohPico"],
-            path: "Sources/CZenohBridge",
-            sources: ["zenoh_bridge.c"],
-            publicHeadersPath: "include",
-            cSettings: [
-                .define("ZENOH_MACOS", to: "1", .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS])),
-                .define("ZENOH_LINUX", to: "1", .when(platforms: [.linux])),
-                .define("ZENOH_WINDOWS", to: "1", .when(platforms: [.windows])),
-                .define("Z_FEATURE_LINK_TCP", to: "1"),
-                .define("Z_FEATURE_LIVELINESS", to: "1"),
-            ],
-            linkerSettings: [
-                .linkedLibrary("Ws2_32", .when(platforms: [.windows])),
-                .linkedLibrary("Iphlpapi", .when(platforms: [.windows])),
-            ]
-        ),
         .target(
             name: "CDDSBridge",
             dependencies: ["CCycloneDDS"],
@@ -160,21 +213,13 @@ let package = Package(
             ]
         ),
 
-        // Swift-facing Zenoh / DDS modules. Host ZenohClient / DDSClient,
-        // the default implementations of the ZenohClientProtocol /
-        // DDSClientProtocol seams defined in SwiftROS2Transport.
-        .target(
-            name: "SwiftROS2Zenoh",
-            dependencies: ["CZenohBridge", "SwiftROS2Transport", "SwiftROS2Wire"],
-            path: "Sources/SwiftROS2Zenoh"
-        ),
         .target(
             name: "SwiftROS2DDS",
             dependencies: ["CDDSBridge", "SwiftROS2Transport", "SwiftROS2Wire"],
             path: "Sources/SwiftROS2DDS"
         ),
 
-        // Public API: Context, Node, Publisher, Subscription
+        // Public API umbrella: Context, Node, Publisher, Subscription
         .target(
             name: "SwiftROS2",
             dependencies: [
@@ -201,26 +246,10 @@ let package = Package(
             path: "Sources/Examples/Listener"
         ),
 
-        // Tests
-        .testTarget(
-            name: "SwiftROS2CDRTests",
-            dependencies: ["SwiftROS2CDR"],
-            path: "Tests/SwiftROS2CDRTests"
-        ),
-        .testTarget(
-            name: "SwiftROS2WireTests",
-            dependencies: ["SwiftROS2Wire"],
-            path: "Tests/SwiftROS2WireTests"
-        ),
         .testTarget(
             name: "SwiftROS2Tests",
             dependencies: ["SwiftROS2", "SwiftROS2Messages", "SwiftROS2CDR"],
             path: "Tests/SwiftROS2Tests"
-        ),
-        .testTarget(
-            name: "SwiftROS2ZenohTests",
-            dependencies: ["SwiftROS2Zenoh"],
-            path: "Tests/SwiftROS2ZenohTests"
         ),
         .testTarget(
             name: "SwiftROS2DDSTests",
@@ -232,5 +261,17 @@ let package = Package(
             dependencies: ["SwiftROS2", "SwiftROS2Messages", "SwiftROS2Transport"],
             path: "Tests/SwiftROS2IntegrationTests"
         ),
-    ]
+    ])
+#endif
+
+let package = Package(
+    name: "swift-ros2",
+    platforms: [
+        .iOS(.v16),
+        .macOS(.v13),
+        .macCatalyst(.v16),
+        .visionOS(.v1),
+    ],
+    products: products,
+    targets: targets
 )

--- a/Package.swift
+++ b/Package.swift
@@ -7,10 +7,12 @@ import PackageDescription
 // via SPM, using the matching platform backend inside vendor/zenoh-pico.
 // See Scripts/build-xcframework.sh for the macOS build helper.
 //
-// CycloneDDS Linux still resolves through pkg-config; Windows DDS
-// support is not yet in this milestone — the cCycloneDDS Windows arm
-// below is a placeholder that will never be fetched as long as downstream
-// builds stay within the Zenoh / core products.
+// CycloneDDS on Linux resolves through pkg-config; on Apple it ships
+// as a prebuilt xcframework. Windows DDS support is not yet in this
+// milestone — the entire DDS path (cCycloneDDS, CDDSBridge, SwiftROS2DDS,
+// the SwiftROS2 umbrella, and the DDS/umbrella tests) is compiled out on
+// Windows by the #if !os(Windows) gate around the targets/products
+// additions further down.
 let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.4.0"
 
 let cZenohPico: Target = {
@@ -82,23 +84,26 @@ let cZenohPico: Target = {
     #endif
 }()
 
-// Only referenced on non-Windows platforms — the DDS path is entirely
-// compiled out for Windows at the targets-array level below.
-let cCycloneDDS: Target = {
-    #if os(Linux)
-        return .systemLibrary(
-            name: "CCycloneDDS",
-            path: "Sources/CCycloneDDS",
-            pkgConfig: "CycloneDDS"
-        )
-    #else
-        return .binaryTarget(
-            name: "CCycloneDDS",
-            url: "\(releaseBaseURL)/CCycloneDDS.xcframework.zip",
-            checksum: "bc72071590791fcb989a69af616c1da771f9c6d79b50de4381d8e95ce33fc8ad"
-        )
-    #endif
-}()
+#if !os(Windows)
+    // The DDS path is compiled out on Windows entirely, so cCycloneDDS
+    // is not defined there — no closure evaluation, no stale placeholder
+    // .binaryTarget construction.
+    let cCycloneDDS: Target = {
+        #if os(Linux)
+            return .systemLibrary(
+                name: "CCycloneDDS",
+                path: "Sources/CCycloneDDS",
+                pkgConfig: "CycloneDDS"
+            )
+        #else
+            return .binaryTarget(
+                name: "CCycloneDDS",
+                url: "\(releaseBaseURL)/CCycloneDDS.xcframework.zip",
+                checksum: "bc72071590791fcb989a69af616c1da771f9c6d79b50de4381d8e95ce33fc8ad"
+            )
+        #endif
+    }()
+#endif
 
 // Products and targets common to every supported platform (the Zenoh
 // path and the pure-Swift layers).


### PR DESCRIPTION
## Summary
Follow-up to #25. Windows x86_64 now compiles zenoh-pico from source (the same way Linux does, just with \`src/system/windows\` kept instead of \`src/system/unix\` and \`ZENOH_WINDOWS\` defined).

## Why source build (not .artifactbundle)
The original plan was to ship pre-built \`CZenohPico-windows-x86_64.artifactbundle.zip\` on each release, consumed via \`.binaryTarget\`. Four iterations against \`0.5.0-rc.1\` proved that SwiftPM 6.0.2 and 6.3.1 both reject C-library \`.artifactbundle\`s on Windows with \`does not contain a binary artifact\` — the library consumption path for non-Apple binary targets is under-exercised and not reliably supported in shipping Swift. This is the Risk §8.7 fallback the design doc pre-authorized.

## Changes
- \`Package.swift\`: Windows \`cZenohPico\` arm flipped from \`.binaryTarget\` to \`.target\` over \`vendor/zenoh-pico\`. Source file exclude list drops \`src/system/unix\` and keeps \`src/system/windows\`. \`ZENOH_WINDOWS\` define added via the existing \`.when(platforms: [.windows])\` gate.
- \`Package.swift\`: the whole DDS family (\`cCycloneDDS\`, \`CDDSBridge\`, \`SwiftROS2DDS\`, the \`SwiftROS2\` umbrella that depends on it, the talker/listener examples that use the umbrella, and the DDS/umbrella tests) is now gated behind \`#if !os(Windows)\` at the targets array — SPM compiles nothing DDS-related on Windows. CycloneDDS-on-Windows is a separate, later milestone.
- \`ci.yml\`: new \`build-windows\` job on \`windows-latest\` with Swift 6.3.1. Runs \`swift build\` + \`swift test --parallel\` at the package level — the Windows build graph is just the Zenoh path + pure Swift layers.

## Consumer impact
Downstream projects (Conduit et al.) that \`import SwiftROS2\` on Apple / Linux are unaffected. On Windows, the umbrella \`SwiftROS2\` module isn't available for 0.5.0; importers should use \`import SwiftROS2Zenoh\` directly. Once CycloneDDS-on-Windows is resolved in a later milestone, the umbrella will light up on Windows too.

## Test plan
- [x] \`swift build\` + \`swift format lint --strict\` clean locally on macOS (Windows arm is inert off-Windows).
- [ ] \`build-windows\` CI job green.
- [ ] Existing \`build-macos\` + \`build-linux\` matrix stays green.