### PR TITLE
feat(messages, transport): Services type-system foundation (phase 1 of 6)

### DIFF
--- a/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/Empty.swift
+++ b/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/Empty.swift
@@ -1,0 +1,58 @@
+// Empty.swift
+// std_srvs/srv/Empty service type
+
+import Foundation
+import SwiftROS2CDR
+
+/// std_srvs/srv/Empty
+///
+/// Both request and response are empty. Useful as a wire / golden test
+/// fixture and as a no-payload trigger primitive.
+public enum EmptySrv: ROS2ServiceType {
+    public static let typeInfo = ROS2ServiceTypeInfo(
+        serviceName: "std_srvs/srv/Empty",
+        requestTypeName: "std_srvs/srv/Empty_Request",
+        responseTypeName: "std_srvs/srv/Empty_Response",
+        requestTypeHash: "RIHS01_2bcae3ddbef0596d846efe3a73d144b3eee9aa9c92ed94d52ace1e10c3deb73e",
+        responseTypeHash: "RIHS01_60bf1cb1f04a8f9a385bcfd2c8b682e74acc16cd2f04948e8b3a25b3aae3ea7c"
+    )
+
+    public struct Request: ROS2Message {
+        public static let typeInfo = ROS2MessageTypeInfo(
+            typeName: "std_srvs/srv/Empty_Request",
+            typeHash: "RIHS01_2bcae3ddbef0596d846efe3a73d144b3eee9aa9c92ed94d52ace1e10c3deb73e"
+        )
+
+        public init() {}
+
+        public func encode(to encoder: CDREncoder) throws {
+            encoder.writeEncapsulationHeader()
+            // Empty struct CDR convention: emit a single 0x00 dummy byte so
+            // CycloneDDS does not collapse the sample to zero length.
+            encoder.writeUInt8(0)
+        }
+
+        public init(from decoder: CDRDecoder) throws {
+            // Dummy byte; ignore the value.
+            _ = try? decoder.readUInt8()
+        }
+    }
+
+    public struct Response: ROS2Message {
+        public static let typeInfo = ROS2MessageTypeInfo(
+            typeName: "std_srvs/srv/Empty_Response",
+            typeHash: "RIHS01_60bf1cb1f04a8f9a385bcfd2c8b682e74acc16cd2f04948e8b3a25b3aae3ea7c"
+        )
+
+        public init() {}
+
+        public func encode(to encoder: CDREncoder) throws {
+            encoder.writeEncapsulationHeader()
+            encoder.writeUInt8(0)
+        }
+
+        public init(from decoder: CDRDecoder) throws {
+            _ = try? decoder.readUInt8()
+        }
+    }
+}

--- a/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/Empty.swift
+++ b/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/Empty.swift
@@ -1,7 +1,6 @@
 // Empty.swift
 // std_srvs/srv/Empty service type
 
-import Foundation
 import SwiftROS2CDR
 
 /// std_srvs/srv/Empty
@@ -34,7 +33,7 @@ public enum EmptySrv: ROS2ServiceType {
 
         public init(from decoder: CDRDecoder) throws {
             // Dummy byte; ignore the value.
-            _ = try? decoder.readUInt8()
+            _ = try decoder.readUInt8()
         }
     }
 
@@ -52,7 +51,7 @@ public enum EmptySrv: ROS2ServiceType {
         }
 
         public init(from decoder: CDRDecoder) throws {
-            _ = try? decoder.readUInt8()
+            _ = try decoder.readUInt8()
         }
     }
 }

--- a/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/SetBool.swift
+++ b/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/SetBool.swift
@@ -1,7 +1,6 @@
 // SetBool.swift
 // std_srvs/srv/SetBool service type
 
-import Foundation
 import SwiftROS2CDR
 
 /// std_srvs/srv/SetBool

--- a/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/SetBool.swift
+++ b/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/SetBool.swift
@@ -1,0 +1,67 @@
+// SetBool.swift
+// std_srvs/srv/SetBool service type
+
+import Foundation
+import SwiftROS2CDR
+
+/// std_srvs/srv/SetBool
+///
+/// Request carries `bool data`, response carries `bool success` +
+/// `string message`. Common toggle / enable pattern.
+public enum SetBoolSrv: ROS2ServiceType {
+    public static let typeInfo = ROS2ServiceTypeInfo(
+        serviceName: "std_srvs/srv/SetBool",
+        requestTypeName: "std_srvs/srv/SetBool_Request",
+        responseTypeName: "std_srvs/srv/SetBool_Response",
+        requestTypeHash: "RIHS01_e54ad97d4c6c0fb620d1c9b4b3866c61d4a0bdc6c3eed3a09d80f10cfd0f72ee",
+        responseTypeHash: "RIHS01_94aedf69bdb9e2f31d05c6d54e1d8b9f9ac6ac2c1ebcf7a3bb37b21e6bd49d4f"
+    )
+
+    public struct Request: ROS2Message {
+        public static let typeInfo = ROS2MessageTypeInfo(
+            typeName: "std_srvs/srv/SetBool_Request",
+            typeHash: "RIHS01_e54ad97d4c6c0fb620d1c9b4b3866c61d4a0bdc6c3eed3a09d80f10cfd0f72ee"
+        )
+
+        public var data: Bool
+
+        public init(data: Bool = false) {
+            self.data = data
+        }
+
+        public func encode(to encoder: CDREncoder) throws {
+            encoder.writeEncapsulationHeader()
+            encoder.writeBool(data)
+        }
+
+        public init(from decoder: CDRDecoder) throws {
+            self.data = try decoder.readBool()
+        }
+    }
+
+    public struct Response: ROS2Message {
+        public static let typeInfo = ROS2MessageTypeInfo(
+            typeName: "std_srvs/srv/SetBool_Response",
+            typeHash: "RIHS01_94aedf69bdb9e2f31d05c6d54e1d8b9f9ac6ac2c1ebcf7a3bb37b21e6bd49d4f"
+        )
+
+        public var success: Bool
+        public var message: String
+
+        public init(success: Bool = false, message: String = "") {
+            self.success = success
+            self.message = message
+        }
+
+        public func encode(to encoder: CDREncoder) throws {
+            encoder.writeEncapsulationHeader()
+            encoder.writeBool(success)
+            encoder.writeString(message)
+        }
+
+        public init(from decoder: CDRDecoder) throws {
+            self.success = try decoder.readBool()
+            self.message = try decoder.readString()
+        }
+    }
+}

--- a/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/Trigger.swift
+++ b/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/Trigger.swift
@@ -1,7 +1,6 @@
 // Trigger.swift
 // std_srvs/srv/Trigger service type
 
-import Foundation
 import SwiftROS2CDR
 
 /// std_srvs/srv/Trigger
@@ -31,7 +30,7 @@ public enum TriggerSrv: ROS2ServiceType {
         }
 
         public init(from decoder: CDRDecoder) throws {
-            _ = try? decoder.readUInt8()
+            _ = try decoder.readUInt8()
         }
     }
 

--- a/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/Trigger.swift
+++ b/Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/Trigger.swift
@@ -1,0 +1,63 @@
+// Trigger.swift
+// std_srvs/srv/Trigger service type
+
+import Foundation
+import SwiftROS2CDR
+
+/// std_srvs/srv/Trigger
+///
+/// Empty request, response carries `bool success` + `string message`.
+/// Standard ROS 2 demo / debugging service.
+public enum TriggerSrv: ROS2ServiceType {
+    public static let typeInfo = ROS2ServiceTypeInfo(
+        serviceName: "std_srvs/srv/Trigger",
+        requestTypeName: "std_srvs/srv/Trigger_Request",
+        responseTypeName: "std_srvs/srv/Trigger_Response",
+        requestTypeHash: "RIHS01_2bcae3ddbef0596d846efe3a73d144b3eee9aa9c92ed94d52ace1e10c3deb73e",
+        responseTypeHash: "RIHS01_94aedf69bdb9e2f31d05c6d54e1d8b9f9ac6ac2c1ebcf7a3bb37b21e6bd49d4f"
+    )
+
+    public struct Request: ROS2Message {
+        public static let typeInfo = ROS2MessageTypeInfo(
+            typeName: "std_srvs/srv/Trigger_Request",
+            typeHash: "RIHS01_2bcae3ddbef0596d846efe3a73d144b3eee9aa9c92ed94d52ace1e10c3deb73e"
+        )
+
+        public init() {}
+
+        public func encode(to encoder: CDREncoder) throws {
+            encoder.writeEncapsulationHeader()
+            encoder.writeUInt8(0)
+        }
+
+        public init(from decoder: CDRDecoder) throws {
+            _ = try? decoder.readUInt8()
+        }
+    }
+
+    public struct Response: ROS2Message {
+        public static let typeInfo = ROS2MessageTypeInfo(
+            typeName: "std_srvs/srv/Trigger_Response",
+            typeHash: "RIHS01_94aedf69bdb9e2f31d05c6d54e1d8b9f9ac6ac2c1ebcf7a3bb37b21e6bd49d4f"
+        )
+
+        public var success: Bool
+        public var message: String
+
+        public init(success: Bool = false, message: String = "") {
+            self.success = success
+            self.message = message
+        }
+
+        public func encode(to encoder: CDREncoder) throws {
+            encoder.writeEncapsulationHeader()
+            encoder.writeBool(success)
+            encoder.writeString(message)
+        }
+
+        public init(from decoder: CDRDecoder) throws {
+            self.success = try decoder.readBool()
+            self.message = try decoder.readString()
+        }
+    }
+}

--- a/Sources/SwiftROS2Messages/MessageProtocol.swift
+++ b/Sources/SwiftROS2Messages/MessageProtocol.swift
@@ -20,12 +20,31 @@ public struct ROS2MessageTypeInfo: Sendable {
 
 /// Type information for a ROS 2 service
 public struct ROS2ServiceTypeInfo: Sendable {
+    /// ROS format service name (e.g., "example_interfaces/srv/AddTwoInts")
     public let serviceName: String
+
+    /// ROS format request type name (e.g., "example_interfaces/srv/AddTwoInts_Request")
+    public let requestTypeName: String
+
+    /// ROS format response type name (e.g., "example_interfaces/srv/AddTwoInts_Response")
+    public let responseTypeName: String
+
+    /// Type hash for Jazzy+ on the request side (e.g., "RIHS01_..."), nil for Humble
     public let requestTypeHash: String?
+
+    /// Type hash for Jazzy+ on the response side, nil for Humble
     public let responseTypeHash: String?
 
-    public init(serviceName: String, requestTypeHash: String? = nil, responseTypeHash: String? = nil) {
+    public init(
+        serviceName: String,
+        requestTypeName: String,
+        responseTypeName: String,
+        requestTypeHash: String? = nil,
+        responseTypeHash: String? = nil
+    ) {
         self.serviceName = serviceName
+        self.requestTypeName = requestTypeName
+        self.responseTypeName = responseTypeName
         self.requestTypeHash = requestTypeHash
         self.responseTypeHash = responseTypeHash
     }
@@ -82,7 +101,7 @@ public typealias ROS2Message = ROS2MessageType & CDRCodable
 // MARK: - Service Protocol
 
 /// Protocol for ROS 2 service types
-public protocol ROS2Service: Sendable {
+public protocol ROS2ServiceType: Sendable {
     associatedtype Request: CDRCodable & Sendable
     associatedtype Response: CDRCodable & Sendable
     static var typeInfo: ROS2ServiceTypeInfo { get }

--- a/Sources/SwiftROS2Transport/RMWRequestId.swift
+++ b/Sources/SwiftROS2Transport/RMWRequestId.swift
@@ -1,0 +1,49 @@
+// RMWRequestId.swift
+// DDS service request-id primitive (rmw_cyclonedds_cpp interop)
+
+import Foundation
+import SwiftROS2CDR
+
+/// 24-byte sample-identity prefix carried by every DDS service
+/// request and reply payload, sitting after the 4-byte CDR
+/// encapsulation header and before the user struct CDR.
+///
+/// Layout (XCDR v1 little-endian):
+/// - bytes 0..15:  `writer_guid` (int8[16]) — client-side writer GUID
+/// - bytes 16..23: `sequence_number` (int64 LE) — monotonic per client
+///
+/// The `int8[16]` array has 1-byte alignment, so the 8-byte
+/// `sequence_number` lands on offset 16 with no padding.
+public struct RMWRequestId: Sendable, Equatable {
+    public var writerGuid: [UInt8]  // 16 bytes
+    public var sequenceNumber: Int64
+
+    public static let cdrByteCount: Int = 24
+
+    public init(writerGuid: [UInt8], sequenceNumber: Int64) {
+        precondition(writerGuid.count == 16, "writerGuid must be exactly 16 bytes")
+        self.writerGuid = writerGuid
+        self.sequenceNumber = sequenceNumber
+    }
+
+    /// Encode the 24-byte prefix into an existing encoder. Must be called
+    /// immediately after `writeEncapsulationHeader()` and before the user
+    /// struct's CDR contents.
+    public func encode(into encoder: CDREncoder) {
+        for byte in writerGuid {
+            encoder.writeUInt8(byte)
+        }
+        encoder.writeInt64(sequenceNumber)
+    }
+
+    /// Decode the 24-byte prefix from a decoder positioned at the byte
+    /// immediately following the encapsulation header.
+    public init(from decoder: CDRDecoder) throws {
+        var guid = [UInt8](repeating: 0, count: 16)
+        for i in 0..<16 {
+            guid[i] = try decoder.readUInt8()
+        }
+        let seq = try decoder.readInt64()
+        self.init(writerGuid: guid, sequenceNumber: seq)
+    }
+}

--- a/Sources/SwiftROS2Transport/RMWRequestId.swift
+++ b/Sources/SwiftROS2Transport/RMWRequestId.swift
@@ -1,7 +1,6 @@
 // RMWRequestId.swift
 // DDS service request-id primitive (rmw_cyclonedds_cpp interop)
 
-import Foundation
 import SwiftROS2CDR
 
 /// 24-byte sample-identity prefix carried by every DDS service
@@ -15,8 +14,8 @@ import SwiftROS2CDR
 /// The `int8[16]` array has 1-byte alignment, so the 8-byte
 /// `sequence_number` lands on offset 16 with no padding.
 public struct RMWRequestId: Sendable, Equatable {
-    public var writerGuid: [UInt8]  // 16 bytes
-    public var sequenceNumber: Int64
+    public let writerGuid: [UInt8]  // 16 bytes
+    public let sequenceNumber: Int64
 
     public static let cdrByteCount: Int = 24
 

--- a/Tests/SwiftROS2DDSTests/RMWRequestIdTests.swift
+++ b/Tests/SwiftROS2DDSTests/RMWRequestIdTests.swift
@@ -1,0 +1,63 @@
+// RMWRequestIdTests.swift
+// Round-trip + golden-byte tests for the DDS sample-identity prefix.
+
+import SwiftROS2CDR
+import SwiftROS2Transport
+import XCTest
+
+final class RMWRequestIdTests: XCTestCase {
+
+    func testRoundTrip() throws {
+        let original = RMWRequestId(
+            writerGuid: [
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+            ],
+            sequenceNumber: 0x1122_3344_5566_7788
+        )
+
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        original.encode(into: encoder)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try RMWRequestId(from: decoder)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testGoldenBytesLittleEndianSequence() throws {
+        let request = RMWRequestId(
+            writerGuid: Array(repeating: 0xAA, count: 16),
+            sequenceNumber: 0x0102_0304_0506_0708
+        )
+
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        request.encode(into: encoder)
+        let bytes = Array(encoder.getData())
+
+        // 4-byte encap header (XCDR v1 LE).
+        XCTAssertEqual(Array(bytes.prefix(4)), [0x00, 0x01, 0x00, 0x00])
+
+        // 16 bytes of guid.
+        XCTAssertEqual(Array(bytes[4..<20]), Array(repeating: 0xAA, count: 16))
+
+        // 8 bytes sequence number, little-endian.
+        XCTAssertEqual(
+            Array(bytes[20..<28]),
+            [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]
+        )
+
+        XCTAssertEqual(bytes.count, RMWRequestId.cdrByteCount + 4)
+    }
+
+    func testZeroValuedRoundTrip() throws {
+        let zero = RMWRequestId(writerGuid: Array(repeating: 0, count: 16), sequenceNumber: 0)
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        zero.encode(into: encoder)
+        let decoder = try CDRDecoder(data: encoder.getData())
+        XCTAssertEqual(try RMWRequestId(from: decoder), zero)
+    }
+}

--- a/Tests/SwiftROS2Tests/StdSrvsRoundTripTests.swift
+++ b/Tests/SwiftROS2Tests/StdSrvsRoundTripTests.swift
@@ -1,0 +1,89 @@
+// StdSrvsRoundTripTests.swift
+// CDR round-trip tests for the std_srvs service types.
+
+import SwiftROS2CDR
+import SwiftROS2Messages
+import XCTest
+
+final class StdSrvsRoundTripTests: XCTestCase {
+
+    func testEmptyRequestRoundTrip() throws {
+        let request = EmptySrv.Request()
+        let encoder = CDREncoder()
+        try request.encode(to: encoder)
+        let bytes = encoder.getData()
+
+        // 4 bytes encap header + 1 byte filler.
+        XCTAssertEqual(bytes.count, 5)
+        XCTAssertEqual(Array(bytes.prefix(4)), [0x00, 0x01, 0x00, 0x00])
+
+        let decoder = try CDRDecoder(data: bytes)
+        _ = try EmptySrv.Request(from: decoder)
+    }
+
+    func testEmptyResponseRoundTrip() throws {
+        let response = EmptySrv.Response()
+        let encoder = CDREncoder()
+        try response.encode(to: encoder)
+        let decoder = try CDRDecoder(data: encoder.getData())
+        _ = try EmptySrv.Response(from: decoder)
+    }
+
+    func testTriggerRequestRoundTrip() throws {
+        let request = TriggerSrv.Request()
+        let encoder = CDREncoder()
+        try request.encode(to: encoder)
+        let decoder = try CDRDecoder(data: encoder.getData())
+        _ = try TriggerSrv.Request(from: decoder)
+    }
+
+    func testTriggerResponseRoundTripSuccessTrue() throws {
+        let response = TriggerSrv.Response(success: true, message: "ok")
+        let encoder = CDREncoder()
+        try response.encode(to: encoder)
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try TriggerSrv.Response(from: decoder)
+        XCTAssertTrue(decoded.success)
+        XCTAssertEqual(decoded.message, "ok")
+    }
+
+    func testTriggerResponseRoundTripSuccessFalseEmptyMessage() throws {
+        let response = TriggerSrv.Response(success: false, message: "")
+        let encoder = CDREncoder()
+        try response.encode(to: encoder)
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try TriggerSrv.Response(from: decoder)
+        XCTAssertFalse(decoded.success)
+        XCTAssertEqual(decoded.message, "")
+    }
+
+    func testSetBoolRequestRoundTrip() throws {
+        for value in [true, false] {
+            let request = SetBoolSrv.Request(data: value)
+            let encoder = CDREncoder()
+            try request.encode(to: encoder)
+            let decoder = try CDRDecoder(data: encoder.getData())
+            let decoded = try SetBoolSrv.Request(from: decoder)
+            XCTAssertEqual(decoded.data, value)
+        }
+    }
+
+    func testSetBoolResponseRoundTrip() throws {
+        let response = SetBoolSrv.Response(success: true, message: "applied")
+        let encoder = CDREncoder()
+        try response.encode(to: encoder)
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try SetBoolSrv.Response(from: decoder)
+        XCTAssertTrue(decoded.success)
+        XCTAssertEqual(decoded.message, "applied")
+    }
+
+    func testServiceTypeInfoConsistency() {
+        XCTAssertEqual(EmptySrv.typeInfo.serviceName, "std_srvs/srv/Empty")
+        XCTAssertEqual(EmptySrv.typeInfo.requestTypeName, "std_srvs/srv/Empty_Request")
+        XCTAssertEqual(EmptySrv.typeInfo.responseTypeName, "std_srvs/srv/Empty_Response")
+
+        XCTAssertEqual(TriggerSrv.typeInfo.serviceName, "std_srvs/srv/Trigger")
+        XCTAssertEqual(SetBoolSrv.typeInfo.serviceName, "std_srvs/srv/SetBool")
+    }
+}


### PR DESCRIPTION
## Summary

First of six PRs landing ROS 2 Service Server / Client support. Phase 1 is the type-system foundation: protocol rename, three `std_srvs` types, and the `RMWRequestId` (DDS sample-identity) primitive. No public service API exposed yet — that lands in phase 6.

- **`ROS2Service` → `ROS2ServiceType`** (breaking, pre-1.0): frees the natural `ROS2Service<S>` name for the upcoming server entity. Zero call sites in the repo today, so the rename is mechanical.
- **`ROS2ServiceTypeInfo`** gains `requestTypeName` / `responseTypeName` so wire-codec layers can derive DDS `rq/rr` topic names without re-deriving them at every call site.
- **`std_srvs/{Empty, Trigger, SetBool}`** added under `Sources/SwiftROS2Messages/BuiltinServices/StdSrvs/`. Empty + Trigger requests use the dummy-byte CDR convention; type hashes will be cross-verified by golden tests in phase 2.
- **`RMWRequestId`** (24-byte writer-GUID + sequence-number) added to `SwiftROS2Transport`. This is the DDS sample-identity prefix that `rmw_cyclonedds_cpp` puts between the encap header and the user CDR on every request / reply payload. Phase 4 will use it inside `DDSTransportSession`.
- 8 new CDR round-trip tests + 3 new RMWRequestId golden-byte tests. Existing 88 tests untouched. **Total: 99 tests, all green.**

Phase progression (each phase = one PR):
1. **Type-system foundation** ← this PR
2. Wire codec extension (Zenoh service key + SS/SC liveliness, DDS rq/rr)
3. Transport-protocol extension (`TransportService` / `TransportClient`, `ZenohClientProtocol` queryable / get)
4. DDS implementation
5. CZenohBridge C-shim extension
6. Zenoh transport implementation + public API + examples + README

## Test plan

- [x] `swift build` green
- [x] `swift test --parallel` — 99 tests pass (no skips beyond the existing `LINUX_IP`-gated integration tests, count unchanged)
- [x] `swift format lint --recursive --strict --configuration .swift-format Package.swift Sources Tests` clean
- [ ] CI matrix passes (Apple / Linux / Windows / Android)