### PR TITLE
test(transport): session unit tests via mock Zenoh / DDS clients

### DIFF
--- a/Tests/SwiftROS2TransportTests/DDSTransportSessionTests.swift
+++ b/Tests/SwiftROS2TransportTests/DDSTransportSessionTests.swift
@@ -148,24 +148,19 @@ final class DDSTransportSessionTests: XCTestCase {
 
     func testSubscriberHandlerReceivesDeliveredSamples() async throws {
         let (session, client) = try await openSession()
-        let received = NSLock()
-        var captured: (Data, UInt64)?
+        let captured = Box<(Data, UInt64)?>(nil)
         _ = try session.createSubscriber(
             topic: "/x",
             typeName: "std_msgs/msg/String",
             typeHash: nil,
             qos: .sensorData
         ) { data, ts in
-            received.lock()
-            defer { received.unlock() }
-            captured = (data, ts)
+            captured.value = (data, ts)
         }
         client.deliver(toTopic: "rt/x", data: Data([0xAB, 0xCD]), timestamp: 99)
 
-        received.lock()
-        defer { received.unlock() }
-        XCTAssertEqual(captured?.0, Data([0xAB, 0xCD]))
-        XCTAssertEqual(captured?.1, 99)
+        XCTAssertEqual(captured.value?.0, Data([0xAB, 0xCD]))
+        XCTAssertEqual(captured.value?.1, 99)
     }
 
     func testCloseDestroysOutstandingWritersAndReaders() async throws {

--- a/Tests/SwiftROS2TransportTests/DDSTransportSessionTests.swift
+++ b/Tests/SwiftROS2TransportTests/DDSTransportSessionTests.swift
@@ -1,0 +1,189 @@
+import SwiftROS2Transport
+import XCTest
+
+final class DDSTransportSessionTests: XCTestCase {
+    private func openSession(
+        client: MockDDSClient = MockDDSClient()
+    ) async throws -> (DDSTransportSession, MockDDSClient) {
+        let session = DDSTransportSession(client: client)
+        try await session.open(config: TransportConfig.ddsMulticast(domainId: 0))
+        return (session, client)
+    }
+
+    // MARK: - open / close
+
+    func testOpenWithMismatchedTransportTypeThrows() async {
+        let session = DDSTransportSession(client: MockDDSClient())
+        do {
+            try await session.open(config: TransportConfig.zenoh(locator: "tcp/x:7447"))
+            XCTFail("Expected invalidConfiguration")
+        } catch TransportError.invalidConfiguration {
+            // ok
+        } catch {
+            XCTFail("Wrong error: \(error)")
+        }
+    }
+
+    func testOpenFailsWhenDDSUnavailable() async {
+        let client = MockDDSClient()
+        client.isAvailable = false
+        let session = DDSTransportSession(client: client)
+        do {
+            try await session.open(config: TransportConfig.ddsMulticast())
+            XCTFail("Expected unsupportedFeature")
+        } catch TransportError.unsupportedFeature {
+            // ok
+        } catch {
+            XCTFail("Wrong error: \(error)")
+        }
+    }
+
+    func testOpenCreatesSessionThroughClient() async throws {
+        let (session, client) = try await openSession()
+        XCTAssertTrue(session.isConnected)
+        XCTAssertEqual(client.sessionCreations.count, 1)
+        XCTAssertEqual(client.sessionCreations[0].domainId, 0)
+        XCTAssertEqual(client.sessionCreations[0].config.mode, .multicast)
+    }
+
+    func testOpenForwardsUnicastPeers() async throws {
+        let client = MockDDSClient()
+        let session = DDSTransportSession(client: client)
+        let peers = [DDSPeer(address: "10.0.0.5"), DDSPeer(address: "10.0.0.6")]
+        try await session.open(config: TransportConfig.ddsUnicast(peers: peers, domainId: 1))
+        XCTAssertEqual(client.sessionCreations[0].config.mode, .unicast)
+        XCTAssertEqual(client.sessionCreations[0].config.unicastPeers, ["10.0.0.5", "10.0.0.6"])
+    }
+
+    func testCloseDestroysSession() async throws {
+        let (session, client) = try await openSession()
+        try session.close()
+        XCTAssertEqual(client.sessionDestructions, 1)
+        XCTAssertFalse(session.isConnected)
+    }
+
+    // MARK: - createPublisher
+
+    func testCreatePublisherRegistersWriter() async throws {
+        let (session, client) = try await openSession()
+        let pub = try session.createPublisher(
+            topic: "/ios/imu",
+            typeName: "sensor_msgs/msg/Imu",
+            typeHash: "RIHS01_abc",
+            qos: .sensorData
+        )
+        XCTAssertTrue(pub.isActive)
+        XCTAssertEqual(client.writers.count, 1)
+        XCTAssertEqual(client.writers[0].topic, "rt/ios/imu")
+        XCTAssertEqual(client.writers[0].type, "sensor_msgs::msg::dds_::Imu_")
+        XCTAssertEqual(client.writers[0].userData, "typehash=RIHS01_abc;")
+    }
+
+    func testCreatePublisherRejectsEmptyTopic() async throws {
+        let (session, _) = try await openSession()
+        XCTAssertThrowsError(
+            try session.createPublisher(topic: "", typeName: "x", typeHash: nil, qos: .sensorData)
+        )
+    }
+
+    func testCreatePublisherRejectsDuplicateTopic() async throws {
+        let (session, _) = try await openSession()
+        _ = try session.createPublisher(
+            topic: "/x",
+            typeName: "std_msgs/msg/String",
+            typeHash: nil,
+            qos: .sensorData
+        )
+        XCTAssertThrowsError(
+            try session.createPublisher(topic: "/x", typeName: "std_msgs/msg/String", typeHash: nil, qos: .sensorData)
+        ) { error in
+            guard case TransportError.publisherCreationFailed = error else {
+                XCTFail("Wrong error: \(error)")
+                return
+            }
+        }
+    }
+
+    func testPublishRequiresMinimum4ByteCDRHeader() async throws {
+        let (session, _) = try await openSession()
+        let pub = try session.createPublisher(
+            topic: "/x",
+            typeName: "std_msgs/msg/String",
+            typeHash: nil,
+            qos: .sensorData
+        )
+        XCTAssertThrowsError(try pub.publish(data: Data([0x00, 0x01, 0x00]), timestamp: 0, sequenceNumber: 0))
+    }
+
+    func testPublishWritesRawCDR() async throws {
+        let (session, client) = try await openSession()
+        let pub = try session.createPublisher(
+            topic: "/x",
+            typeName: "std_msgs/msg/String",
+            typeHash: nil,
+            qos: .sensorData
+        )
+        let payload = Data([0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x68, 0x69])
+        try pub.publish(data: payload, timestamp: 42, sequenceNumber: 0)
+        XCTAssertEqual(client.writes.count, 1)
+        XCTAssertEqual(client.writes[0].data, payload)
+        XCTAssertEqual(client.writes[0].timestamp, 42)
+    }
+
+    // MARK: - createSubscriber
+
+    func testCreateSubscriberRegistersReader() async throws {
+        let (session, client) = try await openSession()
+        _ = try session.createSubscriber(
+            topic: "/x",
+            typeName: "std_msgs/msg/String",
+            typeHash: "RIHS01_abc",
+            qos: .sensorData
+        ) { _, _ in }
+        XCTAssertEqual(client.readers.count, 1)
+        XCTAssertEqual(client.readers[0].topic, "rt/x")
+        XCTAssertEqual(client.readers[0].type, "std_msgs::msg::dds_::String_")
+        XCTAssertEqual(client.readers[0].userData, "typehash=RIHS01_abc;")
+    }
+
+    func testSubscriberHandlerReceivesDeliveredSamples() async throws {
+        let (session, client) = try await openSession()
+        let received = NSLock()
+        var captured: (Data, UInt64)?
+        _ = try session.createSubscriber(
+            topic: "/x",
+            typeName: "std_msgs/msg/String",
+            typeHash: nil,
+            qos: .sensorData
+        ) { data, ts in
+            received.lock()
+            defer { received.unlock() }
+            captured = (data, ts)
+        }
+        client.deliver(toTopic: "rt/x", data: Data([0xAB, 0xCD]), timestamp: 99)
+
+        received.lock()
+        defer { received.unlock() }
+        XCTAssertEqual(captured?.0, Data([0xAB, 0xCD]))
+        XCTAssertEqual(captured?.1, 99)
+    }
+
+    func testCloseDestroysOutstandingWritersAndReaders() async throws {
+        let (session, client) = try await openSession()
+        _ = try session.createPublisher(
+            topic: "/p",
+            typeName: "std_msgs/msg/String",
+            typeHash: nil,
+            qos: .sensorData
+        )
+        _ = try session.createSubscriber(
+            topic: "/s",
+            typeName: "std_msgs/msg/String",
+            typeHash: nil,
+            qos: .sensorData
+        ) { _, _ in }
+        try session.close()
+        XCTAssertEqual(client.destroyedWriters, 1)
+        XCTAssertEqual(client.destroyedReaders, 1)
+    }
+}

--- a/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
@@ -1,0 +1,156 @@
+import Foundation
+import SwiftROS2Transport
+
+/// In-memory DDSClientProtocol used by DDSTransportSession unit tests.
+final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+
+    // Configurable behavior
+    var isAvailable = true
+    var sessionConnected = false
+    var sessionIdValue: String? = "mock-dds-session"
+    var createSessionShouldThrow: DDSError?
+    var createWriterShouldThrow: DDSError?
+    var writeShouldThrow: DDSError?
+    var createReaderShouldThrow: DDSError?
+
+    // Recorded invocations
+    private(set) var sessionCreations: [(domainId: Int32, config: DDSBridgeDiscoveryConfig)] = []
+    private(set) var sessionDestructions = 0
+    private(set) var writers: [(topic: String, type: String, qos: DDSBridgeQoSConfig, userData: String?)] = []
+    private(set) var writes: [(topic: String, data: Data, timestamp: UInt64)] = []
+    private(set) var destroyedWriters = 0
+    private(set) var readers:
+        [(topic: String, type: String, qos: DDSBridgeQoSConfig, userData: String?, handler: (Data, UInt64) -> Void)] =
+            []
+    private(set) var destroyedReaders = 0
+
+    func createSession(domainId: Int32, discoveryConfig: DDSBridgeDiscoveryConfig) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if let e = createSessionShouldThrow { throw e }
+        sessionCreations.append((domainId, discoveryConfig))
+        sessionConnected = true
+    }
+
+    func destroySession() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        sessionDestructions += 1
+        sessionConnected = false
+    }
+
+    func isConnected() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return sessionConnected
+    }
+
+    func getSessionId() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return sessionIdValue
+    }
+
+    func createRawWriter(
+        topicName: String, typeName: String,
+        qos: DDSBridgeQoSConfig, userData: String?
+    ) throws -> any DDSWriterHandle {
+        lock.lock()
+        defer { lock.unlock() }
+        if let e = createWriterShouldThrow { throw e }
+        let handle = MockDDSWriterHandle(topic: topicName)
+        writers.append((topicName, typeName, qos, userData))
+        return handle
+    }
+
+    func writeRawCDR(writer: any DDSWriterHandle, data: Data, timestamp: UInt64) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if let e = writeShouldThrow { throw e }
+        let topic = (writer as? MockDDSWriterHandle)?.topic ?? "<unknown>"
+        writes.append((topic, data, timestamp))
+    }
+
+    func destroyWriter(_ writer: any DDSWriterHandle) {
+        lock.lock()
+        defer { lock.unlock() }
+        destroyedWriters += 1
+        (writer as? MockDDSWriterHandle)?.markClosed()
+    }
+
+    func createRawReader(
+        topicName: String, typeName: String,
+        qos: DDSBridgeQoSConfig, userData: String?,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any DDSReaderHandle {
+        lock.lock()
+        defer { lock.unlock() }
+        if let e = createReaderShouldThrow { throw e }
+        readers.append((topicName, typeName, qos, userData, handler))
+        return MockDDSReaderHandle(topic: topicName)
+    }
+
+    func destroyReader(_ reader: any DDSReaderHandle) {
+        lock.lock()
+        defer { lock.unlock() }
+        destroyedReaders += 1
+        (reader as? MockDDSReaderHandle)?.markClosed()
+    }
+
+    /// Test helper: deliver a sample to readers on the given topic.
+    func deliver(toTopic topic: String, data: Data, timestamp: UInt64) {
+        let handlers: [(Data, UInt64) -> Void] = {
+            lock.lock()
+            defer { lock.unlock() }
+            return readers.filter { $0.topic == topic }.map { $0.handler }
+        }()
+        for handler in handlers {
+            handler(data, timestamp)
+        }
+    }
+}
+
+final class MockDDSWriterHandle: DDSWriterHandle, @unchecked Sendable {
+    let topic: String
+    private var closed = false
+    private let lock = NSLock()
+
+    init(topic: String) { self.topic = topic }
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        closed = true
+    }
+
+    func markClosed() { close() }
+}
+
+final class MockDDSReaderHandle: DDSReaderHandle, @unchecked Sendable {
+    let topic: String
+    private var closed = false
+    private let lock = NSLock()
+
+    init(topic: String) { self.topic = topic }
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        closed = true
+    }
+
+    func markClosed() { close() }
+}

--- a/Tests/SwiftROS2TransportTests/Mocks/MockZenohClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockZenohClient.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+import SwiftROS2Transport
+
+/// In-memory ZenohClientProtocol used by ZenohTransportSession unit tests.
+///
+/// Records every call so tests can assert against `puts`, `keyExprDeclarations`,
+/// `subscriptions`, etc. Lock-protected so tests can also exercise the
+/// session's @Sendable contract.
+final class MockZenohClient: ZenohClientProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+
+    // Configurable behavior
+    var isOpen = false
+    var sessionIdValue = "mock-session-id"
+    var openShouldThrow: ZenohError?
+    var declareKeyExprShouldThrow: ZenohError?
+    var putShouldThrow: ZenohError?
+    var subscribeShouldThrow: ZenohError?
+    var livelinessShouldThrow: ZenohError?
+    var healthOverride: Bool?
+
+    // Recorded invocations
+    private(set) var openedLocators: [String] = []
+    private(set) var closedCount = 0
+    private(set) var keyExprDeclarations: [String] = []
+    private(set) var puts: [(key: String, payload: Data, attachment: Data?)] = []
+    private(set) var subscriptions: [(key: String, handler: (ZenohSample) -> Void)] = []
+    private(set) var livelinessDeclarations: [String] = []
+
+    func open(locator: String) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if let e = openShouldThrow { throw e }
+        openedLocators.append(locator)
+        isOpen = true
+    }
+
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        closedCount += 1
+        isOpen = false
+    }
+
+    func isSessionHealthy() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return healthOverride ?? isOpen
+    }
+
+    func getSessionId() throws -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return sessionIdValue
+    }
+
+    func declareKeyExpr(_ keyExpr: String) throws -> any ZenohKeyExprHandle {
+        lock.lock()
+        defer { lock.unlock() }
+        if let e = declareKeyExprShouldThrow { throw e }
+        keyExprDeclarations.append(keyExpr)
+        return MockKeyExprHandle(keyExpr: keyExpr)
+    }
+
+    func put(keyExpr: any ZenohKeyExprHandle, payload: Data, attachment: Data?) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if let e = putShouldThrow { throw e }
+        let key = (keyExpr as? MockKeyExprHandle)?.keyExpr ?? "<unknown>"
+        puts.append((key: key, payload: payload, attachment: attachment))
+    }
+
+    func put(keyExpr: String, payload: Data, attachment: Data?) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if let e = putShouldThrow { throw e }
+        puts.append((key: keyExpr, payload: payload, attachment: attachment))
+    }
+
+    func subscribe(keyExpr: String, handler: @escaping (ZenohSample) -> Void) throws -> any ZenohSubscriberHandle {
+        lock.lock()
+        defer { lock.unlock() }
+        if let e = subscribeShouldThrow { throw e }
+        subscriptions.append((key: keyExpr, handler: handler))
+        return MockSubscriberHandle()
+    }
+
+    func declareLivelinessToken(_ keyExpr: String) throws -> any ZenohLivelinessTokenHandle {
+        lock.lock()
+        defer { lock.unlock() }
+        if let e = livelinessShouldThrow { throw e }
+        livelinessDeclarations.append(keyExpr)
+        return MockLivelinessTokenHandle()
+    }
+
+    /// Test helper: deliver a sample to all matching subscriber handlers.
+    func deliver(sample: ZenohSample, toKeyExpr key: String) {
+        let handlers: [(ZenohSample) -> Void] = {
+            lock.lock()
+            defer { lock.unlock() }
+            return subscriptions.filter { $0.key == key }.map { $0.handler }
+        }()
+        for handler in handlers {
+            handler(sample)
+        }
+    }
+}
+
+final class MockKeyExprHandle: ZenohKeyExprHandle {
+    let keyExpr: String
+    init(keyExpr: String) { self.keyExpr = keyExpr }
+}
+
+final class MockSubscriberHandle: ZenohSubscriberHandle {
+    private(set) var closeCount = 0
+    private let lock = NSLock()
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        closeCount += 1
+    }
+}
+
+final class MockLivelinessTokenHandle: ZenohLivelinessTokenHandle {
+    private(set) var closeCount = 0
+    private let lock = NSLock()
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        closeCount += 1
+    }
+}

--- a/Tests/SwiftROS2TransportTests/Mocks/SendableBox.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/SendableBox.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Sendable container for capturing values from `@Sendable` handlers in tests.
+///
+/// The transport `createSubscriber` API hands the user a `@Sendable` closure;
+/// asserting on what the handler observed requires a sendable shared
+/// container. `Box` wraps a single value behind an `NSLock` and is callable
+/// from any concurrency context.
+final class Box<T>: @unchecked Sendable {
+    private var _value: T
+    private let lock = NSLock()
+
+    init(_ value: T) {
+        self._value = value
+    }
+
+    var value: T {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _value
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _value = newValue
+        }
+    }
+}

--- a/Tests/SwiftROS2TransportTests/ZenohTransportSessionTests.swift
+++ b/Tests/SwiftROS2TransportTests/ZenohTransportSessionTests.swift
@@ -1,0 +1,195 @@
+import SwiftROS2Transport
+import SwiftROS2Wire
+import XCTest
+
+final class ZenohTransportSessionTests: XCTestCase {
+    // MARK: - Helpers
+
+    private func openSession(
+        wireMode: ROS2Distro? = .jazzy,
+        client: MockZenohClient = MockZenohClient()
+    ) async throws -> (ZenohTransportSession, MockZenohClient) {
+        let session = ZenohTransportSession(client: client)
+        let config = TransportConfig.zenoh(
+            locator: "tcp/127.0.0.1:7447",
+            wireMode: wireMode,
+            connectionTimeout: 1.0
+        )
+        try await session.open(config: config)
+        return (session, client)
+    }
+
+    // MARK: - open / close
+
+    func testOpenWithMismatchedTransportTypeThrows() async {
+        let session = ZenohTransportSession(client: MockZenohClient())
+        let config = TransportConfig.ddsMulticast()
+        do {
+            try await session.open(config: config)
+            XCTFail("Expected invalidConfiguration")
+        } catch TransportError.invalidConfiguration {
+            // ok
+        } catch {
+            XCTFail("Wrong error: \(error)")
+        }
+    }
+
+    func testOpenWithoutLocatorThrows() async {
+        let session = ZenohTransportSession(client: MockZenohClient())
+        let config = TransportConfig(type: .zenoh, zenohLocator: nil)
+        do {
+            try await session.open(config: config)
+            XCTFail("Expected invalidConfiguration")
+        } catch TransportError.invalidConfiguration {
+            // ok
+        } catch {
+            XCTFail("Wrong error: \(error)")
+        }
+    }
+
+    func testOpenSucceedsThroughMock() async throws {
+        let (session, client) = try await openSession()
+        XCTAssertEqual(client.openedLocators, ["tcp/127.0.0.1:7447"])
+        XCTAssertTrue(session.isConnected)
+        XCTAssertEqual(session.transportType, .zenoh)
+    }
+
+    func testOpenWiresExplicitWireMode() async throws {
+        let (session, _) = try await openSession(wireMode: .humble)
+        XCTAssertEqual(session.resolvedWireMode, .humble)
+    }
+
+    func testOpenDefaultsToJazzyWhenNoWireModeGiven() async throws {
+        let session = ZenohTransportSession(client: MockZenohClient())
+        let config = TransportConfig.zenoh(
+            locator: "tcp/127.0.0.1:7447",
+            wireMode: nil,
+            connectionTimeout: 1.0
+        )
+        try await session.open(config: config)
+        XCTAssertEqual(session.resolvedWireMode, .jazzy)
+    }
+
+    func testOpenPropagatesTimeout() async {
+        let client = MockZenohClient()
+        client.openShouldThrow = .sessionCreationFailed("boom")
+        let session = ZenohTransportSession(client: client)
+        let config = TransportConfig.zenoh(locator: "tcp/127.0.0.1:7447", connectionTimeout: 1.0)
+        do {
+            try await session.open(config: config)
+            XCTFail("Expected connectionFailed")
+        } catch TransportError.connectionFailed {
+            // ok
+        } catch {
+            XCTFail("Wrong error: \(error)")
+        }
+    }
+
+    func testCloseClearsResolvedWireMode() async throws {
+        let (session, client) = try await openSession()
+        try session.close()
+        XCTAssertEqual(client.closedCount, 1)
+        XCTAssertNil(session.resolvedWireMode)
+    }
+
+    // MARK: - createPublisher
+
+    func testCreatePublisherDeclaresKeyExprAndLiveliness() async throws {
+        let (session, client) = try await openSession(wireMode: .jazzy)
+        let pub = try session.createPublisher(
+            topic: "/ios/imu",
+            typeName: "sensor_msgs/msg/Imu",
+            typeHash: "RIHS01_abc",
+            qos: .sensorData
+        )
+        XCTAssertTrue(pub.isActive)
+        XCTAssertEqual(client.keyExprDeclarations.count, 1)
+        XCTAssertEqual(client.keyExprDeclarations.first, "0/ios/imu/sensor_msgs::msg::dds_::Imu_/RIHS01_abc")
+        XCTAssertEqual(client.livelinessDeclarations.count, 1)
+        XCTAssertTrue(client.livelinessDeclarations.first?.hasPrefix("@ros2_lv/0/") == true)
+    }
+
+    func testCreatePublisherWithoutOpenThrowsNotConnected() {
+        let session = ZenohTransportSession(client: MockZenohClient())
+        XCTAssertThrowsError(
+            try session.createPublisher(topic: "/x", typeName: "y", typeHash: nil, qos: .sensorData)
+        ) { error in
+            guard case TransportError.notConnected = error else {
+                XCTFail("Wrong error: \(error)")
+                return
+            }
+        }
+    }
+
+    func testPublishSendsAttachmentAndPayload() async throws {
+        let (session, client) = try await openSession()
+        let pub = try session.createPublisher(
+            topic: "/ios/imu",
+            typeName: "sensor_msgs/msg/Imu",
+            typeHash: "RIHS01_abc",
+            qos: .sensorData
+        )
+        let payload = Data([0x00, 0x01, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF])
+        try pub.publish(data: payload, timestamp: 1_000_000_000, sequenceNumber: 7)
+
+        XCTAssertEqual(client.puts.count, 1)
+        let put = client.puts[0]
+        XCTAssertEqual(put.payload, payload)
+        XCTAssertEqual(put.attachment?.count, 33, "Attachment must be 33 bytes")
+    }
+
+    func testPublishAfterCloseThrowsPublisherClosed() async throws {
+        let (session, _) = try await openSession()
+        let pub = try session.createPublisher(
+            topic: "/x",
+            typeName: "std_msgs/msg/String",
+            typeHash: nil,
+            qos: .sensorData
+        )
+        try pub.close()
+        XCTAssertThrowsError(try pub.publish(data: Data(), timestamp: 0, sequenceNumber: 0)) { error in
+            guard case TransportError.publisherClosed = error else {
+                XCTFail("Wrong error: \(error)")
+                return
+            }
+        }
+    }
+
+    func testCloseSessionAlsoClosesPublishers() async throws {
+        let (session, _) = try await openSession()
+        let pub = try session.createPublisher(
+            topic: "/x",
+            typeName: "std_msgs/msg/String",
+            typeHash: nil,
+            qos: .sensorData
+        )
+        try session.close()
+        XCTAssertFalse(pub.isActive)
+    }
+
+    // MARK: - createSubscriber
+
+    func testCreateSubscriberRegistersKeyExpr() async throws {
+        let (session, client) = try await openSession(wireMode: .jazzy)
+        let received = NSLock()
+        var bytes: Data?
+        let sub = try session.createSubscriber(
+            topic: "/ios/imu",
+            typeName: "sensor_msgs/msg/Imu",
+            typeHash: "RIHS01_abc",
+            qos: .sensorData
+        ) { data, _ in
+            received.lock()
+            defer { received.unlock() }
+            bytes = data
+        }
+        XCTAssertTrue(sub.isActive)
+        XCTAssertEqual(client.subscriptions.count, 1)
+
+        let sample = ZenohSample(keyExpr: "ignored", payload: Data([0x01, 0x02]), attachment: nil)
+        client.deliver(sample: sample, toKeyExpr: client.subscriptions[0].key)
+        received.lock()
+        defer { received.unlock() }
+        XCTAssertEqual(bytes, Data([0x01, 0x02]))
+    }
+}

--- a/Tests/SwiftROS2TransportTests/ZenohTransportSessionTests.swift
+++ b/Tests/SwiftROS2TransportTests/ZenohTransportSessionTests.swift
@@ -70,7 +70,7 @@ final class ZenohTransportSessionTests: XCTestCase {
         XCTAssertEqual(session.resolvedWireMode, .jazzy)
     }
 
-    func testOpenPropagatesTimeout() async {
+    func testOpenPropagatesConnectionFailure() async {
         let client = MockZenohClient()
         client.openShouldThrow = .sessionCreationFailed("boom")
         let session = ZenohTransportSession(client: client)
@@ -171,25 +171,20 @@ final class ZenohTransportSessionTests: XCTestCase {
 
     func testCreateSubscriberRegistersKeyExpr() async throws {
         let (session, client) = try await openSession(wireMode: .jazzy)
-        let received = NSLock()
-        var bytes: Data?
+        let bytes = Box<Data?>(nil)
         let sub = try session.createSubscriber(
             topic: "/ios/imu",
             typeName: "sensor_msgs/msg/Imu",
             typeHash: "RIHS01_abc",
             qos: .sensorData
         ) { data, _ in
-            received.lock()
-            defer { received.unlock() }
-            bytes = data
+            bytes.value = data
         }
         XCTAssertTrue(sub.isActive)
         XCTAssertEqual(client.subscriptions.count, 1)
 
         let sample = ZenohSample(keyExpr: "ignored", payload: Data([0x01, 0x02]), attachment: nil)
         client.deliver(sample: sample, toKeyExpr: client.subscriptions[0].key)
-        received.lock()
-        defer { received.unlock() }
-        XCTAssertEqual(bytes, Data([0x01, 0x02]))
+        XCTAssertEqual(bytes.value, Data([0x01, 0x02]))
     }
 }


### PR DESCRIPTION
## Summary

Stands up two in-memory mocks (`MockZenohClient`, `MockDDSClient`) that conform to the existing public `ZenohClientProtocol` / `DDSClientProtocol` and uses them to drive 26 new unit tests covering `ZenohTransportSession` and `DDSTransportSession` lifecycle / publisher / subscriber paths. No production code change. No `@testable import` — every assertion goes through the public surface.

This is the largest coverage uplift in the runway plan: it brings `SwiftROS2Transport` from "helpers only" (PR 4) up toward the §6.2 80% threshold without requiring a LAN integration environment.

## Spec

- `docs/superpowers/specs/2026-04-28-swift-ros2-1.0.0-runway-design.md` §5.1 (items 6–7), §5.2
- §8 PR 5

Depends on #58 (already merged).

## What's covered

| File | Tests |
|---|---|
| `Mocks/MockZenohClient.swift` | mock implementing `ZenohClientProtocol` + `ZenohKeyExprHandle` / `ZenohSubscriberHandle` / `ZenohLivelinessTokenHandle`; records every call; configurable `*ShouldThrow` knobs for failure paths; `deliver(sample:toKeyExpr:)` test helper |
| `Mocks/MockDDSClient.swift` | mock implementing `DDSClientProtocol` + `DDSWriterHandle` / `DDSReaderHandle`; records every call; configurable `*ShouldThrow` knobs; `deliver(toTopic:data:timestamp:)` test helper |
| `ZenohTransportSessionTests.swift` | 13 — open/close transport-type mismatch, missing locator, success path, explicit/default wire mode (`humble` vs `jazzy`), connection-failure propagation, `resolvedWireMode` cleared on close; createPublisher declares the exact key expression `0/ios/imu/sensor_msgs::msg::dds_::Imu_/RIHS01_abc` and a `@ros2_lv/0/...` liveliness token; createPublisher without open throws `notConnected`; publish sends the payload + 33-byte attachment; publish-after-close throws `publisherClosed`; session close invalidates publishers; createSubscriber registers + delivers samples |
| `DDSTransportSessionTests.swift` | 13 — open/close transport-type mismatch, `unsupportedFeature` when client `isAvailable=false`, multicast success, unicast peers forwarded as `String` array, close destroys session; createPublisher rejects empty topic, rejects duplicate topic with `publisherCreationFailed`, registers writer with `rt/x` topic / `std_msgs::msg::dds_::String_` type / `typehash=...;` userData; publish enforces the documented 4-byte CDR-header minimum; publish writes raw CDR; createSubscriber registers + delivers; close destroys outstanding writers and readers |

## Verification

- `swift build` — clean.
- `swift test --parallel` — 154 tests, zero failures (was 128; +26 new = 13 + 13).
- `swift format lint --recursive --strict` — clean over the new files.
- `swift package diagnose-api-breaking-changes 0.6.0` — no new breakages. The 3 pre-existing breakages in `SwiftROS2Messages` (the `ROS2Service` → `ROS2ServiceType` rename from #52) are unchanged baseline.
- Mocks conform only to public protocols — no `@testable import` anywhere.
- `testCreatePublisherDeclaresKeyExprAndLiveliness` asserts the **exact** Zenoh key expression — locks in the wire-format contract through the session API.
- `testPublishRequiresMinimum4ByteCDRHeader` enforces the documented `data.count >= 4` precondition (`Sources/SwiftROS2Transport/DDSTransportSession+Publisher.swift:102-104`).

## Known noise

Compilation surfaces three Swift 6 sendable warnings in the subscriber-delivery tests (NSLock `lock()` / `unlock()` from async context, and `var` capture in a `@Sendable` closure). These are warnings under the package's current Swift 5 language mode and don't fail the build. Happy to switch to a `final class Box: @unchecked Sendable` pattern in a follow-up if you'd prefer them silenced now.

## Test plan

- [ ] CI: macOS, Linux (Humble/Jazzy/Rolling × x86_64/aarch64), Windows, Android matrices all green — the new tests are in the always-on `SwiftROS2TransportTests` target and don't depend on CycloneDDS being linked.
- [ ] Coverage report shows `ZenohTransportSession*.swift` and `DDSTransportSession*.swift` rising substantially toward the 80% gate (verified by PR 8's gate when it lands).