### PR TITLE
refactor(transport): split DDSTransportSession into focused files

### DIFF
--- a/Sources/SwiftROS2Transport/DDSTransportSession+Publisher.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Publisher.swift
@@ -1,0 +1,131 @@
+// DDSTransportSession+Publisher.swift
+// Publisher creation and the DDSTransportPublisherImpl concrete type.
+
+import Foundation
+import SwiftROS2Wire
+
+extension DDSTransportSession {
+    public func createPublisher(
+        topic: String,
+        typeName: String,
+        typeHash: String?,
+        qos: TransportQoS
+    ) throws -> any TransportPublisher {
+        guard !topic.isEmpty else {
+            throw TransportError.invalidConfiguration("Topic name cannot be empty")
+        }
+
+        guard !typeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Type name cannot be empty")
+        }
+
+        lock.lock()
+        guard _isOpen else {
+            lock.unlock()
+            throw TransportError.notConnected
+        }
+
+        if publishers[topic] != nil {
+            lock.unlock()
+            throw TransportError.publisherCreationFailed("Publisher already exists for topic: \(topic)")
+        }
+        lock.unlock()
+
+        // Convert ROS 2 names to DDS names
+        let ddsCodec = DDSWireCodec()
+        let ddsTopicName = ddsCodec.ddsTopic(from: topic)
+        let ddsTypeName = ddsCodec.ddsTypeName(from: typeName)
+        let userData = ddsCodec.userDataString(typeHash: typeHash)
+
+        // Build QoS
+        let cfg = bridgeQoS(from: qos)
+
+        let writerHandle = try client.createRawWriter(
+            topicName: ddsTopicName,
+            typeName: ddsTypeName,
+            qos: cfg,
+            userData: userData
+        )
+
+        let publisher = DDSTransportPublisherImpl(
+            client: client,
+            writer: writerHandle,
+            topic: topic
+        )
+
+        appendPublisher(publisher, for: topic)
+        return publisher
+    }
+
+    private func appendPublisher(_ publisher: DDSTransportPublisherImpl, for topic: String) {
+        lock.lock()
+        publishers[topic] = publisher
+        lock.unlock()
+    }
+
+    func takeAllPublishers() -> [DDSTransportPublisherImpl] {
+        lock.lock()
+        let pubs = Array(publishers.values)
+        publishers.removeAll()
+        lock.unlock()
+        return pubs
+    }
+}
+
+// MARK: - DDS Transport Publisher
+
+final class DDSTransportPublisherImpl: TransportPublisher, @unchecked Sendable {
+    private let client: any DDSClientProtocol
+    private var writer: (any DDSWriterHandle)?
+    public let topic: String
+    private let lock = NSLock()
+    private var closed = false
+
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if closed { return false }
+        return writer?.isActive ?? false
+    }
+
+    init(client: any DDSClientProtocol, writer: any DDSWriterHandle, topic: String) {
+        self.client = client
+        self.writer = writer
+        self.topic = topic
+    }
+
+    public func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws {
+        guard !data.isEmpty else {
+            throw TransportError.publishFailed("Data is empty")
+        }
+
+        guard data.count >= 4 else {
+            throw TransportError.publishFailed("Data too short: missing CDR encapsulation header")
+        }
+
+        lock.lock()
+        guard !closed, let w = writer else {
+            lock.unlock()
+            throw TransportError.publisherClosed
+        }
+        lock.unlock()
+
+        try client.writeRawCDR(writer: w, data: data, timestamp: timestamp)
+    }
+
+    public func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let w = writer
+        writer = nil
+        lock.unlock()
+
+        if let w = w {
+            client.destroyWriter(w)
+        }
+    }
+}

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Publisher.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Publisher.swift
@@ -20,7 +20,7 @@ extension DDSTransportSession {
         }
 
         lock.lock()
-        guard _isOpen else {
+        guard isOpen else {
             lock.unlock()
             throw TransportError.notConnected
         }

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Subscriber.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Subscriber.swift
@@ -1,0 +1,112 @@
+// DDSTransportSession+Subscriber.swift
+// Subscriber creation and the DDSTransportSubscriberImpl concrete type.
+
+import Foundation
+import SwiftROS2Wire
+
+extension DDSTransportSession {
+    public func createSubscriber(
+        topic: String,
+        typeName: String,
+        typeHash: String?,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any TransportSubscriber {
+        guard !topic.isEmpty else {
+            throw TransportError.invalidConfiguration("Topic name cannot be empty")
+        }
+        guard !typeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Type name cannot be empty")
+        }
+
+        lock.lock()
+        guard _isOpen else {
+            lock.unlock()
+            throw TransportError.notConnected
+        }
+        lock.unlock()
+
+        // Convert ROS 2 names to DDS names
+        let ddsCodec = DDSWireCodec()
+        let ddsTopicName = ddsCodec.ddsTopic(from: topic)
+        let ddsTypeName = ddsCodec.ddsTypeName(from: typeName)
+        let userData = ddsCodec.userDataString(typeHash: typeHash)
+
+        // Build QoS
+        let cfg = bridgeQoS(from: qos)
+
+        let readerHandle: any DDSReaderHandle
+        do {
+            readerHandle = try client.createRawReader(
+                topicName: ddsTopicName,
+                typeName: ddsTypeName,
+                qos: cfg,
+                userData: userData,
+                handler: handler
+            )
+        } catch let e as DDSError {
+            throw TransportError.subscriberCreationFailed(e.errorDescription ?? "\(e)")
+        }
+
+        let subscriber = DDSTransportSubscriberImpl(
+            client: client,
+            reader: readerHandle,
+            topic: topic
+        )
+        appendSubscriber(subscriber)
+        return subscriber
+    }
+
+    private func appendSubscriber(_ subscriber: DDSTransportSubscriberImpl) {
+        lock.lock()
+        subscribers.append(subscriber)
+        lock.unlock()
+    }
+
+    func takeAllSubscribers() -> [DDSTransportSubscriberImpl] {
+        lock.lock()
+        let subs = subscribers
+        subscribers.removeAll()
+        lock.unlock()
+        return subs
+    }
+}
+
+// MARK: - DDS Transport Subscriber
+
+final class DDSTransportSubscriberImpl: TransportSubscriber, @unchecked Sendable {
+    private let client: any DDSClientProtocol
+    private var reader: (any DDSReaderHandle)?
+    public let topic: String
+    private let lock = NSLock()
+    private var closed = false
+
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if closed { return false }
+        return reader?.isActive ?? false
+    }
+
+    init(client: any DDSClientProtocol, reader: any DDSReaderHandle, topic: String) {
+        self.client = client
+        self.reader = reader
+        self.topic = topic
+    }
+
+    public func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let r = reader
+        reader = nil
+        lock.unlock()
+
+        if let r = r {
+            client.destroyReader(r)
+        }
+    }
+}

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Subscriber.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Subscriber.swift
@@ -20,7 +20,7 @@ extension DDSTransportSession {
         }
 
         lock.lock()
-        guard _isOpen else {
+        guard isOpen else {
             lock.unlock()
             throw TransportError.notConnected
         }

--- a/Sources/SwiftROS2Transport/DDSTransportSession.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession.swift
@@ -100,7 +100,7 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
         client.isConnected()
     }
 
-    // MARK: - Private Helpers
+    // MARK: - Helpers
 
     func bridgeQoS(from qos: TransportQoS) -> DDSBridgeQoSConfig {
         DDSBridgeQoSConfig(

--- a/Sources/SwiftROS2Transport/DDSTransportSession.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession.swift
@@ -96,77 +96,11 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
         try client.destroySession()
     }
 
-    public func createPublisher(
-        topic: String,
-        typeName: String,
-        typeHash: String?,
-        qos: TransportQoS
-    ) throws -> any TransportPublisher {
-        guard !topic.isEmpty else {
-            throw TransportError.invalidConfiguration("Topic name cannot be empty")
-        }
-
-        guard !typeName.isEmpty else {
-            throw TransportError.invalidConfiguration("Type name cannot be empty")
-        }
-
-        lock.lock()
-        guard _isOpen else {
-            lock.unlock()
-            throw TransportError.notConnected
-        }
-
-        if publishers[topic] != nil {
-            lock.unlock()
-            throw TransportError.publisherCreationFailed("Publisher already exists for topic: \(topic)")
-        }
-        lock.unlock()
-
-        // Convert ROS 2 names to DDS names
-        let ddsCodec = DDSWireCodec()
-        let ddsTopicName = ddsCodec.ddsTopic(from: topic)
-        let ddsTypeName = ddsCodec.ddsTypeName(from: typeName)
-        let userData = ddsCodec.userDataString(typeHash: typeHash)
-
-        // Build QoS
-        let cfg = bridgeQoS(from: qos)
-
-        let writerHandle = try client.createRawWriter(
-            topicName: ddsTopicName,
-            typeName: ddsTypeName,
-            qos: cfg,
-            userData: userData
-        )
-
-        let publisher = DDSTransportPublisherImpl(
-            client: client,
-            writer: writerHandle,
-            topic: topic
-        )
-
-        appendPublisher(publisher, for: topic)
-        return publisher
-    }
-
     public func checkHealth() -> Bool {
         client.isConnected()
     }
 
     // MARK: - Private Helpers
-
-    private func appendPublisher(_ publisher: DDSTransportPublisherImpl, for topic: String) {
-        lock.lock()
-        publishers[topic] = publisher
-        lock.unlock()
-    }
-
-    private func takeAllPublishers() -> [DDSTransportPublisherImpl] {
-        lock.lock()
-        let pubs = Array(publishers.values)
-        publishers.removeAll()
-        lock.unlock()
-        return pubs
-    }
 
     func bridgeQoS(from qos: TransportQoS) -> DDSBridgeQoSConfig {
         DDSBridgeQoSConfig(
@@ -189,63 +123,5 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
 
     private func generateFallbackSessionId() -> String {
         UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "").prefix(32).description
-    }
-}
-
-// MARK: - DDS Transport Publisher
-
-final class DDSTransportPublisherImpl: TransportPublisher, @unchecked Sendable {
-    private let client: any DDSClientProtocol
-    private var writer: (any DDSWriterHandle)?
-    public let topic: String
-    private let lock = NSLock()
-    private var closed = false
-
-    public var isActive: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        if closed { return false }
-        return writer?.isActive ?? false
-    }
-
-    init(client: any DDSClientProtocol, writer: any DDSWriterHandle, topic: String) {
-        self.client = client
-        self.writer = writer
-        self.topic = topic
-    }
-
-    public func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws {
-        guard !data.isEmpty else {
-            throw TransportError.publishFailed("Data is empty")
-        }
-
-        guard data.count >= 4 else {
-            throw TransportError.publishFailed("Data too short: missing CDR encapsulation header")
-        }
-
-        lock.lock()
-        guard !closed, let w = writer else {
-            lock.unlock()
-            throw TransportError.publisherClosed
-        }
-        lock.unlock()
-
-        try client.writeRawCDR(writer: w, data: data, timestamp: timestamp)
-    }
-
-    public func close() throws {
-        lock.lock()
-        guard !closed else {
-            lock.unlock()
-            return
-        }
-        closed = true
-        let w = writer
-        writer = nil
-        lock.unlock()
-
-        if let w = w {
-            client.destroyWriter(w)
-        }
     }
 }

--- a/Sources/SwiftROS2Transport/DDSTransportSession.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession.swift
@@ -14,13 +14,13 @@ import SwiftROS2Wire
 /// The client protocol is injected at construction time, allowing the
 /// consuming app (e.g., Conduit) to provide its own CycloneDDS C bridge wrapper.
 public final class DDSTransportSession: TransportSession, @unchecked Sendable {
-    private let client: any DDSClientProtocol
+    let client: any DDSClientProtocol
     private var config: TransportConfig?
-    private var publishers: [String: DDSTransportPublisherImpl] = [:]
-    private var subscribers: [DDSTransportSubscriberImpl] = []
-    private let lock = NSLock()
+    var publishers: [String: DDSTransportPublisherImpl] = [:]
+    var subscribers: [DDSTransportSubscriberImpl] = []
+    let lock = NSLock()
     private var _sessionId: String = ""
-    private var _isOpen = false
+    var _isOpen = false
 
     public var transportType: TransportType { .dds }
 
@@ -148,58 +148,6 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
         return publisher
     }
 
-    public func createSubscriber(
-        topic: String,
-        typeName: String,
-        typeHash: String?,
-        qos: TransportQoS,
-        handler: @escaping @Sendable (Data, UInt64) -> Void
-    ) throws -> any TransportSubscriber {
-        guard !topic.isEmpty else {
-            throw TransportError.invalidConfiguration("Topic name cannot be empty")
-        }
-        guard !typeName.isEmpty else {
-            throw TransportError.invalidConfiguration("Type name cannot be empty")
-        }
-
-        lock.lock()
-        guard _isOpen else {
-            lock.unlock()
-            throw TransportError.notConnected
-        }
-        lock.unlock()
-
-        // Convert ROS 2 names to DDS names
-        let ddsCodec = DDSWireCodec()
-        let ddsTopicName = ddsCodec.ddsTopic(from: topic)
-        let ddsTypeName = ddsCodec.ddsTypeName(from: typeName)
-        let userData = ddsCodec.userDataString(typeHash: typeHash)
-
-        // Build QoS
-        let cfg = bridgeQoS(from: qos)
-
-        let readerHandle: any DDSReaderHandle
-        do {
-            readerHandle = try client.createRawReader(
-                topicName: ddsTopicName,
-                typeName: ddsTypeName,
-                qos: cfg,
-                userData: userData,
-                handler: handler
-            )
-        } catch let e as DDSError {
-            throw TransportError.subscriberCreationFailed(e.errorDescription ?? "\(e)")
-        }
-
-        let subscriber = DDSTransportSubscriberImpl(
-            client: client,
-            reader: readerHandle,
-            topic: topic
-        )
-        appendSubscriber(subscriber)
-        return subscriber
-    }
-
     public func checkHealth() -> Bool {
         client.isConnected()
     }
@@ -220,21 +168,7 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
         return pubs
     }
 
-    private func appendSubscriber(_ subscriber: DDSTransportSubscriberImpl) {
-        lock.lock()
-        subscribers.append(subscriber)
-        lock.unlock()
-    }
-
-    private func takeAllSubscribers() -> [DDSTransportSubscriberImpl] {
-        lock.lock()
-        let subs = subscribers
-        subscribers.removeAll()
-        lock.unlock()
-        return subs
-    }
-
-    private func bridgeQoS(from qos: TransportQoS) -> DDSBridgeQoSConfig {
+    func bridgeQoS(from qos: TransportQoS) -> DDSBridgeQoSConfig {
         DDSBridgeQoSConfig(
             reliability: qos.reliability == .reliable ? .reliable : .bestEffort,
             durability: qos.durability == .transientLocal ? .transientLocal : .volatile,
@@ -312,45 +246,6 @@ final class DDSTransportPublisherImpl: TransportPublisher, @unchecked Sendable {
 
         if let w = w {
             client.destroyWriter(w)
-        }
-    }
-}
-
-// MARK: - DDS Transport Subscriber
-
-final class DDSTransportSubscriberImpl: TransportSubscriber, @unchecked Sendable {
-    private let client: any DDSClientProtocol
-    private var reader: (any DDSReaderHandle)?
-    public let topic: String
-    private let lock = NSLock()
-    private var closed = false
-
-    public var isActive: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        if closed { return false }
-        return reader?.isActive ?? false
-    }
-
-    init(client: any DDSClientProtocol, reader: any DDSReaderHandle, topic: String) {
-        self.client = client
-        self.reader = reader
-        self.topic = topic
-    }
-
-    public func close() throws {
-        lock.lock()
-        guard !closed else {
-            lock.unlock()
-            return
-        }
-        closed = true
-        let r = reader
-        reader = nil
-        lock.unlock()
-
-        if let r = r {
-            client.destroyReader(r)
         }
     }
 }

--- a/Sources/SwiftROS2Transport/DDSTransportSession.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession.swift
@@ -20,14 +20,14 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
     var subscribers: [DDSTransportSubscriberImpl] = []
     let lock = NSLock()
     private var _sessionId: String = ""
-    var _isOpen = false
+    var isOpen = false
 
     public var transportType: TransportType { .dds }
 
     public var isConnected: Bool {
         lock.lock()
         defer { lock.unlock() }
-        return _isOpen && client.isConnected()
+        return isOpen && client.isConnected()
     }
 
     public var sessionId: String {
@@ -71,7 +71,7 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
 
         lock.lock()
         self.config = config
-        self._isOpen = true
+        self.isOpen = true
         self._sessionId = client.getSessionId() ?? generateFallbackSessionId()
         lock.unlock()
     }
@@ -88,7 +88,7 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
         }
 
         lock.lock()
-        _isOpen = false
+        isOpen = false
         _sessionId = ""
         config = nil
         lock.unlock()


### PR DESCRIPTION
## Summary

Decomposes the 356-line `Sources/SwiftROS2Transport/DDSTransportSession.swift` into three focused files in the same SPM target. Pure refactor — no public API change, no behavior change, no new tests.

Symmetric to #50, which performed the same split on `ZenohTransportSession.swift`.

## Resulting structure

```
Sources/SwiftROS2Transport/
├── DDSTransportSession.swift            (127 lines: properties, init, open, close, checkHealth, bridgeQoS, generateFallbackSessionId)
├── DDSTransportSession+Publisher.swift  (131 lines: createPublisher + appendPublisher + takeAllPublishers + DDSTransportPublisherImpl)
└── DDSTransportSession+Subscriber.swift (112 lines: createSubscriber + appendSubscriber + takeAllSubscribers + DDSTransportSubscriberImpl)
```

## Access-modifier changes (module-internal only)

To let cross-file extensions compile, the following `DDSTransportSession` members were demoted from `private` to default-internal: `client`, `publishers`, `subscribers`, `lock`, `_isOpen`, `bridgeQoS`. `config`, `_sessionId`, and `generateFallbackSessionId` stay `private` because only core-file methods touch them.

`appendPublisher` and `appendSubscriber` are `private` (each is called only from the same-file extension method). `takeAllPublishers` and `takeAllSubscribers` stay default-internal so `close()` in the core file can reach them.

`DDSTransportPublisherImpl` and `DDSTransportSubscriberImpl` stay default-internal (not `private`, unlike Zenoh's `ZenohTransportSubscriberWrapper`) because the core file's `publishers` dictionary and `subscribers` array reference them by name.

None of these changes affect the public API. Verified by `swift package diagnose-api-breaking-changes 0.6.0` reporting no breakages on all 7 targets.

## Test plan

- [x] `swift build` succeeds
- [x] `swift test --parallel` runs 88/88 tests
- [x] `swift package diagnose-api-breaking-changes 0.6.0` reports "No breaking changes detected" on all 7 targets
- [x] `swift format lint --strict` is clean over the whole tree
- [ ] CI green on macOS / Linux × 6 / Windows / Android × 2