### PR TITLE
refactor(transport): extract AttachmentBuilder / TransportQoSMapper internal helpers

### DIFF
--- a/Sources/SwiftROS2Transport/DDSTransportSession.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession.swift
@@ -103,22 +103,7 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
     // MARK: - Helpers
 
     func bridgeQoS(from qos: TransportQoS) -> DDSBridgeQoSConfig {
-        DDSBridgeQoSConfig(
-            reliability: qos.reliability == .reliable ? .reliable : .bestEffort,
-            durability: qos.durability == .transientLocal ? .transientLocal : .volatile,
-            historyKind: {
-                switch qos.history {
-                case .keepLast: return .keepLast
-                case .keepAll: return .keepAll
-                }
-            }(),
-            historyDepth: {
-                switch qos.history {
-                case .keepLast(let n): return Int32(n)
-                case .keepAll: return 0
-                }
-            }()
-        )
+        TransportQoSMapper.toDDSBridgeQoSConfig(qos)
     }
 
     private func generateFallbackSessionId() -> String {

--- a/Sources/SwiftROS2Transport/Internal/TransportQoSMapper.swift
+++ b/Sources/SwiftROS2Transport/Internal/TransportQoSMapper.swift
@@ -1,0 +1,54 @@
+// TransportQoSMapper.swift
+// Internal mapping helpers from TransportQoS to wire and DDS-bridge QoS.
+//
+// Centralizes the three-way conversion so DDSTransportSession.bridgeQoS,
+// TransportQoS.toQoSPolicy, and any future consumer all share one
+// implementation. Internal — public callers go through the existing
+// public conversion methods.
+
+import SwiftROS2Wire
+
+enum TransportQoSMapper {
+    static func toWireQoSPolicy(_ qos: TransportQoS) -> QoSPolicy {
+        let rel: QoSPolicy.Reliability = qos.reliability == .reliable ? .reliable : .bestEffort
+        let dur: QoSPolicy.Durability = qos.durability == .transientLocal ? .transientLocal : .volatile
+        let hist: QoSPolicy.HistoryPolicy
+        let depth: Int
+
+        switch qos.history {
+        case .keepLast(let n):
+            hist = .keepLast
+            depth = n
+        case .keepAll:
+            hist = .keepAll
+            depth = 1000
+        }
+
+        return QoSPolicy(
+            reliability: rel,
+            durability: dur,
+            historyPolicy: hist,
+            historyDepth: depth
+        )
+    }
+
+    static func toDDSBridgeQoSConfig(_ qos: TransportQoS) -> DDSBridgeQoSConfig {
+        let kind: DDSBridgeQoSConfig.HistoryKind
+        let depth: Int32
+        switch qos.history {
+        case .keepLast(let n):
+            kind = .keepLast
+            depth = Int32(n)
+        case .keepAll:
+            kind = .keepAll
+            depth = 0
+        }
+
+        return DDSBridgeQoSConfig(
+            reliability: qos.reliability == .reliable ? .reliable : .bestEffort,
+            durability: qos.durability == .transientLocal ? .transientLocal : .volatile,
+            historyKind: kind,
+            historyDepth: depth
+        )
+    }
+}

--- a/Sources/SwiftROS2Transport/Internal/TransportQoSMapper.swift
+++ b/Sources/SwiftROS2Transport/Internal/TransportQoSMapper.swift
@@ -1,7 +1,7 @@
 // TransportQoSMapper.swift
 // Internal mapping helpers from TransportQoS to wire and DDS-bridge QoS.
 //
-// Centralizes the three-way conversion so DDSTransportSession.bridgeQoS,
+// Centralizes the shared mapping logic so DDSTransportSession.bridgeQoS,
 // TransportQoS.toQoSPolicy, and any future consumer all share one
 // implementation. Internal — public callers go through the existing
 // public conversion methods.

--- a/Sources/SwiftROS2Transport/TransportQoS+QoSPolicy.swift
+++ b/Sources/SwiftROS2Transport/TransportQoS+QoSPolicy.swift
@@ -1,34 +1,11 @@
 // TransportQoS+QoSPolicy.swift
 // Conversion from TransportQoS to wire-level QoSPolicy.
-//
-// Lives in SwiftROS2Transport because the conversion is consumed by
-// transport sessions when emitting liveliness tokens. The function
-// itself is a pure mapping and has no transport-specific logic.
 
 import SwiftROS2Wire
 
 extension TransportQoS {
     /// Convert to wire-level QoSPolicy for liveliness token encoding
     public func toQoSPolicy() -> QoSPolicy {
-        let rel: QoSPolicy.Reliability = self.reliability == .reliable ? .reliable : .bestEffort
-        let dur: QoSPolicy.Durability = self.durability == .transientLocal ? .transientLocal : .volatile
-        let hist: QoSPolicy.HistoryPolicy
-        let depth: Int
-
-        switch self.history {
-        case .keepLast(let n):
-            hist = .keepLast
-            depth = n
-        case .keepAll:
-            hist = .keepAll
-            depth = 1000
-        }
-
-        return QoSPolicy(
-            reliability: rel,
-            durability: dur,
-            historyPolicy: hist,
-            historyDepth: depth
-        )
+        TransportQoSMapper.toWireQoSPolicy(self)
     }
 }

--- a/Sources/SwiftROS2Wire/Internal/AttachmentBuilder.swift
+++ b/Sources/SwiftROS2Wire/Internal/AttachmentBuilder.swift
@@ -1,0 +1,37 @@
+// AttachmentBuilder.swift
+// Builds the 33-byte rmw_zenoh attachment blob.
+//
+// Pure-bytes helper kept internal to SwiftROS2Wire — exposed only via
+// ZenohWireCodec.buildAttachment. Lives in SwiftROS2Wire (not Transport)
+// to avoid a Wire → Transport dependency cycle.
+
+import Foundation
+
+/// Builds the 33-byte rmw_zenoh attachment payload.
+///
+/// Layout (Zenoh ext::Serializer format):
+/// - Bytes  0–7 : seq           (Int64 LE)
+/// - Bytes  8–15: timestamp_ns  (Int64 LE)
+/// - Byte   16  : 0x10          (LEB128 length prefix for 16-byte array)
+/// - Bytes 17–32: GID           (16 raw bytes)
+enum AttachmentBuilder {
+    /// Build the 33-byte attachment.
+    /// - Precondition: `gid.count == 16`.
+    static func build(seq: Int64, tsNsec: Int64, gid: [UInt8]) -> Data {
+        precondition(gid.count == 16, "Publisher GID must be exactly 16 bytes, got \(gid.count)")
+
+        var data = Data(capacity: 33)
+
+        var seqLE = seq.littleEndian
+        withUnsafeBytes(of: &seqLE) { data.append(contentsOf: $0) }
+
+        var tsLE = tsNsec.littleEndian
+        withUnsafeBytes(of: &tsLE) { data.append(contentsOf: $0) }
+
+        data.append(0x10)
+        data.append(contentsOf: gid)
+
+        assert(data.count == 33, "Attachment must be exactly 33 bytes")
+        return data
+    }
+}

--- a/Sources/SwiftROS2Wire/ZenohWireCodec.swift
+++ b/Sources/SwiftROS2Wire/ZenohWireCodec.swift
@@ -81,22 +81,6 @@ public struct ZenohWireCodec: WireCodec {
         tsNsec: Int64,
         gid: [UInt8]
     ) -> Data {
-        precondition(gid.count == 16, "Publisher GID must be exactly 16 bytes, got \(gid.count)")
-
-        var data = Data(capacity: 33)
-
-        var seqLE = seq.littleEndian
-        withUnsafeBytes(of: &seqLE) { data.append(contentsOf: $0) }
-
-        var tsLE = tsNsec.littleEndian
-        withUnsafeBytes(of: &tsLE) { data.append(contentsOf: $0) }
-
-        // LEB128 length prefix for 16-byte GID array
-        data.append(0x10)
-
-        data.append(contentsOf: gid)
-
-        assert(data.count == 33, "Attachment must be exactly 33 bytes")
-        return data
+        AttachmentBuilder.build(seq: seq, tsNsec: tsNsec, gid: gid)
     }
 }


### PR DESCRIPTION
## Summary

Pure refactor — moves duplicated / wedged logic into focused internal helpers without changing the public API or any observable behavior.

- **`AttachmentBuilder`** (new, in `Sources/SwiftROS2Wire/Internal/`): pure 33-byte rmw_zenoh attachment builder. `ZenohWireCodec.buildAttachment` is now a one-line delegation. Lives in `SwiftROS2Wire` (not `SwiftROS2Transport`) because the dependency direction is `Transport → Wire`, never the reverse.
- **`TransportQoSMapper`** (new, in `Sources/SwiftROS2Transport/Internal/`): centralizes the two `TransportQoS → ...` conversions. `TransportQoS.toQoSPolicy()` and `DDSTransportSession.bridgeQoS(from:)` now both delegate. The mapper preserves the historical `keepAll` depth split (`1000` for the wire path, `0` for the DDS-bridge path) bit-for-bit.

## Spec

- `docs/superpowers/specs/2026-04-28-swift-ros2-1.0.0-runway-design.md` §4.2
- §8 PR 3

## Verification

- `swift build` — clean.
- `swift test --parallel` — 99/99 pass, zero failures (same count as pre-refactor baseline).
- `swift format lint --recursive --strict` over `Sources/SwiftROS2Transport` and `Sources/SwiftROS2Wire` — clean.
- `swift package diagnose-api-breaking-changes 0.6.0` — no new breakages introduced. The 3 pre-existing breakages in `SwiftROS2Messages` (the `ROS2Service` → `ROS2ServiceType` rename from #52) are unchanged baseline.
- All three callers (`ZenohWireCodec.buildAttachment`, `TransportQoS.toQoSPolicy`, `DDSTransportSession.bridgeQoS`) delegate; no inline duplication remains.
- No file under `Internal/` declares any `public` symbol.

## Test plan

- [ ] CI: macOS, Linux (Humble/Jazzy/Rolling × x86_64/aarch64), Windows, Android matrices all green.
- [ ] Wire-format golden tests (`testAttachmentSize`, `testAttachmentFormat` in `WireCodecTests.swift`) pass — they exercise `AttachmentBuilder` through the existing public surface.