### PR TITLE
chore: pin 0.6.1 release URL + xcframework checksums

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ let isLinuxBuild = targetOS == "linux"
 let isWindowsBuild = targetOS == "windows"
 let isAndroidBuild = targetOS == "android"
 
-let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.6.0"
+let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.6.1"
 
 // Non-unix zenoh-pico platform backends shared between the Linux and
 // Android arms — both use the unix backend inside `src/system/unix`.
@@ -123,7 +123,7 @@ let cZenohPico: Target = {
         return .binaryTarget(
             name: "CZenohPico",
             url: "\(releaseBaseURL)/CZenohPico.xcframework.zip",
-            checksum: "1e35069f923d2892680555c3c07d3cac864934ead3fbe2523b3767c222f41908"
+            checksum: "5e7ea4118a9a89929a5fb9840cd4d1907f9714c640af12f56c600a116a07283b"
         )
     }
 }()
@@ -235,7 +235,7 @@ if !isWindowsBuild && !isAndroidBuild {
             return .binaryTarget(
                 name: "CCycloneDDS",
                 url: "\(releaseBaseURL)/CCycloneDDS.xcframework.zip",
-                checksum: "e5cb2d358acb2682bace03aed0971cc5a92892cc58ef5416f9161b51b06c9c80"
+                checksum: "03ff41ba90f7e466dedef7cf2f092923035d9772ff7031ce88f0d79108b3f748"
             )
         }
     }()


### PR DESCRIPTION
## Summary

- Bump \`releaseBaseURL\` from \`0.6.0\` to \`0.6.1\` in \`Package.swift\`.
- Refresh both \`binaryTarget\` checksums against the freshly published 0.6.1 xcframework assets:
  - \`CZenohPico.xcframework.zip\` → \`5e7ea4118a9a89929a5fb9840cd4d1907f9714c640af12f56c600a116a07283b\`
  - \`CCycloneDDS.xcframework.zip\` → \`03ff41ba90f7e466dedef7cf2f092923035d9772ff7031ce88f0d79108b3f748\`

This is the final step of the 0.6.1 release flow described in \`CLAUDE.md\` — the tag, GitHub Release, and xcframework artifacts are already in place; this PR points \`Package.swift\` at them so downstream consumers (e.g. Conduit) can bump the submodule.

0.6.1 ships the CycloneDDS 11 fix from #51 / #55 — without this pin, downstream consumers can't pick it up.

## Test plan

- [x] \`swift package resolve\` fetches the new 0.6.1 artifacts and matches the pinned checksums
- [x] \`swift build\` succeeds against the new xcframeworks
- [x] \`swift format lint --strict\` clean
- [ ] CI matrix (macOS / Linux x86_64+aarch64 across humble/jazzy/rolling / Windows / Android) green