### PR TITLE
refactor(transport): split ZenohTransportSession into focused files

### DIFF
--- a/Sources/SwiftROS2Transport/TransportQoS+QoSPolicy.swift
+++ b/Sources/SwiftROS2Transport/TransportQoS+QoSPolicy.swift
@@ -5,7 +5,6 @@
 // transport sessions when emitting liveliness tokens. The function
 // itself is a pure mapping and has no transport-specific logic.
 
-import Foundation
 import SwiftROS2Wire
 
 extension TransportQoS {

--- a/Sources/SwiftROS2Transport/TransportQoS+QoSPolicy.swift
+++ b/Sources/SwiftROS2Transport/TransportQoS+QoSPolicy.swift
@@ -1,0 +1,35 @@
+// TransportQoS+QoSPolicy.swift
+// Conversion from TransportQoS to wire-level QoSPolicy.
+//
+// Lives in SwiftROS2Transport because the conversion is consumed by
+// transport sessions when emitting liveliness tokens. The function
+// itself is a pure mapping and has no transport-specific logic.
+
+import Foundation
+import SwiftROS2Wire
+
+extension TransportQoS {
+    /// Convert to wire-level QoSPolicy for liveliness token encoding
+    public func toQoSPolicy() -> QoSPolicy {
+        let rel: QoSPolicy.Reliability = self.reliability == .reliable ? .reliable : .bestEffort
+        let dur: QoSPolicy.Durability = self.durability == .transientLocal ? .transientLocal : .volatile
+        let hist: QoSPolicy.HistoryPolicy
+        let depth: Int
+
+        switch self.history {
+        case .keepLast(let n):
+            hist = .keepLast
+            depth = n
+        case .keepAll:
+            hist = .keepAll
+            depth = 1000
+        }
+
+        return QoSPolicy(
+            reliability: rel,
+            durability: dur,
+            historyPolicy: hist,
+            historyDepth: depth
+        )
+    }
+}

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Connection.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Connection.swift
@@ -33,7 +33,7 @@ extension ZenohTransportSession {
 
 // MARK: - Connection Result (Thread-safe)
 
-final class ConnectionResult: @unchecked Sendable {
+private final class ConnectionResult: @unchecked Sendable {
     private var error: Error?
     private var completed = false
     private let lock = NSLock()

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Connection.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Connection.swift
@@ -1,0 +1,65 @@
+// ZenohTransportSession+Connection.swift
+// Connection establishment with timeout polling.
+
+import Foundation
+
+extension ZenohTransportSession {
+    func connectWithTimeout(locator: String, timeout: TimeInterval) async throws {
+        let result = ConnectionResult()
+        let client = self.client
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try client.open(locator: locator)
+                result.setCompleted()
+            } catch {
+                result.setError(error)
+            }
+        }
+
+        let startTime = Date()
+        while !result.isCompleted() {
+            if Date().timeIntervalSince(startTime) > timeout {
+                throw TransportError.connectionTimeout(timeout)
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)  // 50ms polling
+        }
+
+        if let error = result.getError() {
+            throw TransportError.connectionFailed(error.localizedDescription)
+        }
+    }
+}
+
+// MARK: - Connection Result (Thread-safe)
+
+final class ConnectionResult: @unchecked Sendable {
+    private var error: Error?
+    private var completed = false
+    private let lock = NSLock()
+
+    func setCompleted() {
+        lock.lock()
+        completed = true
+        lock.unlock()
+    }
+
+    func setError(_ err: Error) {
+        lock.lock()
+        error = err
+        completed = true
+        lock.unlock()
+    }
+
+    func isCompleted() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return completed
+    }
+
+    func getError() -> Error? {
+        lock.lock()
+        defer { lock.unlock() }
+        return error
+    }
+}

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Publisher.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Publisher.swift
@@ -1,0 +1,178 @@
+// ZenohTransportSession+Publisher.swift
+// Publisher creation and the ZenohTransportPublisher concrete type.
+
+import Foundation
+import SwiftROS2Wire
+
+extension ZenohTransportSession {
+    public func createPublisher(
+        topic: String,
+        typeName: String,
+        typeHash: String?,
+        qos: TransportQoS
+    ) throws -> any TransportPublisher {
+        guard isConnected else {
+            throw TransportError.notConnected
+        }
+
+        guard let config = config else {
+            throw TransportError.notConnected
+        }
+
+        let wireMode = resolvedWireMode ?? (typeHash != nil ? .jazzy : .humble)
+        let codec = ZenohWireCodec(distro: wireMode)
+
+        let effectiveTypeHash: String?
+        if wireMode.supportsTypeHash {
+            effectiveTypeHash = typeHash
+        } else {
+            effectiveTypeHash = nil
+        }
+
+        let keyExpr = codec.makeKeyExpr(
+            domainId: config.domainId,
+            namespace: extractNamespace(from: topic),
+            topic: extractTopicName(from: topic),
+            typeName: typeName,
+            typeHash: effectiveTypeHash ?? wireMode.typeHashPlaceholder
+        )
+
+        // Declare key expression
+        let declaredKey: any ZenohKeyExprHandle
+        do {
+            declaredKey = try client.declareKeyExpr(keyExpr)
+        } catch let error as ZenohError {
+            throw TransportError.publisherCreationFailed(error.localizedDescription ?? "Key declaration failed")
+        }
+
+        // Create liveliness token for ROS 2 discovery
+        let sid = (try? client.getSessionId()) ?? "unknown"
+        let nodeId = String(entityManager.getNextEntityId())
+        let entityId = String(entityManager.getNextEntityId())
+        let nodeName = "ios_\(extractTopicName(from: topic))_node"
+
+        let qosPolicy = qos.toQoSPolicy()
+        let livelinessKeyExpr = codec.makeLivelinessToken(
+            domainId: config.domainId,
+            sessionId: sid,
+            nodeId: nodeId,
+            entityId: entityId,
+            namespace: extractNamespace(from: topic),
+            nodeName: nodeName,
+            topic: extractTopicName(from: topic),
+            typeName: typeName,
+            typeHash: effectiveTypeHash ?? wireMode.typeHashPlaceholder,
+            qos: qosPolicy
+        )
+
+        let livelinessToken: (any ZenohLivelinessTokenHandle)?
+        do {
+            livelinessToken = try client.declareLivelinessToken(livelinessKeyExpr)
+        } catch {
+            livelinessToken = nil
+        }
+
+        let gid = gidManager.getOrCreateGid()
+
+        let publisher = ZenohTransportPublisher(
+            client: client,
+            declaredKey: declaredKey,
+            livelinessToken: livelinessToken,
+            codec: codec,
+            gid: gid,
+            topic: topic
+        )
+
+        appendPublisher(publisher, for: topic)
+        return publisher
+    }
+
+    func appendPublisher(_ publisher: ZenohTransportPublisher, for topic: String) {
+        publishersLock.lock()
+        publishers[topic] = publisher
+        publishersLock.unlock()
+    }
+
+    func takeAllPublishers() -> [ZenohTransportPublisher] {
+        publishersLock.lock()
+        let pubs = Array(publishers.values)
+        publishers.removeAll()
+        publishersLock.unlock()
+        return pubs
+    }
+}
+
+// MARK: - Zenoh Transport Publisher
+
+/// TransportPublisher using Zenoh
+public final class ZenohTransportPublisher: TransportPublisher, @unchecked Sendable {
+    private let client: any ZenohClientProtocol
+    private var declaredKey: (any ZenohKeyExprHandle)?
+    private var livelinessToken: (any ZenohLivelinessTokenHandle)?
+    private let codec: ZenohWireCodec
+    private let gid: [UInt8]
+    public let topic: String
+    private let lock = NSLock()
+    private var closed = false
+
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed && declaredKey != nil
+    }
+
+    init(
+        client: any ZenohClientProtocol,
+        declaredKey: any ZenohKeyExprHandle,
+        livelinessToken: (any ZenohLivelinessTokenHandle)?,
+        codec: ZenohWireCodec,
+        gid: [UInt8],
+        topic: String
+    ) {
+        self.client = client
+        self.declaredKey = declaredKey
+        self.livelinessToken = livelinessToken
+        self.codec = codec
+        self.gid = gid
+        self.topic = topic
+    }
+
+    public func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws {
+        lock.lock()
+        guard !closed, let key = declaredKey else {
+            lock.unlock()
+            throw TransportError.publisherClosed
+        }
+        lock.unlock()
+
+        let attachment = codec.buildAttachment(
+            seq: sequenceNumber,
+            tsNsec: Int64(bitPattern: timestamp),
+            gid: gid
+        )
+
+        do {
+            try client.put(keyExpr: key, payload: data, attachment: attachment)
+        } catch let error as ZenohError {
+            if case .sessionDisconnected = error {
+                throw TransportError.sessionUnhealthy(error.localizedDescription ?? "Disconnected")
+            }
+            throw TransportError.publishFailed(error.localizedDescription ?? "Put failed")
+        }
+    }
+
+    public func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let token = livelinessToken
+        livelinessToken = nil
+        declaredKey = nil
+        lock.unlock()
+
+        try? token?.close()
+    }
+}

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Publisher.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Publisher.swift
@@ -87,7 +87,7 @@ extension ZenohTransportSession {
         return publisher
     }
 
-    func appendPublisher(_ publisher: ZenohTransportPublisher, for topic: String) {
+    private func appendPublisher(_ publisher: ZenohTransportPublisher, for topic: String) {
         publishersLock.lock()
         publishers[topic] = publisher
         publishersLock.unlock()

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Subscriber.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Subscriber.swift
@@ -1,0 +1,75 @@
+// ZenohTransportSession+Subscriber.swift
+// Subscriber creation and the ZenohTransportSubscriberWrapper concrete type.
+
+import Foundation
+import SwiftROS2Wire
+
+extension ZenohTransportSession {
+    public func createSubscriber(
+        topic: String,
+        typeName: String,
+        typeHash: String?,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any TransportSubscriber {
+        guard isConnected else {
+            throw TransportError.notConnected
+        }
+
+        guard let config = config else {
+            throw TransportError.notConnected
+        }
+
+        let wireMode = resolvedWireMode ?? .jazzy
+        let codec = ZenohWireCodec(distro: wireMode)
+
+        let effectiveTypeHash: String?
+        if wireMode.supportsTypeHash {
+            effectiveTypeHash = typeHash
+        } else {
+            effectiveTypeHash = nil
+        }
+
+        let keyExpr = codec.makeKeyExpr(
+            domainId: config.domainId,
+            namespace: extractNamespace(from: topic),
+            topic: extractTopicName(from: topic),
+            typeName: typeName,
+            typeHash: effectiveTypeHash ?? wireMode.typeHashPlaceholder
+        )
+
+        let subHandle = try client.subscribe(keyExpr: keyExpr) { sample in
+            let timestampNs = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
+            handler(sample.payload, timestampNs)
+        }
+
+        return ZenohTransportSubscriberWrapper(handle: subHandle, topic: topic)
+    }
+}
+
+// MARK: - Zenoh Transport Subscriber Wrapper
+
+final class ZenohTransportSubscriberWrapper: TransportSubscriber, @unchecked Sendable {
+    private let handle: any ZenohSubscriberHandle
+    public let topic: String
+    private var _isActive = true
+    private let lock = NSLock()
+
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _isActive
+    }
+
+    init(handle: any ZenohSubscriberHandle, topic: String) {
+        self.handle = handle
+        self.topic = topic
+    }
+
+    public func close() throws {
+        lock.lock()
+        _isActive = false
+        lock.unlock()
+        try handle.close()
+    }
+}

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Subscriber.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Subscriber.swift
@@ -49,7 +49,7 @@ extension ZenohTransportSession {
 
 // MARK: - Zenoh Transport Subscriber Wrapper
 
-final class ZenohTransportSubscriberWrapper: TransportSubscriber, @unchecked Sendable {
+private final class ZenohTransportSubscriberWrapper: TransportSubscriber, @unchecked Sendable {
     private let handle: any ZenohSubscriberHandle
     public let topic: String
     private var _isActive = true

--- a/Sources/SwiftROS2Transport/ZenohTransportSession.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession.swift
@@ -414,31 +414,3 @@ final class ZenohTransportSubscriberWrapper: TransportSubscriber, @unchecked Sen
         try handle.close()
     }
 }
-
-// MARK: - TransportQoS → QoSPolicy Conversion
-
-extension TransportQoS {
-    /// Convert to wire-level QoSPolicy for liveliness token encoding
-    public func toQoSPolicy() -> QoSPolicy {
-        let rel: QoSPolicy.Reliability = self.reliability == .reliable ? .reliable : .bestEffort
-        let dur: QoSPolicy.Durability = self.durability == .transientLocal ? .transientLocal : .volatile
-        let hist: QoSPolicy.HistoryPolicy
-        let depth: Int
-
-        switch self.history {
-        case .keepLast(let n):
-            hist = .keepLast
-            depth = n
-        case .keepAll:
-            hist = .keepAll
-            depth = 1000
-        }
-
-        return QoSPolicy(
-            reliability: rel,
-            durability: dur,
-            historyPolicy: hist,
-            historyDepth: depth
-        )
-    }
-}

--- a/Sources/SwiftROS2Transport/ZenohTransportSession.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession.swift
@@ -14,7 +14,7 @@ import SwiftROS2Wire
 /// The client protocol is injected at construction time, allowing the
 /// consuming app (e.g., Conduit) to provide its own C bridge wrapper.
 public final class ZenohTransportSession: TransportSession, @unchecked Sendable {
-    private let client: any ZenohClientProtocol
+    let client: any ZenohClientProtocol
     private var config: TransportConfig?
     private var publishers: [String: ZenohTransportPublisher] = [:]
     private let lock = NSLock()
@@ -78,32 +78,6 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
             throw TransportError.connectionFailed(error.localizedDescription ?? "Zenoh connection failed")
         } catch let error as TransportError {
             throw error
-        }
-    }
-
-    private func connectWithTimeout(locator: String, timeout: TimeInterval) async throws {
-        let result = ConnectionResult()
-        let client = self.client
-
-        DispatchQueue.global(qos: .userInitiated).async {
-            do {
-                try client.open(locator: locator)
-                result.setCompleted()
-            } catch {
-                result.setError(error)
-            }
-        }
-
-        let startTime = Date()
-        while !result.isCompleted() {
-            if Date().timeIntervalSince(startTime) > timeout {
-                throw TransportError.connectionTimeout(timeout)
-            }
-            try await Task.sleep(nanoseconds: 50_000_000)  // 50ms polling
-        }
-
-        if let error = result.getError() {
-            throw TransportError.connectionFailed(error.localizedDescription)
         }
     }
 
@@ -277,39 +251,6 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
     private func extractTopicName(from topic: String) -> String {
         let components = topic.split(separator: "/").map(String.init)
         return components.last ?? topic
-    }
-}
-
-// MARK: - Connection Result (Thread-safe)
-
-final class ConnectionResult: @unchecked Sendable {
-    private var error: Error?
-    private var completed = false
-    private let lock = NSLock()
-
-    func setCompleted() {
-        lock.lock()
-        completed = true
-        lock.unlock()
-    }
-
-    func setError(_ err: Error) {
-        lock.lock()
-        error = err
-        completed = true
-        lock.unlock()
-    }
-
-    func isCompleted() -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return completed
-    }
-
-    func getError() -> Error? {
-        lock.lock()
-        defer { lock.unlock() }
-        return error
     }
 }
 

--- a/Sources/SwiftROS2Transport/ZenohTransportSession.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession.swift
@@ -15,7 +15,7 @@ import SwiftROS2Wire
 /// consuming app (e.g., Conduit) to provide its own C bridge wrapper.
 public final class ZenohTransportSession: TransportSession, @unchecked Sendable {
     let client: any ZenohClientProtocol
-    private var config: TransportConfig?
+    var config: TransportConfig?
     private var publishers: [String: ZenohTransportPublisher] = [:]
     private let lock = NSLock()
     private let entityManager: EntityManager
@@ -179,47 +179,6 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
         return publisher
     }
 
-    public func createSubscriber(
-        topic: String,
-        typeName: String,
-        typeHash: String?,
-        qos: TransportQoS,
-        handler: @escaping @Sendable (Data, UInt64) -> Void
-    ) throws -> any TransportSubscriber {
-        guard isConnected else {
-            throw TransportError.notConnected
-        }
-
-        guard let config = config else {
-            throw TransportError.notConnected
-        }
-
-        let wireMode = resolvedWireMode ?? .jazzy
-        let codec = ZenohWireCodec(distro: wireMode)
-
-        let effectiveTypeHash: String?
-        if wireMode.supportsTypeHash {
-            effectiveTypeHash = typeHash
-        } else {
-            effectiveTypeHash = nil
-        }
-
-        let keyExpr = codec.makeKeyExpr(
-            domainId: config.domainId,
-            namespace: extractNamespace(from: topic),
-            topic: extractTopicName(from: topic),
-            typeName: typeName,
-            typeHash: effectiveTypeHash ?? wireMode.typeHashPlaceholder
-        )
-
-        let subHandle = try client.subscribe(keyExpr: keyExpr) { sample in
-            let timestampNs = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
-            handler(sample.payload, timestampNs)
-        }
-
-        return ZenohTransportSubscriberWrapper(handle: subHandle, topic: topic)
-    }
-
     public func checkHealth() -> Bool {
         client.isSessionHealthy()
     }
@@ -240,7 +199,7 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
         return pubs
     }
 
-    private func extractNamespace(from topic: String) -> String {
+    func extractNamespace(from topic: String) -> String {
         let components = topic.split(separator: "/").map(String.init)
         if components.count > 1 {
             return "/" + components.dropLast().joined(separator: "/")
@@ -248,7 +207,7 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
         return "/"
     }
 
-    private func extractTopicName(from topic: String) -> String {
+    func extractTopicName(from topic: String) -> String {
         let components = topic.split(separator: "/").map(String.init)
         return components.last ?? topic
     }
@@ -326,32 +285,5 @@ public final class ZenohTransportPublisher: TransportPublisher, @unchecked Senda
         lock.unlock()
 
         try? token?.close()
-    }
-}
-
-// MARK: - Zenoh Transport Subscriber Wrapper
-
-final class ZenohTransportSubscriberWrapper: TransportSubscriber, @unchecked Sendable {
-    private let handle: any ZenohSubscriberHandle
-    public let topic: String
-    private var _isActive = true
-    private let lock = NSLock()
-
-    public var isActive: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return _isActive
-    }
-
-    init(handle: any ZenohSubscriberHandle, topic: String) {
-        self.handle = handle
-        self.topic = topic
-    }
-
-    public func close() throws {
-        lock.lock()
-        _isActive = false
-        lock.unlock()
-        try handle.close()
     }
 }

--- a/Sources/SwiftROS2Transport/ZenohTransportSession.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession.swift
@@ -16,10 +16,10 @@ import SwiftROS2Wire
 public final class ZenohTransportSession: TransportSession, @unchecked Sendable {
     let client: any ZenohClientProtocol
     var config: TransportConfig?
-    private var publishers: [String: ZenohTransportPublisher] = [:]
-    private let lock = NSLock()
-    private let entityManager: EntityManager
-    private let gidManager: GIDManager
+    var publishers: [String: ZenohTransportPublisher] = [:]
+    let publishersLock = NSLock()
+    let entityManager: EntityManager
+    let gidManager: GIDManager
 
     /// Detected or configured wire mode (set after open)
     public private(set) var resolvedWireMode: ROS2Distro?
@@ -97,107 +97,11 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
         config = nil
     }
 
-    public func createPublisher(
-        topic: String,
-        typeName: String,
-        typeHash: String?,
-        qos: TransportQoS
-    ) throws -> any TransportPublisher {
-        guard isConnected else {
-            throw TransportError.notConnected
-        }
-
-        guard let config = config else {
-            throw TransportError.notConnected
-        }
-
-        let wireMode = resolvedWireMode ?? (typeHash != nil ? .jazzy : .humble)
-        let codec = ZenohWireCodec(distro: wireMode)
-
-        let effectiveTypeHash: String?
-        if wireMode.supportsTypeHash {
-            effectiveTypeHash = typeHash
-        } else {
-            effectiveTypeHash = nil
-        }
-
-        let keyExpr = codec.makeKeyExpr(
-            domainId: config.domainId,
-            namespace: extractNamespace(from: topic),
-            topic: extractTopicName(from: topic),
-            typeName: typeName,
-            typeHash: effectiveTypeHash ?? wireMode.typeHashPlaceholder
-        )
-
-        // Declare key expression
-        let declaredKey: any ZenohKeyExprHandle
-        do {
-            declaredKey = try client.declareKeyExpr(keyExpr)
-        } catch let error as ZenohError {
-            throw TransportError.publisherCreationFailed(error.localizedDescription ?? "Key declaration failed")
-        }
-
-        // Create liveliness token for ROS 2 discovery
-        let sid = (try? client.getSessionId()) ?? "unknown"
-        let nodeId = String(entityManager.getNextEntityId())
-        let entityId = String(entityManager.getNextEntityId())
-        let nodeName = "ios_\(extractTopicName(from: topic))_node"
-
-        let qosPolicy = qos.toQoSPolicy()
-        let livelinessKeyExpr = codec.makeLivelinessToken(
-            domainId: config.domainId,
-            sessionId: sid,
-            nodeId: nodeId,
-            entityId: entityId,
-            namespace: extractNamespace(from: topic),
-            nodeName: nodeName,
-            topic: extractTopicName(from: topic),
-            typeName: typeName,
-            typeHash: effectiveTypeHash ?? wireMode.typeHashPlaceholder,
-            qos: qosPolicy
-        )
-
-        let livelinessToken: (any ZenohLivelinessTokenHandle)?
-        do {
-            livelinessToken = try client.declareLivelinessToken(livelinessKeyExpr)
-        } catch {
-            livelinessToken = nil
-        }
-
-        let gid = gidManager.getOrCreateGid()
-
-        let publisher = ZenohTransportPublisher(
-            client: client,
-            declaredKey: declaredKey,
-            livelinessToken: livelinessToken,
-            codec: codec,
-            gid: gid,
-            topic: topic
-        )
-
-        appendPublisher(publisher, for: topic)
-        return publisher
-    }
-
     public func checkHealth() -> Bool {
         client.isSessionHealthy()
     }
 
     // MARK: - Private Helpers
-
-    private func appendPublisher(_ publisher: ZenohTransportPublisher, for topic: String) {
-        lock.lock()
-        publishers[topic] = publisher
-        lock.unlock()
-    }
-
-    private func takeAllPublishers() -> [ZenohTransportPublisher] {
-        lock.lock()
-        let pubs = Array(publishers.values)
-        publishers.removeAll()
-        lock.unlock()
-        return pubs
-    }
 
     func extractNamespace(from topic: String) -> String {
         let components = topic.split(separator: "/").map(String.init)
@@ -210,80 +114,5 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
     func extractTopicName(from topic: String) -> String {
         let components = topic.split(separator: "/").map(String.init)
         return components.last ?? topic
-    }
-}
-
-// MARK: - Zenoh Transport Publisher
-
-/// TransportPublisher using Zenoh
-public final class ZenohTransportPublisher: TransportPublisher, @unchecked Sendable {
-    private let client: any ZenohClientProtocol
-    private var declaredKey: (any ZenohKeyExprHandle)?
-    private var livelinessToken: (any ZenohLivelinessTokenHandle)?
-    private let codec: ZenohWireCodec
-    private let gid: [UInt8]
-    public let topic: String
-    private let lock = NSLock()
-    private var closed = false
-
-    public var isActive: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return !closed && declaredKey != nil
-    }
-
-    init(
-        client: any ZenohClientProtocol,
-        declaredKey: any ZenohKeyExprHandle,
-        livelinessToken: (any ZenohLivelinessTokenHandle)?,
-        codec: ZenohWireCodec,
-        gid: [UInt8],
-        topic: String
-    ) {
-        self.client = client
-        self.declaredKey = declaredKey
-        self.livelinessToken = livelinessToken
-        self.codec = codec
-        self.gid = gid
-        self.topic = topic
-    }
-
-    public func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws {
-        lock.lock()
-        guard !closed, let key = declaredKey else {
-            lock.unlock()
-            throw TransportError.publisherClosed
-        }
-        lock.unlock()
-
-        let attachment = codec.buildAttachment(
-            seq: sequenceNumber,
-            tsNsec: Int64(bitPattern: timestamp),
-            gid: gid
-        )
-
-        do {
-            try client.put(keyExpr: key, payload: data, attachment: attachment)
-        } catch let error as ZenohError {
-            if case .sessionDisconnected = error {
-                throw TransportError.sessionUnhealthy(error.localizedDescription ?? "Disconnected")
-            }
-            throw TransportError.publishFailed(error.localizedDescription ?? "Put failed")
-        }
-    }
-
-    public func close() throws {
-        lock.lock()
-        guard !closed else {
-            lock.unlock()
-            return
-        }
-        closed = true
-        let token = livelinessToken
-        livelinessToken = nil
-        declaredKey = nil
-        lock.unlock()
-
-        try? token?.close()
     }
 }

--- a/Sources/SwiftROS2Transport/ZenohTransportSession.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession.swift
@@ -101,7 +101,7 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
         client.isSessionHealthy()
     }
 
-    // MARK: - Private Helpers
+    // MARK: - Topic Path Helpers
 
     func extractNamespace(from topic: String) -> String {
         let components = topic.split(separator: "/").map(String.init)


### PR DESCRIPTION
## Summary

Decomposes the 444-line `Sources/SwiftROS2Transport/ZenohTransportSession.swift` into five focused files in the same SPM target. Pure refactor — no public API change, no behavior change, no new tests.

## Resulting structure

```
Sources/SwiftROS2Transport/
├── ZenohTransportSession.swift            (118 lines: properties, init, open, close, checkHealth, namespace helpers)
├── ZenohTransportSession+Connection.swift (65 lines: connectWithTimeout + ConnectionResult helper)
├── ZenohTransportSession+Subscriber.swift (75 lines: createSubscriber + ZenohTransportSubscriberWrapper)
├── ZenohTransportSession+Publisher.swift  (178 lines: createPublisher + helpers + ZenohTransportPublisher)
└── TransportQoS+QoSPolicy.swift           (35 lines: relocated public extension)
```

`TransportQoS+QoSPolicy.swift` is not Zenoh-specific — it's a transport-agnostic conversion that the symmetric DDS extraction (next PR) will share.

## Access-modifier changes (module-internal only)

To let cross-file extensions compile, a minimum-necessary set of `ZenohTransportSession` members was demoted from `private` to default-internal: `client`, `config`, `extractNamespace`, `extractTopicName`, `publishers`, `entityManager`, `gidManager`. The `lock` property was renamed to `publishersLock` for clarity (it only ever guarded the `publishers` dictionary). The `private` members of `ZenohTransportPublisher` (a different class in the same file) were preserved through the move.

None of these changes affect the public API. Verified by `swift package diagnose-api-breaking-changes 0.6.0` reporting no breakages on all 7 targets.

## Why now

This is the first of nine PRs that prepare swift-ros2 for a 1.0.0 freeze. The next PR will perform the symmetric extraction on `DDSTransportSession.swift`. Subsequent PRs add unit-test coverage for Transport (currently 0% direct coverage), code-coverage CI gates, and DocC content.

## Test plan

- [x] `swift build` succeeds
- [x] `swift test --parallel` exits 0 with all 88 test items running
- [x] `swift package diagnose-api-breaking-changes 0.6.0` reports "No breaking changes detected" on all 7 targets
- [x] `swift format lint --strict` is clean over `Sources/SwiftROS2Transport/`
- [ ] CI green on macOS / Linux × 6 / Windows / Android × 2