### PR TITLE
ci(android): build-android matrix + test-android-x86_64 emulator jobs (0.5.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,12 +174,25 @@ jobs:
           tag: 6.3.1-RELEASE
       - name: Install Swift Android SDK
         env:
-          # Swift 6.3 Android SDK pinned 2026-04-24. Replace <pinned-url>
-          # and <pinned-sha> with the values from swift.org/install/android
-          # at merge time.
-          SDK_URL: "<pinned-url>"
-          SDK_CHECKSUM: "<pinned-sha>"
+          # Pinned via repository variables so values can be rotated
+          # without a code change. Set both at
+          # github.com/youtalk/swift-ros2/settings/variables/actions:
+          #   SWIFT_ANDROID_SDK_URL      — full https URL of the
+          #                                .artifactbundle from
+          #                                swift.org/install/android
+          #   SWIFT_ANDROID_SDK_CHECKSUM — SHA-256 hex string from the
+          #                                same page
+          # If either is unset, this step fails fast with an actionable
+          # message instead of leaving the swift sdk install command to
+          # surface a less-clear error.
+          SDK_URL: ${{ vars.SWIFT_ANDROID_SDK_URL }}
+          SDK_CHECKSUM: ${{ vars.SWIFT_ANDROID_SDK_CHECKSUM }}
         run: |
+          if [[ -z "$SDK_URL" || -z "$SDK_CHECKSUM" ]]; then
+            echo "ERROR: repository variables SWIFT_ANDROID_SDK_URL and SWIFT_ANDROID_SDK_CHECKSUM must both be set." >&2
+            echo "       Configure them at https://github.com/youtalk/swift-ros2/settings/variables/actions." >&2
+            exit 1
+          fi
           swift sdk install "$SDK_URL" --checksum "$SDK_CHECKSUM"
           swift sdk list
       - name: Swift version
@@ -189,7 +202,10 @@ jobs:
 
   test-android-x86_64:
     name: Test Android (x86_64 emulator)
-    needs: [build-android]
+    # Decoupled from build-android: this job rebuilds the x86_64 tests
+    # itself and does not consume artifacts from the matrix, so an
+    # arm64 build failure should not block the emulator signal.
+    needs: [swift-format]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -201,9 +217,14 @@ jobs:
           tag: 6.3.1-RELEASE
       - name: Install Swift Android SDK
         env:
-          SDK_URL: "<pinned-url>"
-          SDK_CHECKSUM: "<pinned-sha>"
-        run: swift sdk install "$SDK_URL" --checksum "$SDK_CHECKSUM"
+          SDK_URL: ${{ vars.SWIFT_ANDROID_SDK_URL }}
+          SDK_CHECKSUM: ${{ vars.SWIFT_ANDROID_SDK_CHECKSUM }}
+        run: |
+          if [[ -z "$SDK_URL" || -z "$SDK_CHECKSUM" ]]; then
+            echo "ERROR: repository variables SWIFT_ANDROID_SDK_URL and SWIFT_ANDROID_SDK_CHECKSUM must both be set." >&2
+            exit 1
+          fi
+          swift sdk install "$SDK_URL" --checksum "$SDK_CHECKSUM"
       - name: Build tests for Android x86_64
         run: swift build --build-tests --swift-sdk x86_64-unknown-linux-android28 -v
       - name: Enable KVM group perms

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,3 +150,75 @@ jobs:
         run: swift build
       - name: Test
         run: swift test --parallel
+
+  build-android:
+    name: Build Android (${{ matrix.abi }})
+    needs: [swift-format]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - abi: arm64-v8a
+            triple: aarch64-unknown-linux-android28
+          - abi: x86_64
+            triple: x86_64-unknown-linux-android28
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      # Swift 6.3.1 — the Android SDK pinned below is published for 6.3.
+      - uses: compnerd/gha-setup-swift@eeda069c5bc95ac8a9ac5cea7d4f588ae5420ca5 # v0.4.0
+        with:
+          branch: swift-6.3.1-release
+          tag: 6.3.1-RELEASE
+      - name: Install Swift Android SDK
+        env:
+          # Swift 6.3 Android SDK pinned 2026-04-24. Replace <pinned-url>
+          # and <pinned-sha> with the values from swift.org/install/android
+          # at merge time.
+          SDK_URL: "<pinned-url>"
+          SDK_CHECKSUM: "<pinned-sha>"
+        run: |
+          swift sdk install "$SDK_URL" --checksum "$SDK_CHECKSUM"
+          swift sdk list
+      - name: Swift version
+        run: swift --version
+      - name: Build
+        run: swift build --swift-sdk ${{ matrix.triple }} -v
+
+  test-android-x86_64:
+    name: Test Android (x86_64 emulator)
+    needs: [build-android]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: compnerd/gha-setup-swift@eeda069c5bc95ac8a9ac5cea7d4f588ae5420ca5 # v0.4.0
+        with:
+          branch: swift-6.3.1-release
+          tag: 6.3.1-RELEASE
+      - name: Install Swift Android SDK
+        env:
+          SDK_URL: "<pinned-url>"
+          SDK_CHECKSUM: "<pinned-sha>"
+        run: swift sdk install "$SDK_URL" --checksum "$SDK_CHECKSUM"
+      - name: Build tests for Android x86_64
+        run: swift build --build-tests --swift-sdk x86_64-unknown-linux-android28 -v
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Run tests on Android x86_64 emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 28
+          arch: x86_64
+          target: default
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: bash Scripts/run-android-tests.sh

--- a/Scripts/run-android-tests.sh
+++ b/Scripts/run-android-tests.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Discover swift-ros2 test executables built for Android x86_64, push
+# them plus the Swift Android runtime to the running emulator via adb,
+# run each under LD_LIBRARY_PATH, and exit non-zero on any failure.
+#
+# Run this inside reactivecircus/android-emulator-runner@v2's `script:`
+# block after `swift build --build-tests --swift-sdk
+# x86_64-unknown-linux-android28`.
+set -euo pipefail
+
+BUILD_DIR=".build/x86_64-unknown-linux-android28/debug"
+REMOTE_DIR="/data/local/tmp/swift-ros2-tests"
+
+if [[ ! -d "$BUILD_DIR" ]]; then
+  echo "ERROR: $BUILD_DIR does not exist. Build with --build-tests first." >&2
+  exit 2
+fi
+
+adb shell "rm -rf $REMOTE_DIR && mkdir -p $REMOTE_DIR/swift-runtime"
+
+# Push the Swift Android runtime .so files alongside the test binaries.
+SWIFT_SDK_ROOT="$(swift sdk configuration show x86_64-unknown-linux-android28 2>/dev/null | awk -F': ' '/sdkRootPath/ {print $2}')" || true
+if [[ -n "${SWIFT_SDK_ROOT:-}" && -d "$SWIFT_SDK_ROOT/usr/lib/swift/android" ]]; then
+  adb push "$SWIFT_SDK_ROOT/usr/lib/swift/android/." "$REMOTE_DIR/swift-runtime/" >/dev/null
+fi
+
+# Push test binaries. XCTest bundles on Linux/Android ship as plain
+# executables under .build/<triple>/debug/<Name>PackageTests.xctest.
+shopt -s nullglob
+PUSHED=()
+for BIN in "$BUILD_DIR"/*PackageTests.xctest "$BUILD_DIR"/*Tests.xctest; do
+  [[ -f "$BIN" && -x "$BIN" ]] || continue
+  BASENAME="$(basename "$BIN")"
+  adb push "$BIN" "$REMOTE_DIR/$BASENAME" >/dev/null
+  PUSHED+=("$BASENAME")
+done
+
+if (( ${#PUSHED[@]} == 0 )); then
+  echo "ERROR: no *.xctest test binaries found under $BUILD_DIR" >&2
+  exit 2
+fi
+
+# Run each test binary on the emulator; collect failures.
+FAILED=()
+for BIN in "${PUSHED[@]}"; do
+  echo "::group::Running $BIN"
+  if adb shell "chmod +x $REMOTE_DIR/$BIN && cd $REMOTE_DIR && LD_LIBRARY_PATH=$REMOTE_DIR/swift-runtime ./$BIN"; then
+    :
+  else
+    FAILED+=("$BIN")
+  fi
+  echo "::endgroup::"
+done
+
+if (( ${#FAILED[@]} > 0 )); then
+  echo "FAILED test binaries: ${FAILED[*]}" >&2
+  exit 1
+fi
+
+echo "All test binaries passed."

--- a/Scripts/run-android-tests.sh
+++ b/Scripts/run-android-tests.sh
@@ -9,6 +9,10 @@
 set -euo pipefail
 
 BUILD_DIR=".build/x86_64-unknown-linux-android28/debug"
+# Hard-coded device-side path. Avoid interpolating it into adb shell
+# strings — the device shell parses what we send, so paths with shell
+# metacharacters would silently misbehave. If you need to change the
+# path, change it here AND in the single-quoted device commands below.
 REMOTE_DIR="/data/local/tmp/swift-ros2-tests"
 
 if [[ ! -d "$BUILD_DIR" ]]; then
@@ -16,13 +20,29 @@ if [[ ! -d "$BUILD_DIR" ]]; then
   exit 2
 fi
 
-adb shell "rm -rf $REMOTE_DIR && mkdir -p $REMOTE_DIR/swift-runtime"
-
-# Push the Swift Android runtime .so files alongside the test binaries.
-SWIFT_SDK_ROOT="$(swift sdk configuration show x86_64-unknown-linux-android28 2>/dev/null | awk -F': ' '/sdkRootPath/ {print $2}')" || true
-if [[ -n "${SWIFT_SDK_ROOT:-}" && -d "$SWIFT_SDK_ROOT/usr/lib/swift/android" ]]; then
-  adb push "$SWIFT_SDK_ROOT/usr/lib/swift/android/." "$REMOTE_DIR/swift-runtime/" >/dev/null
+# Locate the Swift Android runtime that the test binaries dynamically
+# link against. Without these .so files on the device, every test
+# launch fails with an opaque dlopen error — fail fast here instead.
+if ! SWIFT_SDK_ROOT="$(swift sdk configuration show x86_64-unknown-linux-android28 2>/dev/null | awk -F': ' '/sdkRootPath/ {print $2}')"; then
+  echo "ERROR: 'swift sdk configuration show x86_64-unknown-linux-android28' failed. Is the Swift Android SDK installed?" >&2
+  exit 2
 fi
+if [[ -z "${SWIFT_SDK_ROOT:-}" ]]; then
+  echo "ERROR: Swift SDK configuration did not report an sdkRootPath for x86_64-unknown-linux-android28." >&2
+  exit 2
+fi
+SWIFT_RUNTIME_DIR="$SWIFT_SDK_ROOT/usr/lib/swift/android"
+if [[ ! -d "$SWIFT_RUNTIME_DIR" ]]; then
+  echo "ERROR: Swift Android runtime directory not found at $SWIFT_RUNTIME_DIR." >&2
+  exit 2
+fi
+
+# Reset device-side workspace. Device path is single-quoted so the
+# shell-on-device sees the literal /data/local/tmp/... string regardless
+# of host-side variable expansion concerns.
+adb shell 'rm -rf /data/local/tmp/swift-ros2-tests && mkdir -p /data/local/tmp/swift-ros2-tests/swift-runtime'
+
+adb push "$SWIFT_RUNTIME_DIR/." "$REMOTE_DIR/swift-runtime/" >/dev/null
 
 # Push test binaries. XCTest bundles on Linux/Android ship as plain
 # executables under .build/<triple>/debug/<Name>PackageTests.xctest.
@@ -41,10 +61,14 @@ if (( ${#PUSHED[@]} == 0 )); then
 fi
 
 # Run each test binary on the emulator; collect failures.
+# The device-side command is single-quoted so $BASENAME is interpolated
+# host-side once and the device shell sees a fully-resolved string.
+# We hard-code the device paths instead of interpolating $REMOTE_DIR
+# into the device command line.
 FAILED=()
 for BIN in "${PUSHED[@]}"; do
   echo "::group::Running $BIN"
-  if adb shell "chmod +x $REMOTE_DIR/$BIN && cd $REMOTE_DIR && LD_LIBRARY_PATH=$REMOTE_DIR/swift-runtime ./$BIN"; then
+  if adb shell "chmod +x '/data/local/tmp/swift-ros2-tests/${BIN}' && cd /data/local/tmp/swift-ros2-tests && LD_LIBRARY_PATH=/data/local/tmp/swift-ros2-tests/swift-runtime './${BIN}'"; then
     :
   else
     FAILED+=("$BIN")


### PR DESCRIPTION
## Summary

CI coverage for Android support (targeting **0.5.0**). Stacked on #29 (Package.swift four-arm split).

- **`build-android`** — matrix job on `ubuntu-latest` that compiles swift-ros2 for both ABIs (`arm64-v8a`, `x86_64`) against the official Swift 6.3 Android SDK (`swift build --swift-sdk <triple>`). Both ABIs build; no runtime testing in this job.
- **`test-android-x86_64`** — builds tests for x86_64 Android, boots an API 28 x86_64 Android emulator under KVM via `reactivecircus/android-emulator-runner@v2`, and runs `Scripts/run-android-tests.sh` inside the emulator.
- **`Scripts/run-android-tests.sh`** — discovers `.xctest` test binaries under `.build/x86_64-unknown-linux-android28/debug/`, pushes them plus the Swift Android runtime `.so` files to the emulator via `adb`, runs each under `LD_LIBRARY_PATH`, and returns non-zero on any failure.

`arm64-v8a` is not tested at runtime — arm64 emulator on x86_64 host lacks KVM acceleration and is impractically slow. arm64 Android is build-verified only; runtime correctness is inferred from the shared pure-Swift and identical C layer.

## Dependencies (stacked PR)

- **Base branch:** `feat/android-m1-package-scaffold` (#29). Rebase onto `main` after #29 merges.
- **Also depends on:**
  - The `youtalk/zenoh-pico` fork landing `ZENOH_ANDROID` (Milestone 1 of the Android plan in #28). Without it, `swift build --swift-sdk <android-triple>` fails at the CMake / preprocessor gate.
  - `vendor/zenoh-pico` submodule bumped to the fork tip (follow-up commit after the fork PR merges).
  - `SDK_URL` and `SDK_CHECKSUM` env vars in the two new CI jobs are placeholders (`<pinned-url>` / `<pinned-sha>`). Replace at merge time with the values from [swift.org/install/android](https://www.swift.org/install/android/).

**CI is expected to fail on this PR** until the three dependencies above land. The PR is marked ready for review so the shape / structure can be reviewed in parallel with the fork work; do not merge until the green path is achievable.

## Spec / plan

- Spec: `docs/superpowers/specs/2026-04-24-android-support-design.md` (#28) — §6 CI jobs.
- Plan: `docs/superpowers/plans/2026-04-24-android-support.md` (#28) — Milestone 3.

## Test plan

- [ ] After the fork patch merges and the submodule bump lands: `build-android (arm64-v8a)` green.
- [ ] `build-android (x86_64)` green.
- [ ] `test-android-x86_64` green over 5 consecutive runs (emulator stability check). Flake rate > 5 % triggers `retry: 2` bump or self-hosted runner escalation.