### PR TITLE
chore: add .spi.yml for Swift Package Index documentation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,11 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets:
+        - SwiftROS2
+        - SwiftROS2Zenoh
+        - SwiftROS2DDS
+        - SwiftROS2Transport
+        - SwiftROS2Messages
+        - SwiftROS2Wire
+        - SwiftROS2CDR

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,7 +1,8 @@
 version: 1
 builder:
   configs:
-    - documentation_targets:
+    - platform: macosSpm
+      documentation_targets:
         - SwiftROS2
         - SwiftROS2Zenoh
         - SwiftROS2DDS


### PR DESCRIPTION
## Summary
- Add `.spi.yml` declaring the seven public library targets as `documentation_targets` so [Swift Package Index](https://swiftpackageindex.com) generates per-target symbol-graph docs.
- Targets declared: `SwiftROS2`, `SwiftROS2Zenoh`, `SwiftROS2DDS`, `SwiftROS2Transport`, `SwiftROS2Messages`, `SwiftROS2Wire`, `SwiftROS2CDR`.
- Lands ahead of submitting the package at https://swiftpackageindex.com/add-a-package so the very first SPI build picks up the manifest.

## Test plan
- [ ] After merge, submit `https://github.com/youtalk/swift-ros2.git` at https://swiftpackageindex.com/add-a-package
- [ ] Wait for the SPI build matrix to run — confirm green Apple / Linux rows and that the seven targets appear under "Documentation"
- [ ] Drop SPI compatibility/documentation badges into README in a follow-up PR once the package URL is live