### PR TITLE
docs: add Android 0.5.0 release runbook

### DIFF
--- a/docs/superpowers/runbooks/2026-04-24-android-0.5.0-release-runbook.md
+++ b/docs/superpowers/runbooks/2026-04-24-android-0.5.0-release-runbook.md
@@ -1,0 +1,339 @@
+# Android 0.5.0 リリース手順書
+
+- **対象**: swift-ros2 メンテナ（Yutaka Kondo）
+- **目的**: PR #31（Android CI ジョブ追加）を green にし、Android 対応を含む 0.5.0 をリリースするまでの一連の外部作業をまとめる
+- **背景**: 仕様 (`docs/superpowers/specs/2026-04-24-android-support-design.md`) と実装プラン (`docs/superpowers/plans/2026-04-24-android-support.md`) は別途存在するが、PR #31 の CI は意図的な fail-fast でストップしており、コードでは解決できない外部設定が必要。本ランブックはその外部作業を順序付きで列挙する。
+
+> 手順 1〜2 は **swift-ros2 リポジトリの外** で行う作業（fork PR + repo settings）、手順 3〜6 は swift-ros2 内で行う作業。順番厳守。
+
+---
+
+## 全体像
+
+| # | フェーズ | 何をするか | 触る場所 |
+|---|---|---|---|
+| 1 | fork パッチ | `youtalk/zenoh-pico` に `ZENOH_ANDROID` 対応を入れる | github.com/youtalk/zenoh-pico |
+| 2 | submodule bump | swift-ros2 の `vendor/zenoh-pico` を新 fork tip に更新 | github.com/youtalk/swift-ros2 |
+| 3 | repo 変数登録 | Swift 6.3 Android SDK の URL/SHA を repository variables に登録 | github.com 設定画面 |
+| 4 | PR #31 リベース | submodule bump 後の main に乗せ直す | ローカル + push |
+| 5 | CI green 確認 | 12 ジョブすべて green になるのを見守る | GitHub Actions |
+| 6 | 0.5.0 タグ cut | リリースワークフローを発火、checksum bump | git tag + 別 PR |
+
+---
+
+## 手順 1: `youtalk/zenoh-pico` fork に Android 対応を入れる
+
+これがないと Swift Android SDK でクロスコンパイルしようとした際、zenoh-pico の CMakeLists が `FATAL_ERROR: zenoh-pico is not yet available on Android platform` で落ちる。
+
+### 1-1. fork をローカルにクローン
+
+```bash
+cd /tmp
+git clone --branch swift-ros2-main git@github.com:youtalk/zenoh-pico.git zenoh-pico-android
+cd zenoh-pico-android
+git checkout -b feat/android-support
+```
+
+### 1-2. `CMakeLists.txt` に Android 分岐を追加
+
+`if(CMAKE_SYSTEM_NAME MATCHES "Linux")` ブロック（line 167 付近）の直後、`elseif(CMAKE_SYSTEM_NAME MATCHES "BSD")` の前に挿入：
+
+```cmake
+elseif(CMAKE_SYSTEM_NAME MATCHES "Android")
+  pico_add_compile_definition(ZENOH_ANDROID)
+```
+
+さらに line 352 付近の unix backend 収集ブロックを拡張：
+
+```cmake
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Darwin" OR CMAKE_SYSTEM_NAME MATCHES "BSD" OR CMAKE_SYSTEM_NAME MATCHES "Android" OR POSIX_COMPATIBLE)
+```
+
+### 1-3. ヘッダ・ソースの preprocessor gate を拡張
+
+```bash
+grep -rn "defined(ZENOH_LINUX)\|defined(ZENOH_MACOS)\|defined(ZENOH_BSD)" include/ src/ | grep -v Binary
+```
+
+ヒット箇所（`include/zenoh-pico/system/platform.h`、`src/system/platform.c` など 3〜10 箇所）の `#if defined(ZENOH_LINUX) || defined(ZENOH_MACOS) || defined(ZENOH_BSD)` 形式の gate に `|| defined(ZENOH_ANDROID)` を追加。
+
+> ⚠️ glibc 専用 syscall を呼ぶような Linux 特化 gate には Android を**入れない**。unix backend 選択（POSIX socket / pthread）の gate のみが対象。判断に迷ったら、その gate 内のコードが `#include <sys/syscall.h>` や `<linux/...>` を必要とするか確認する。
+
+### 1-4. NDK でローカル検証
+
+```bash
+brew install --cask android-ndk            # 未インストールなら
+export ANDROID_NDK_ROOT=/opt/homebrew/share/android-ndk   # 環境に合わせて
+
+cd /tmp/zenoh-pico-android
+mkdir -p build-android-arm64 && cd build-android-arm64
+cmake \
+  -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake \
+  -DANDROID_ABI=arm64-v8a \
+  -DANDROID_NATIVE_API_LEVEL=28 \
+  -DBUILD_SHARED_LIBS=Off \
+  ..
+cmake --build . --parallel
+file libzenohpico.a   # "current ar archive" + ARM64 表示なら成功
+```
+
+x86_64 でも同じく `-DANDROID_ABI=x86_64` で実施。**両 ABI でビルド成功**を確認すること。
+
+### 1-5. PR 発行 → セルフマージ
+
+```bash
+git add CMakeLists.txt include/ src/
+git commit -m "feat(android): add ZENOH_ANDROID platform support
+
+Adds an Android branch to the CMakeLists platform switch and extends
+unix-backend preprocessor gates to include ZENOH_ANDROID. The unix
+backend works on Android's Bionic libc; this change is a CMake +
+preprocessor-only extension with no new source files.
+
+Verified by cross-compiling for both arm64-v8a and x86_64 with
+Android NDK r26 targeting API 28."
+git push -u origin feat/android-support
+
+gh pr create --repo youtalk/zenoh-pico --base swift-ros2-main \
+  --title "feat(android): add ZENOH_ANDROID platform support" \
+  --body "..."
+```
+
+セルフレビューでマージ。マージ後の **新 tip SHA** を控えておく：
+
+```bash
+gh api repos/youtalk/zenoh-pico/branches/swift-ros2-main -q .commit.sha
+```
+
+---
+
+## 手順 2: swift-ros2 で submodule bump
+
+手順 1 の fork PR が `swift-ros2-main` ブランチにマージされても、swift-ros2 の `vendor/zenoh-pico` submodule は古い tip を指したまま。新しい tip を指すよう更新する。
+
+### 2-1. swift-ros2 のメインリポで作業ブランチを作る
+
+```bash
+cd ~/src/conduit/deps/swift-ros2     # メイン worktree
+git fetch origin
+git checkout -b chore/bump-zenoh-pico-android origin/main
+```
+
+### 2-2. submodule を fork の最新 tip に更新
+
+```bash
+cd vendor/zenoh-pico
+git fetch origin swift-ros2-main
+git checkout origin/swift-ros2-main
+cd ../..
+git add vendor/zenoh-pico
+```
+
+### 2-3. コミット → push → PR
+
+```bash
+git commit -m "build(vendor): bump zenoh-pico to tip with ZENOH_ANDROID support
+
+Pulls in the Android platform branch and unix-backend preprocessor
+gate extensions merged in youtalk/zenoh-pico#<PR#>. Apple / Linux /
+Windows builds are unaffected; Android builds now succeed against
+the bumped submodule (verified by PR #31's build-android job after
+the SDK URL/checksum repo variables are configured)."
+
+git push -u origin chore/bump-zenoh-pico-android
+
+gh pr create --base main \
+  --title "build(vendor): bump zenoh-pico submodule for Android support" \
+  --body "..."
+```
+
+CI が green になることを確認（既存ジョブのみ走る。Android ジョブはまだ #31 経由でしかテストできない）→ マージ。
+
+---
+
+## 手順 3: GitHub repository variables を登録
+
+PR #31 の Android ジョブは `vars.SWIFT_ANDROID_SDK_URL` と `vars.SWIFT_ANDROID_SDK_CHECKSUM` を参照する。両方未設定だと `Install Swift Android SDK` ステップで fail-fast する設計（PR #31 review の対応として導入）。
+
+### 3-1. ブラウザで設定画面を開く
+
+> https://github.com/youtalk/swift-ros2/settings/variables/actions
+
+**Variables** タブの **Repository variables** セクションで「**New repository variable**」をクリック。
+
+### 3-2. SDK URL と SHA-256 を取得
+
+[swift.org/install/android](https://www.swift.org/install/android/) を開き、Swift 6.3.x Android SDK の `.artifactbundle.tar.gz` URL を取得。形式例：
+
+```
+https://download.swift.org/swift-6.3.1-release/android/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE-android-0.1.artifactbundle.tar.gz
+```
+
+> バージョンは時期により変動。**6.3 系の最新パッチ**を選ぶこと。
+
+SHA-256 はページ内の `.sha256` 表示か、手元計算：
+
+```bash
+curl -fsSL <SDK_URL> -o /tmp/sdk.tar.gz
+shasum -a 256 /tmp/sdk.tar.gz
+# 出力末尾の 64 桁 hex がチェックサム
+```
+
+### 3-3. 2 つの変数を登録
+
+| Name | Value |
+|---|---|
+| `SWIFT_ANDROID_SDK_URL` | 上記 URL（フル）|
+| `SWIFT_ANDROID_SDK_CHECKSUM` | 64 桁 hex の SHA-256 |
+
+> 💡 これらは公開しても支障ない情報なので **Secrets ではなく Variables** で OK。Secrets に入れると CI ログ上でマスクされて diagnose しづらくなる。
+
+---
+
+## 手順 4: PR #31 をリベース → force-push-with-lease
+
+手順 2 の submodule bump が main に入った時点で、PR #31 のベースが古くなる。リベース：
+
+```bash
+cd /tmp/android-ci          # PR #31 用の worktree
+git fetch origin --prune
+git rebase origin/main
+git push --force-with-lease origin feat/android-ci-jobs
+```
+
+> ⚠️ 必ず `--force-with-lease`。素の `--force` は使わない（同時に他人が push していたら上書きしてしまう）。
+
+PR #31 は `Scripts/run-android-tests.sh` と `.github/workflows/ci.yml` のみを編集しているので、submodule bump とコンフリクトしない見込み。コンフリクトしたら止めて確認。
+
+---
+
+## 手順 5: PR #31 の CI が green になるのを確認
+
+push 直後に自動で CI が走る。**12 ジョブ**が全部 green になることを確認：
+
+| ジョブ | 期待結果 |
+|---|---|
+| swift-format lint | ✓ |
+| Build & Test (macOS) | ✓ |
+| Build & Test (Ubuntu 22.04 x86_64 + ROS 2 humble) | ✓ |
+| Build & Test (Ubuntu 22.04 aarch64 + ROS 2 humble) | ✓ |
+| Build & Test (Ubuntu 24.04 x86_64 + ROS 2 jazzy) | ✓ |
+| Build & Test (Ubuntu 24.04 aarch64 + ROS 2 jazzy) | ✓ |
+| Build & Test (Ubuntu 24.04 x86_64 + ROS 2 rolling) | ✓ |
+| Build & Test (Ubuntu 24.04 aarch64 + ROS 2 rolling) | ✓ |
+| Build & Test (Windows x86_64, Zenoh only) | ✓ |
+| **Build Android (arm64-v8a)** | ✓（手順 1〜3 が完了していれば成功） |
+| **Build Android (x86_64)** | ✓（同上） |
+| **Test Android (x86_64 emulator)** | ✓（emulator で unit test 全パス） |
+
+ローカルから見守る場合：
+
+```bash
+gh pr checks 31 --watch
+```
+
+green になったらレビュー → squash merge：
+
+```bash
+gh pr merge 31 --squash --delete-branch
+```
+
+---
+
+## 手順 6: 0.5.0 タグ cut → リリース
+
+### 6-1. main を最新化してタグを打つ
+
+```bash
+git fetch origin main
+git checkout main
+git pull --ff-only
+
+# README banner を 0.4.0 → 0.5.0 に更新する PR を任意で先に出してマージ
+# （別 PR で出す or タグと同時に決め打ちで bump する）
+
+git tag 0.5.0
+git push origin 0.5.0
+```
+
+タグ push と同時に `.github/workflows/release-xcframework.yml` が起動：
+
+- `CZenohPico.xcframework.zip` + `.checksum`
+- `CCycloneDDS.xcframework.zip` + `.checksum`
+
+の 4 個が 0.5.0 リリースにアップロードされる。**Android 用 artifact は無い**（source build なので）。
+
+```bash
+gh run watch <release-run-id>
+gh release view 0.5.0
+```
+
+### 6-2. `Package.swift` の `releaseBaseURL` と checksum を 0.5.0 に bump
+
+GitHub は upload 時に zip を再生成するので、ローカルで計算した SHA とサーバ側の SHA は**一致しない**。必ずダウンロードして再計算：
+
+```bash
+mkdir -p /tmp/release-0.5.0
+gh release download 0.5.0 --pattern '*.xcframework.zip' --dir /tmp/release-0.5.0
+swift package compute-checksum /tmp/release-0.5.0/CZenohPico.xcframework.zip
+swift package compute-checksum /tmp/release-0.5.0/CCycloneDDS.xcframework.zip
+```
+
+得られた 2 個の SHA-256 を `Package.swift` に貼り付け、`releaseBaseURL` を 0.5.0 に変える別 PR を出す：
+
+```swift
+let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.5.0"
+```
+
+`cZenohPico` と `cCycloneDDS` の Apple `else` 分岐の `checksum:` 値を更新。
+
+```bash
+git checkout -b chore/release-0.5.0
+git add Package.swift
+git commit -m "chore: ship 0.5.0
+
+First swift-ros2 release with Android support (arm64-v8a + x86_64,
+API 28+, source build via Swift 6.3 Android SDK, Zenoh only).
+Updates Apple binaryTarget URLs + checksums to 0.5.0 release zips."
+git push -u origin chore/release-0.5.0
+gh pr create --base main --title "chore: ship 0.5.0 with Android support" --body "..."
+```
+
+CI green でマージ。
+
+---
+
+## チェックリスト
+
+- [ ] **手順 1**: `youtalk/zenoh-pico#<PR>` マージ済 → 新 tip SHA を記録
+- [ ] **手順 2**: swift-ros2 で submodule bump PR マージ済
+- [ ] **手順 3**: `SWIFT_ANDROID_SDK_URL` 登録済
+- [ ] **手順 3**: `SWIFT_ANDROID_SDK_CHECKSUM` 登録済
+- [ ] **手順 4**: PR #31 を `git rebase origin/main` + `--force-with-lease` push 完了
+- [ ] **手順 5**: PR #31 の 12 ジョブすべて green 確認 → squash merge
+- [ ] **手順 6**: `0.5.0` タグ cut → release ワークフロー成功 → checksum bump PR マージ
+- [ ] README の `Shipping as **0.4.0**` を `**0.5.0**` に更新
+
+---
+
+## トラブルシュート
+
+| 失敗箇所 | 想定原因 | 対処 |
+|---|---|---|
+| `Install Swift Android SDK` で 404 | SDK URL が古い／typo | 手順 3 の URL を最新に更新 |
+| `Install Swift Android SDK` で checksum mismatch | URL は新しいが SHA が古い | `shasum -a 256` で再計算、両方を同時更新 |
+| `swift build` で `'zenoh-pico is not yet available on Android platform'` | submodule が古い／fork に `ZENOH_ANDROID` が入っていない | 手順 1, 2 の完了状況を確認 |
+| `swift build` で undefined reference (socket / pthread / pipe など) | unix backend gate で `ZENOH_ANDROID` が未追加のサイトがある | 手順 1-3 の grep をやり直して漏れを潰す |
+| `swift build` で macros 関連エラー | NDK の Bionic header が想定と異なる | Bionic の対応 syscall を `#ifdef __ANDROID__` で fork 側に分岐実装 |
+| Emulator boot timeout | reactivecircus action のフレーク | `reactivecircus/android-emulator-runner@v2` の `script:` 直前に `retry: 2` を追加、ダメなら self-hosted runner に escalate |
+| `test-android-x86_64` の `Run tests on Android x86_64 emulator` ステップだけ失敗 | テスト自体の Android-specific なバグ | `gh run view <id> --log-failed` で `adb shell ./*PackageTests.xctest` の出力を確認、CDR / Wire test なら golden bytes 食い違いを疑う |
+| `swift sdk list` に Android triple が出ない | Swift 6.3 toolchain 自体が古い／6.0.x にダウングレードされている | CI の `compnerd/gha-setup-swift` の `tag` が `6.3.1-RELEASE` か確認 |
+
+---
+
+## 次回以降のメンテ
+
+- Swift Android SDK のバージョンを上げるとき: 手順 3 の 2 変数を更新するだけ。コードの push なし。
+- NDK 自体のバージョンを上げるとき: ローカル検証用の `ANDROID_NDK_ROOT` のみ影響。CI は Swift SDK 同梱の sysroot を使うので NDK install していない。
+- `armeabi-v7a`（32-bit ARM）追加: Package.swift 修正不要、`.github/workflows/ci.yml` の matrix に `triple: arm-unknown-linux-androideabi28` を追加。エミュレータテストは x86_64 のみ維持。
+- DDS on Android を将来やるとき: 別途 spec を起こす（CycloneDDS の `ddsrt` configure-time header 問題が解決ルートを切る必要あり）。


### PR DESCRIPTION
## Summary

Adds a Japanese-language runbook at `docs/superpowers/runbooks/2026-04-24-android-0.5.0-release-runbook.md` that walks through the external steps required to take PR #31 from its current intentional fail-fast state to a merged 0.5.0 release.

The autofix loop on PR #31 reached a structural blocker — the new Android CI jobs fail fast on `vars.SWIFT_ANDROID_SDK_URL` / `vars.SWIFT_ANDROID_SDK_CHECKSUM` being unset, which is the desired fail-fast (per Copilot review on #31, comment 3140787643). Resolving it requires three external actions Claude cannot perform autonomously:

1. Land a fork PR on `youtalk/zenoh-pico` with `ZENOH_ANDROID` (CMakeLists + unix-backend preprocessor gates), verified locally with NDK r26.
2. Bump `vendor/zenoh-pico` submodule on swift-ros2 to the new fork tip.
3. Configure two repository variables (`SWIFT_ANDROID_SDK_URL`, `SWIFT_ANDROID_SDK_CHECKSUM`) at github.com/youtalk/swift-ros2/settings/variables/actions.

The runbook captures these as a six-phase checklist with exact commands, a troubleshooting matrix keyed by likely failure site, and notes for future maintenance (Swift / NDK / ABI bumps).

Doc body is Japanese (matches the maintainer's working language); commit subject and PR title are English per the project convention.

## Test plan

- [x] No code changes, no CI impact.
- [ ] Maintainer follows the runbook end-to-end and reaches a 0.5.0 release.