### PR TITLE
docs(readme): add Swift Package Index compatibility badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%206.0%20%7C%206.3-orange.svg)](https://swift.org)
 [![ROS 2](https://img.shields.io/badge/ROS%202-Humble%20%7C%20Jazzy%20%7C%20Kilted%20%7C%20Rolling-22314E.svg)](https://docs.ros.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![SPI Swift compatibility](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyoutalk%2Fswift-ros2%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/youtalk/swift-ros2)
+[![SPI platform compatibility](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyoutalk%2Fswift-ros2%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/youtalk/swift-ros2)
 
 Native Swift client library for ROS 2. Publish and subscribe to ROS 2 topics over **Zenoh** (via `zenoh-pico`) or **DDS** (via CycloneDDS) — without a bridge, without `rcl` / `rclcpp`, on every consumer device OS that runs Swift.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Windows CI](https://img.shields.io/github/actions/workflow/status/youtalk/swift-ros2/ci.yml?branch=main&label=Windows)](https://github.com/youtalk/swift-ros2/actions/workflows/ci.yml)
 [![Android CI](https://img.shields.io/github/actions/workflow/status/youtalk/swift-ros2/ci.yml?branch=main&label=Android)](https://github.com/youtalk/swift-ros2/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/youtalk/swift-ros2?label=release&sort=semver)](https://github.com/youtalk/swift-ros2/releases)
-[![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%206.0%20%7C%206.3-orange.svg)](https://swift.org)
 [![ROS 2](https://img.shields.io/badge/ROS%202-Humble%20%7C%20Jazzy%20%7C%20Kilted%20%7C%20Rolling-22314E.svg)](https://docs.ros.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![SPI Swift compatibility](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyoutalk%2Fswift-ros2%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/youtalk/swift-ros2)


### PR DESCRIPTION
## Summary
- Add the two Swift Package Index dynamic badges (Swift versions + platforms) now that the package is live at https://swiftpackageindex.com/youtalk/swift-ros2 via [SwiftPackageIndex/PackageList#13355](https://github.com/SwiftPackageIndex/PackageList/pull/13355).
- Both badges link to the SPI package page so readers can drill into the full per-platform / per-Swift status and the generated DocC documentation.

Current SPI matrix output:
- swift-versions: \`6.3 | 6.2 | 6.1 | 6.0\`
- platforms: \`iOS | macOS | visionOS\`

## Test plan
- [ ] After merge, confirm both badges render on https://github.com/youtalk/swift-ros2 (no broken-image fallbacks).
- [ ] Confirm clicking each badge lands on https://swiftpackageindex.com/youtalk/swift-ros2.