### PR TITLE
chore: pin 0.5.0 release URL + xcframework checksums

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ import PackageDescription
 // SwiftROS2 umbrella, and the DDS/umbrella tests) is compiled out on
 // both platforms by the #if !os(Windows) && !os(Android) gate around
 // the targets/products additions further down.
-let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.4.0"
+let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.5.0"
 
 let cZenohPico: Target = {
     #if os(Linux)
@@ -108,7 +108,7 @@ let cZenohPico: Target = {
         return .binaryTarget(
             name: "CZenohPico",
             url: "\(releaseBaseURL)/CZenohPico.xcframework.zip",
-            checksum: "de7d7a02605234d364a464fb0169bc18efb46440976b8e8a26021eb416386c95"
+            checksum: "3cc9437a1ed68b539a86dad687cc470013472a15a48ed6c1e3d8c9c51e8f0e28"
         )
     #endif
 }()
@@ -131,7 +131,7 @@ let cZenohPico: Target = {
             return .binaryTarget(
                 name: "CCycloneDDS",
                 url: "\(releaseBaseURL)/CCycloneDDS.xcframework.zip",
-                checksum: "bc72071590791fcb989a69af616c1da771f9c6d79b50de4381d8e95ce33fc8ad"
+                checksum: "fe47aa6f0896b8babec9b4782db463c9461208b89429aba9c92fe82ecec59e44"
             )
         #endif
     }()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Native Swift client library for ROS 2. Publishes and subscribes over **Zenoh** (via zenoh-pico) or **DDS** (via CycloneDDS) without a bridge, without pulling in the full ROS 2 stack.
 
-Shipping as **0.4.0** — pre-built xcframeworks on every Apple platform, source build on Linux.
+Shipping as **0.5.0** — pre-built xcframeworks on every Apple platform; zenoh-pico source build on Linux and Windows (Zenoh only on Windows; DDS pending).
 
 ## Features
 
@@ -34,7 +34,7 @@ Swift 5.9+ on Apple platforms and Linux; Windows currently requires Swift 6.3.1.
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.4.0"),
+    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.5.0"),
 ],
 targets: [
     .target(
@@ -46,7 +46,7 @@ targets: [
 ]
 ```
 
-That's it — `swift build` downloads the xcframeworks from the 0.4.0 release assets. `SwiftROS2` already links `SwiftROS2Zenoh` + `SwiftROS2DDS` transitively, so the high-level `ROS2Context` / `ROS2Node` API works out of the box. Add the transport-specific products only if you need `ZenohClient` / `DDSClient` directly (e.g. for custom session configuration or testing).
+That's it — `swift build` downloads the xcframeworks from the 0.5.0 release assets. `SwiftROS2` already links `SwiftROS2Zenoh` + `SwiftROS2DDS` transitively, so the high-level `ROS2Context` / `ROS2Node` API works out of the box. Add the transport-specific products only if you need `ZenohClient` / `DDSClient` directly (e.g. for custom session configuration or testing).
 
 ### Linux
 
@@ -75,7 +75,7 @@ Add the package to your `Package.swift` as usual and declare a dependency on `Sw
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.4.0"),
+    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.5.0"),
 ],
 targets: [
     .target(
@@ -200,6 +200,7 @@ PRs welcome. The wire format fixtures in `Tests/SwiftROS2WireTests/` and the gol
 - [x] 0.2.0: Publisher + Subscriber core, pure-Swift CDR, Jazzy/Humble wire codecs, Apple xcframework + Linux source build, dual-transport (Zenoh + DDS) FFI
 - [x] 0.3.1: CDR decoder bounds + string null-terminator validation — rejects untrusted length prefixes before `reserveCapacity`, fails fast on malformed strings instead of silently dropping bytes.
 - [x] 0.4.0: DDS subscriber support — `raw_cdr_serdata_from_ser` fragchain walk, `bridge_dds_reader_t` + listener callback, `DDSReaderHandle` / `createRawReader` / `destroyReader` on `DDSClientProtocol`, `DDSTransportSession.createSubscriber` wired through, `swift run listener dds` enabled.
+- [x] 0.5.0: Windows x86_64 support — three-arm `Package.swift` platform split, `zenoh-pico` source build with `ZENOH_WINDOWS` define and Winsock + Iphlpapi linkage, `build-windows` CI job on `windows-latest` (Swift 6.3.1). Zenoh only; CycloneDDS-on-Windows is tracked as a follow-up. README installation row + Windows subsection added.
 - [ ] Services (request/reply) and Actions (goal/feedback/result)
 - [ ] `swift-ros2-gen` code generator for `.msg` / `.srv` / `.action` files
 - [ ] Expanded message catalog (nav_msgs, visualization_msgs, …)


### PR DESCRIPTION
## Summary

- Bump `releaseBaseURL` in `Package.swift` from `0.4.0` to `0.5.0`.
- Re-pin Apple xcframework SHA-256s to the values computed from the GitHub-hosted zips (GitHub re-zips on upload — server-side checksums always differ from locally-computed ones, per the established release flow).
  - `CZenohPico.xcframework.zip` → `3cc9437a…`
  - `CCycloneDDS.xcframework.zip` → `fe47aa6f…`
- README: bump `Shipping as **0.4.0**` → `0.5.0`, with the Linux + Windows source-build framing (Zenoh-only on Windows; DDS pending).
- README: bump SPM dependency examples (`from: "0.4.0"` → `from: "0.5.0"`) and the inline "0.4.0 release assets" reference.
- README: add a Roadmap entry for 0.5.0 — Windows x86_64 support (three-arm `Package.swift` split, `zenoh-pico` source build with `ZENOH_WINDOWS` define + Winsock/Iphlpapi linkage, `build-windows` CI on `windows-latest` Swift 6.3.1, Zenoh-only).

## Test Plan

- [x] `rm -rf .build && swift build` resolves the new `binaryTarget`s and links cleanly on macOS.
- [ ] CI `build-macos` stays green (validates the new checksums against the live release).
- [ ] CI `build-linux` matrix stays green (no change — Linux still source-builds zenoh-pico and `pkg-config`-resolves CycloneDDS).
- [ ] CI `build-windows` stays green (no change — Windows source-builds zenoh-pico).
- [ ] Reviewer sanity-check: only `Package.swift` URL + 2 checksums and `README.md` version mentions changed; no logic or layout changes.

## Release-flow context

Tag `0.5.0` was cut from `df8c437` (the latest `main` after the Windows README and Android scaffolding landed). The release workflow built and uploaded the Apple xcframeworks; this PR is the canonical "checksum-pin" follow-up that makes 0.5.0 the consumable resolved version.