### PR TITLE
fix(cdds): support cyclonedds 11 radmin header rename

### DIFF
--- a/Sources/CDDSBridge/raw_cdr_sertype.c
+++ b/Sources/CDDSBridge/raw_cdr_sertype.c
@@ -27,12 +27,12 @@
 #  include <dds/ddsi/ddsi_radmin.h>
 #  define RAW_CDR_RDATA_T struct ddsi_rdata
 #  define RAW_CDR_RMSG_PAYLOADOFF(m, o) DDSI_RMSG_PAYLOADOFF((m), (o))
-#  define RAW_CDR_RDATA_PAYLOAD_OFF(r) DDSI_RDATA_PAYLOAD_OFF(r)
+#  define RAW_CDR_RDATA_PAYLOAD_OFF(r) DDSI_RDATA_PAYLOAD_OFF((r))
 #else
 #  include <dds/ddsi/q_radmin.h>
 #  define RAW_CDR_RDATA_T struct nn_rdata
 #  define RAW_CDR_RMSG_PAYLOADOFF(m, o) NN_RMSG_PAYLOADOFF((m), (o))
-#  define RAW_CDR_RDATA_PAYLOAD_OFF(r) NN_RDATA_PAYLOAD_OFF(r)
+#  define RAW_CDR_RDATA_PAYLOAD_OFF(r) NN_RDATA_PAYLOAD_OFF((r))
 #endif
 
 // =============================================================================

--- a/Sources/CDDSBridge/raw_cdr_sertype.c
+++ b/Sources/CDDSBridge/raw_cdr_sertype.c
@@ -15,7 +15,25 @@
 #include <assert.h>
 #include <dds/ddsrt/heap.h>
 #include <dds/ddsrt/md5.h>
-#include <dds/ddsi/q_radmin.h>
+
+// CycloneDDS 11 (released 2026-04 in ros-rolling apt) renamed the receive-side
+// fragment-chain admin header from <dds/ddsi/q_radmin.h> to
+// <dds/ddsi/ddsi_radmin.h> and the type from `struct nn_rdata` to
+// `struct ddsi_rdata`. The struct fields (rmsg, nextfrag, min, maxp1) and the
+// payload macros (NN_*/DDSI_*) are otherwise identical. Pick the right header
+// at compile time so the same source builds against humble/jazzy (0.10.x) and
+// rolling (11.x).
+#if __has_include(<dds/ddsi/ddsi_radmin.h>)
+#  include <dds/ddsi/ddsi_radmin.h>
+#  define RAW_CDR_RDATA_T struct ddsi_rdata
+#  define RAW_CDR_RMSG_PAYLOADOFF(m, o) DDSI_RMSG_PAYLOADOFF((m), (o))
+#  define RAW_CDR_RDATA_PAYLOAD_OFF(r) DDSI_RDATA_PAYLOAD_OFF(r)
+#else
+#  include <dds/ddsi/q_radmin.h>
+#  define RAW_CDR_RDATA_T struct nn_rdata
+#  define RAW_CDR_RMSG_PAYLOADOFF(m, o) NN_RMSG_PAYLOADOFF((m), (o))
+#  define RAW_CDR_RDATA_PAYLOAD_OFF(r) NN_RDATA_PAYLOAD_OFF(r)
+#endif
 
 // =============================================================================
 // MARK: - Sertype Operations Implementation
@@ -146,7 +164,7 @@ static struct ddsi_serdata *raw_cdr_serdata_from_ser_iov(
 static struct ddsi_serdata *raw_cdr_serdata_from_ser(
     const struct ddsi_sertype *type,
     enum ddsi_serdata_kind kind,
-    const struct nn_rdata *fragchain,
+    const RAW_CDR_RDATA_T *fragchain,
     size_t size)
 {
     // Must have at least the 4-byte XCDR encapsulation header.
@@ -180,7 +198,7 @@ static struct ddsi_serdata *raw_cdr_serdata_from_ser(
         assert(fragchain->maxp1 <= size);
         if (fragchain->maxp1 > off) {
             const unsigned char *payload =
-                NN_RMSG_PAYLOADOFF(fragchain->rmsg, NN_RDATA_PAYLOAD_OFF(fragchain));
+                RAW_CDR_RMSG_PAYLOADOFF(fragchain->rmsg, RAW_CDR_RDATA_PAYLOAD_OFF(fragchain));
             memcpy(rd->cdr_data + off, payload + off - fragchain->min, fragchain->maxp1 - off);
             off = fragchain->maxp1;
         }


### PR DESCRIPTION
## Summary

CycloneDDS 11 (shipped to `ros-rolling` apt on 2026-04-24 as `11.0.1-1noble.20260424.195636`) renamed the receive-side fragment-chain admin header:

- `<dds/ddsi/q_radmin.h>` → `<dds/ddsi/ddsi_radmin.h>`
- `struct nn_rdata` → `struct ddsi_rdata`
- `NN_RMSG_PAYLOADOFF` / `NN_RDATA_PAYLOAD_OFF` → `DDSI_RMSG_PAYLOADOFF` / `DDSI_RDATA_PAYLOAD_OFF`

The struct fields (`rmsg`, `nextfrag`, `min`, `maxp1`, `payload_zoff`) and macro semantics are otherwise identical. A thin compile-time shim keyed off `__has_include` picks the right names without forking the fragment-chain walk in `raw_cdr_serdata_from_ser`.

This is option 2 ("adapt to the public 11 API") from #51 — the durable fix that also keeps downstream rolling users building.

## Why this is safe

| Path                                  | CycloneDDS version | Branch taken         |
| ------------------------------------- | ------------------ | -------------------- |
| Apple xcframework (Conduit, CI macOS) | 0.10.x             | `#else` (q_radmin)   |
| ros-humble-cyclonedds (Ubuntu 22.04)  | 0.10.x             | `#else` (q_radmin)   |
| ros-jazzy-cyclonedds (Ubuntu 24.04)   | 0.10.x             | `#else` (q_radmin)   |
| ros-rolling-cyclonedds (≥ 11.0.1)     | 11.x               | `#if`   (ddsi_radmin)|

`q_radmin.h` only exists in 0.10.x; `ddsi_radmin.h` only exists in 11.x — `__has_include` cleanly distinguishes them with no overlap.

## Refs

- Closes #51
- Failing run: https://github.com/youtalk/swift-ros2/actions/runs/25065270339

## Test plan

- [x] `swift build` on macOS (exercises the `q_radmin.h` branch)
- [x] `swift test --parallel` on macOS (no regressions; integration tests skipped without `LINUX_IP`)
- [ ] CI: rolling x86_64 + aarch64 (exercises the `ddsi_radmin.h` branch — primary target of this fix)
- [ ] CI: humble/jazzy x86_64 + aarch64 stay green
- [ ] CI: Windows + Android stay green (DDS family is compiled out on those arms)