### PR TITLE
ci(android): align job name with other Build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         run: swift test --parallel
 
   build-android:
-    name: Build Android (${{ matrix.abi }})
+    name: Build (Android ${{ matrix.abi }})
     needs: [swift-format]
     # Pin explicitly to ubuntu-24.04 — the Swift 6.3.1 tarball downloaded
     # below is the ubuntu24.04 build, so the runner must stay on 24.04.


### PR DESCRIPTION
## Summary
- The Android CI job was named `Build Android (<abi>)` while every other job follows `Build & Test (<OS>...)`. Rename to `Build (Android <abi>)` so the OS name lives inside the parentheses like the rest. Kept `Build` (not `Build & Test`) because this job only builds — there is no Android test step today.

## Test plan
- [ ] CI shows the renamed `Build (Android arm64-v8a)` / `Build (Android x86_64)` jobs and they pass.