### PR TITLE
build(android): Package.swift four-arm split + DDS carve-out (0.5.0)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -112,10 +112,13 @@ let cZenohPico: Target = {
     #endif
 }()
 
-#if !os(Windows)
-    // The DDS path is compiled out on Windows entirely, so cCycloneDDS
-    // is not defined there — no closure evaluation, no stale placeholder
-    // .binaryTarget construction.
+#if !os(Windows) && !os(Android)
+    // The DDS path is compiled out on Windows and Android entirely, so
+    // cCycloneDDS is not defined there — no closure evaluation, no stale
+    // placeholder .binaryTarget construction. Android is carved out for
+    // the same reason Windows is: SwiftPM cannot orchestrate CycloneDDS's
+    // ddsrt CMake-configure-time header generation, and no usable
+    // prebuilt .binaryTarget path exists yet.
     let cCycloneDDS: Target = {
         #if os(Linux)
             return .systemLibrary(
@@ -223,10 +226,11 @@ var targets: [Target] = [
 
 // DDS path + the SwiftROS2 umbrella + examples + umbrella-level tests.
 // These are only included on platforms where CycloneDDS is consumable.
-// Windows will join once M3 settles the DDS-on-Windows story; for now,
-// Windows users should import SwiftROS2Zenoh directly instead of the
-// SwiftROS2 umbrella.
-#if !os(Windows)
+// Windows and Android do not build CycloneDDS from source (SPM cannot
+// orchestrate the ddsrt CMake configure-time header generation), so
+// both platforms import SwiftROS2Zenoh directly instead of the
+// SwiftROS2 umbrella. DDS on Windows / Android is a future track.
+#if !os(Windows) && !os(Android)
     products.append(contentsOf: [
         .library(name: "SwiftROS2", targets: ["SwiftROS2"]),
         .library(name: "SwiftROS2DDS", targets: ["SwiftROS2DDS"]),

--- a/Package.swift
+++ b/Package.swift
@@ -189,6 +189,7 @@ var targets: [Target] = [
             .define("ZENOH_MACOS", to: "1", .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS])),
             .define("ZENOH_LINUX", to: "1", .when(platforms: [.linux])),
             .define("ZENOH_WINDOWS", to: "1", .when(platforms: [.windows])),
+            .define("ZENOH_ANDROID", to: "1", .when(platforms: [.android])),
             .define("Z_FEATURE_LINK_TCP", to: "1"),
             .define("Z_FEATURE_LIVELINESS", to: "1"),
         ],

--- a/Package.swift
+++ b/Package.swift
@@ -3,16 +3,17 @@
 import PackageDescription
 
 // Apple platforms: pre-built xcframework binaryTargets hosted on
-// GitHub Releases. Linux and Windows: compile the C sources directly
-// via SPM, using the matching platform backend inside vendor/zenoh-pico.
-// See Scripts/build-xcframework.sh for the macOS build helper.
+// GitHub Releases. Linux, Windows, and Android: compile the C sources
+// directly via SPM, using the matching platform backend inside
+// vendor/zenoh-pico. See Scripts/build-xcframework.sh for the macOS
+// build helper.
 //
 // CycloneDDS on Linux resolves through pkg-config; on Apple it ships
-// as a prebuilt xcframework. Windows DDS support is not yet in this
-// milestone — the entire DDS path (cCycloneDDS, CDDSBridge, SwiftROS2DDS,
-// the SwiftROS2 umbrella, and the DDS/umbrella tests) is compiled out on
-// Windows by the #if !os(Windows) gate around the targets/products
-// additions further down.
+// as a prebuilt xcframework. Windows and Android do not ship DDS —
+// the entire DDS path (cCycloneDDS, CDDSBridge, SwiftROS2DDS, the
+// SwiftROS2 umbrella, and the DDS/umbrella tests) is compiled out on
+// both platforms by the #if !os(Windows) && !os(Android) gate around
+// the targets/products additions further down.
 let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.4.0"
 
 let cZenohPico: Target = {

--- a/Package.swift
+++ b/Package.swift
@@ -75,6 +75,34 @@ let cZenohPico: Target = {
                 .define("ZENOH_WINDOWS", to: "1"),
             ]
         )
+    #elseif os(Android)
+        return .target(
+            name: "CZenohPico",
+            path: "vendor/zenoh-pico",
+            exclude: [
+                "CMakeLists.txt", "README.md", "LICENSE", "tests", "examples", "docs", "ci",
+                // Android uses the unix backend (Bionic is POSIX-ish);
+                // exclude every other backend, same pattern as Linux.
+                "src/system/arduino",
+                "src/system/emscripten",
+                "src/system/espidf",
+                "src/system/freertos_plus_tcp",
+                "src/system/mbed",
+                "src/system/rpi_pico",
+                "src/system/void",
+                "src/system/windows",
+                "src/system/zephyr",
+                "src/system/flipper",
+            ],
+            sources: ["src"],
+            publicHeadersPath: "include",
+            cSettings: [
+                .headerSearchPath("src"),
+                .define("Z_FEATURE_LINK_TCP", to: "1"),
+                .define("Z_FEATURE_LIVELINESS", to: "1"),
+                .define("ZENOH_ANDROID", to: "1"),
+            ]
+        )
     #else
         return .binaryTarget(
             name: "CZenohPico",


### PR DESCRIPTION
## Summary

Code-side of Android support (targeting **0.5.0**). Extends `Package.swift` only:

- **`cZenohPico` fourth arm** (`#elseif os(Android)`) — source-compiles `vendor/zenoh-pico` with the unix backend, defines `ZENOH_ANDROID`. Mirrors the Linux / Windows source-build arms introduced in commits `47f903d` / `8c55971`.
- **DDS carve-out gate extended** from `#if !os(Windows)` to `#if !os(Windows) && !os(Android)` at every site. CycloneDDS, CDDSBridge, SwiftROS2DDS, the SwiftROS2 umbrella, examples, and DDS / umbrella tests are compiled out on Android, mirroring Windows. Downstream Android consumers import `SwiftROS2Zenoh` directly.
- **`ZENOH_ANDROID` define added to `CZenohBridge` cSettings** for symmetry with the existing Apple / Linux / Windows defines.
- **Block comment refreshed** to document the new fourth platform.

Apple / Linux / Windows builds are unaffected — this only adds new branches and extends an existing gate condition.

## Dependencies

- **Design / plan companion:** #28 (docs only, independent).
- **CI jobs:** #31 (stacked on this branch).
- Depends on the `youtalk/zenoh-pico` fork landing a `ZENOH_ANDROID` CMake branch + unix-backend preprocessor gate extensions (Milestone 1 of the plan in #28). The submodule bump happens in a follow-up commit once the fork PR merges.

## Spec / plan

- Spec: `docs/superpowers/specs/2026-04-24-android-support-design.md` (#28)
- Plan: `docs/superpowers/plans/2026-04-24-android-support.md` (#28)

Release ordering: Android 0.5.0 (this work) → Windows DDS 0.7.0 (not yet designed).

## Test plan

- [x] `swift package dump-package` parses on macOS locally (Swift 6.3.1).
- [ ] CI `build-linux`, `build-macos`, `build-windows` stay green.
- [ ] After this and the fork submodule bump land, the follow-up CI job PR (#31) verifies end-to-end Android build.