### PR TITLE
test(umbrella): Node / Publisher / Subscription / QoSProfile via mock session

### DIFF
--- a/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
+++ b/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
@@ -25,6 +25,19 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
 
     func open(config: TransportConfig) async throws {
         if let e = openShouldThrow { throw e }
+        // Mirror real Zenoh / DDS sessions: reject configs whose transport type
+        // doesn't match this session and run the same validate() check.
+        guard config.type == transportType else {
+            throw TransportError.invalidConfiguration(
+                "Expected \(transportType) configuration, got \(config.type)"
+            )
+        }
+        try config.validate()
+        recordOpen(config: config)
+    }
+
+    /// Sync helper — keeps NSLock out of the async open() context.
+    private func recordOpen(config: TransportConfig) {
         lock.lock()
         defer { lock.unlock() }
         openedConfigs.append(config)
@@ -32,10 +45,22 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
     }
 
     func close() throws {
+        let publishersToClose: [MockTransportPublisher]
+        let subscribersToClose: [MockTransportSubscriber]
+
         lock.lock()
-        defer { lock.unlock() }
         closedCount += 1
         isConnected = false
+        publishersToClose = publishers
+        subscribersToClose = subscribers
+        lock.unlock()
+
+        for publisher in publishersToClose {
+            try publisher.close()
+        }
+        for subscriber in subscribersToClose {
+            try subscriber.close()
+        }
     }
 
     func checkHealth() -> Bool { isConnected }
@@ -44,17 +69,32 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
         topic: String, typeName: String, typeHash: String?, qos: TransportQoS
     ) throws -> any TransportPublisher {
         if let e = createPublisherShouldThrow { throw e }
+        // Mirror real Zenoh / DDS sessions: refuse on a closed session and
+        // reject empty topic / type names.
+        guard isConnected else {
+            throw TransportError.notConnected
+        }
+        guard !topic.isEmpty else {
+            throw TransportError.invalidConfiguration("Topic name cannot be empty")
+        }
+        guard !typeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Type name cannot be empty")
+        }
         let pub = MockTransportPublisher(topic: topic, typeName: typeName, typeHash: typeHash, qos: qos)
         lock.lock()
         defer { lock.unlock() }
         publishers.append(pub)
         // Wire publisher → matching subscribers so publish() forwards through.
+        // Match on topic + typeName + typeHash, and skip subscribers that
+        // have already been closed/cancelled.
         pub.deliveryFanout = { [weak self] data, ts in
             guard let self = self else { return }
             let matches: [MockTransportSubscriber] = {
                 self.lock.lock()
                 defer { self.lock.unlock() }
-                return self.subscribers.filter { $0.topic == topic }
+                return self.subscribers.filter { sub in
+                    sub.isActive && sub.topic == topic && sub.typeName == typeName && sub.typeHash == typeHash
+                }
             }()
             for sub in matches {
                 sub.handler(data, ts)
@@ -68,6 +108,15 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
         handler: @escaping @Sendable (Data, UInt64) -> Void
     ) throws -> any TransportSubscriber {
         if let e = createSubscriberShouldThrow { throw e }
+        guard isConnected else {
+            throw TransportError.notConnected
+        }
+        guard !topic.isEmpty else {
+            throw TransportError.invalidConfiguration("Topic name cannot be empty")
+        }
+        guard !typeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Type name cannot be empty")
+        }
         let sub = MockTransportSubscriber(
             topic: topic,
             typeName: typeName,

--- a/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
+++ b/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+import SwiftROS2Transport
+
+/// In-memory TransportSession used by SwiftROS2 umbrella unit tests.
+///
+/// Records publisher/subscriber creations and forwards published payloads
+/// through the matching subscriber's handler so tests can drive end-to-end
+/// flow without any real transport.
+final class MockTransportSession: TransportSession, @unchecked Sendable {
+    private let lock = NSLock()
+
+    var transportType: TransportType { .zenoh }
+    var isConnected: Bool = true
+    var sessionId: String = "mock-umbrella-session"
+
+    var openShouldThrow: TransportError?
+    var createPublisherShouldThrow: TransportError?
+    var createSubscriberShouldThrow: TransportError?
+
+    private(set) var openedConfigs: [TransportConfig] = []
+    private(set) var publishers: [MockTransportPublisher] = []
+    private(set) var subscribers: [MockTransportSubscriber] = []
+    private(set) var closedCount = 0
+
+    func open(config: TransportConfig) async throws {
+        if let e = openShouldThrow { throw e }
+        lock.lock()
+        defer { lock.unlock() }
+        openedConfigs.append(config)
+        isConnected = true
+    }
+
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        closedCount += 1
+        isConnected = false
+    }
+
+    func checkHealth() -> Bool { isConnected }
+
+    func createPublisher(
+        topic: String, typeName: String, typeHash: String?, qos: TransportQoS
+    ) throws -> any TransportPublisher {
+        if let e = createPublisherShouldThrow { throw e }
+        let pub = MockTransportPublisher(topic: topic, typeName: typeName, typeHash: typeHash, qos: qos)
+        lock.lock()
+        defer { lock.unlock() }
+        publishers.append(pub)
+        // Wire publisher → matching subscribers so publish() forwards through.
+        pub.deliveryFanout = { [weak self] data, ts in
+            guard let self = self else { return }
+            let matches: [MockTransportSubscriber] = {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                return self.subscribers.filter { $0.topic == topic }
+            }()
+            for sub in matches {
+                sub.handler(data, ts)
+            }
+        }
+        return pub
+    }
+
+    func createSubscriber(
+        topic: String, typeName: String, typeHash: String?, qos: TransportQoS,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any TransportSubscriber {
+        if let e = createSubscriberShouldThrow { throw e }
+        let sub = MockTransportSubscriber(
+            topic: topic,
+            typeName: typeName,
+            typeHash: typeHash,
+            qos: qos,
+            handler: handler
+        )
+        lock.lock()
+        defer { lock.unlock() }
+        subscribers.append(sub)
+        return sub
+    }
+}
+
+final class MockTransportPublisher: TransportPublisher, @unchecked Sendable {
+    let topic: String
+    let typeName: String
+    let typeHash: String?
+    let qos: TransportQoS
+
+    private let lock = NSLock()
+    private var closed = false
+    private(set) var publishedPayloads: [(data: Data, timestamp: UInt64, sequenceNumber: Int64)] = []
+    var deliveryFanout: ((Data, UInt64) -> Void)?
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+
+    init(topic: String, typeName: String, typeHash: String?, qos: TransportQoS) {
+        self.topic = topic
+        self.typeName = typeName
+        self.typeHash = typeHash
+        self.qos = qos
+    }
+
+    func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            throw TransportError.publisherClosed
+        }
+        publishedPayloads.append((data, timestamp, sequenceNumber))
+        let fanout = deliveryFanout
+        lock.unlock()
+        fanout?(data, timestamp)
+    }
+
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        closed = true
+    }
+}
+
+final class MockTransportSubscriber: TransportSubscriber, @unchecked Sendable {
+    let topic: String
+    let typeName: String
+    let typeHash: String?
+    let qos: TransportQoS
+    let handler: @Sendable (Data, UInt64) -> Void
+
+    private let lock = NSLock()
+    private var closed = false
+
+    init(
+        topic: String, typeName: String, typeHash: String?, qos: TransportQoS,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) {
+        self.topic = topic
+        self.typeName = typeName
+        self.typeHash = typeHash
+        self.qos = qos
+        self.handler = handler
+    }
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        closed = true
+    }
+}

--- a/Tests/SwiftROS2Tests/NodeLifecycleTests.swift
+++ b/Tests/SwiftROS2Tests/NodeLifecycleTests.swift
@@ -103,19 +103,24 @@ final class NodeLifecycleTests: XCTestCase {
         let sub = try await node.createSubscription(StringMsg.self, topic: "chatter")
         let pub = try await node.createPublisher(StringMsg.self, topic: "chatter")
 
-        try pub.publish(StringMsg(data: "hello world"))
+        // Start the consumer before publish, then await its first delivery
+        // deterministically. Avoids the timing-dependent Task.sleep dance.
+        let received = expectation(description: "Receive first subscription message")
 
         let task = Task { () -> StringMsg? in
             for await msg in sub.messages {
+                received.fulfill()
                 return msg
             }
             return nil
         }
-        // Give the AsyncStream a moment.
-        try await Task.sleep(nanoseconds: 50_000_000)
+
+        try pub.publish(StringMsg(data: "hello world"))
+
+        await fulfillment(of: [received], timeout: 1.0)
         sub.cancel()
-        let received = await task.value
-        XCTAssertEqual(received?.data, "hello world")
+        let message = await task.value
+        XCTAssertEqual(message?.data, "hello world")
     }
 
     // MARK: - QoS propagation

--- a/Tests/SwiftROS2Tests/NodeLifecycleTests.swift
+++ b/Tests/SwiftROS2Tests/NodeLifecycleTests.swift
@@ -1,0 +1,161 @@
+import SwiftROS2
+import SwiftROS2Messages
+import SwiftROS2Transport
+import XCTest
+
+final class NodeLifecycleTests: XCTestCase {
+    private func makeContext(
+        session: MockTransportSession = MockTransportSession()
+    ) async throws -> (ROS2Context, MockTransportSession) {
+        let config = TransportConfig.zenoh(locator: "tcp/mock:7447")
+        let ctx = try await ROS2Context(transport: config, session: session)
+        return (ctx, session)
+    }
+
+    // MARK: - Node creation
+
+    func testContextWithInjectedSessionSkipsFactory() async throws {
+        let (ctx, session) = try await makeContext()
+        XCTAssertTrue(ctx.isConnected)
+        // The mock starts as already-connected, so open() should not be called.
+        XCTAssertEqual(session.openedConfigs.count, 0)
+    }
+
+    func testContextOpensSessionWhenNotConnected() async throws {
+        let session = MockTransportSession()
+        session.isConnected = false
+        _ = try await ROS2Context(transport: .zenoh(locator: "tcp/m:7447"), session: session)
+        XCTAssertEqual(session.openedConfigs.count, 1)
+    }
+
+    func testCreateNodeReturnsNodeWithFullyQualifiedName() async throws {
+        let (ctx, _) = try await makeContext()
+        let node = try await ctx.createNode(name: "imu_node", namespace: "/ios")
+        XCTAssertEqual(node.name, "imu_node")
+        XCTAssertEqual(node.namespace, "/ios")
+        XCTAssertEqual(node.fullyQualifiedName, "/ios/imu_node")
+    }
+
+    func testCreateNodeWithRootNamespaceUsesSlashJoin() async throws {
+        let (ctx, _) = try await makeContext()
+        let node = try await ctx.createNode(name: "n", namespace: "/")
+        XCTAssertEqual(node.fullyQualifiedName, "/n")
+    }
+
+    // MARK: - Publisher
+
+    func testCreatePublisherForwardsToSession() async throws {
+        let (ctx, session) = try await makeContext()
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+        _ = try await node.createPublisher(StringMsg.self, topic: "chatter")
+
+        XCTAssertEqual(session.publishers.count, 1)
+        let recorded = session.publishers[0]
+        XCTAssertEqual(recorded.topic, "/ns/chatter", "Topic must be namespace-prefixed")
+        XCTAssertEqual(recorded.typeName, StringMsg.typeInfo.typeName)
+    }
+
+    func testPublishMessageEncodesAndDelegates() async throws {
+        let (ctx, session) = try await makeContext()
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+        let pub = try await node.createPublisher(StringMsg.self, topic: "chatter")
+        try pub.publish(StringMsg(data: "hello"))
+
+        let recorded = session.publishers[0]
+        XCTAssertEqual(recorded.publishedPayloads.count, 1)
+        let payload = recorded.publishedPayloads[0]
+        XCTAssertGreaterThanOrEqual(payload.data.count, 4, "CDR encapsulation header must be present")
+        XCTAssertEqual(payload.sequenceNumber, 0)
+    }
+
+    func testPublishIncrementsSequenceNumber() async throws {
+        let (ctx, session) = try await makeContext()
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+        let pub = try await node.createPublisher(StringMsg.self, topic: "chatter")
+        try pub.publish(StringMsg(data: "a"))
+        try pub.publish(StringMsg(data: "b"))
+        try pub.publish(StringMsg(data: "c"))
+
+        let seqs = session.publishers[0].publishedPayloads.map { $0.sequenceNumber }
+        XCTAssertEqual(seqs, [0, 1, 2])
+    }
+
+    func testPublisherUsesAbsoluteTopicWhenLeadingSlash() async throws {
+        let (ctx, session) = try await makeContext()
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+        _ = try await node.createPublisher(StringMsg.self, topic: "/abs/topic")
+        XCTAssertEqual(session.publishers[0].topic, "/abs/topic")
+    }
+
+    // MARK: - Subscription
+
+    func testSubscriptionForwardsToSession() async throws {
+        let (ctx, session) = try await makeContext()
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+        _ = try await node.createSubscription(StringMsg.self, topic: "chatter")
+        XCTAssertEqual(session.subscribers.count, 1)
+        XCTAssertEqual(session.subscribers[0].topic, "/ns/chatter")
+    }
+
+    func testPublishedMessageIsDeliveredToMatchingSubscription() async throws {
+        let (ctx, _) = try await makeContext()
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+        let sub = try await node.createSubscription(StringMsg.self, topic: "chatter")
+        let pub = try await node.createPublisher(StringMsg.self, topic: "chatter")
+
+        try pub.publish(StringMsg(data: "hello world"))
+
+        let task = Task { () -> StringMsg? in
+            for await msg in sub.messages {
+                return msg
+            }
+            return nil
+        }
+        // Give the AsyncStream a moment.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        sub.cancel()
+        let received = await task.value
+        XCTAssertEqual(received?.data, "hello world")
+    }
+
+    // MARK: - QoS propagation
+
+    func testQoSProfileFlowsThroughToTransport() async throws {
+        let (ctx, session) = try await makeContext()
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+        _ = try await node.createPublisher(
+            StringMsg.self,
+            topic: "chatter",
+            qos: QoSProfile(reliability: .reliable, durability: .transientLocal, history: .keepLast(7))
+        )
+
+        let qos = session.publishers[0].qos
+        XCTAssertEqual(qos.reliability, .reliable)
+        XCTAssertEqual(qos.durability, .transientLocal)
+        if case .keepLast(let n) = qos.history {
+            XCTAssertEqual(n, 7)
+        } else {
+            XCTFail("Expected keepLast(7)")
+        }
+    }
+
+    // MARK: - Shutdown
+
+    func testShutdownClosesSession() async throws {
+        let (ctx, session) = try await makeContext()
+        await ctx.shutdown()
+        XCTAssertEqual(session.closedCount, 1)
+    }
+
+    func testShutdownClosesAllPublishers() async throws {
+        let (ctx, session) = try await makeContext()
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+        _ = try await node.createPublisher(StringMsg.self, topic: "a")
+        _ = try await node.createPublisher(StringMsg.self, topic: "b")
+
+        await ctx.shutdown()
+        for pub in session.publishers {
+            XCTAssertFalse(pub.isActive)
+        }
+    }
+}

--- a/Tests/SwiftROS2Tests/QoSProfileTests.swift
+++ b/Tests/SwiftROS2Tests/QoSProfileTests.swift
@@ -1,0 +1,87 @@
+import SwiftROS2
+import SwiftROS2Transport
+import SwiftROS2Wire
+import XCTest
+
+final class QoSProfileTests: XCTestCase {
+    // MARK: - presets
+
+    func testSensorDataPreset() {
+        XCTAssertEqual(QoSProfile.sensorData.reliability, .bestEffort)
+        XCTAssertEqual(QoSProfile.sensorData.durability, .volatile)
+        XCTAssertEqual(QoSProfile.sensorData.history, .keepLast(10))
+    }
+
+    func testReliableSensorPreset() {
+        XCTAssertEqual(QoSProfile.reliableSensor.reliability, .reliable)
+        XCTAssertEqual(QoSProfile.reliableSensor.durability, .volatile)
+        XCTAssertEqual(QoSProfile.reliableSensor.history, .keepLast(10))
+    }
+
+    func testLatchedPreset() {
+        XCTAssertEqual(QoSProfile.latched.reliability, .reliable)
+        XCTAssertEqual(QoSProfile.latched.durability, .transientLocal)
+        XCTAssertEqual(QoSProfile.latched.history, .keepLast(1))
+    }
+
+    func testServicesDefaultPreset() {
+        XCTAssertEqual(QoSProfile.servicesDefault.reliability, .reliable)
+        XCTAssertEqual(QoSProfile.servicesDefault.durability, .volatile)
+    }
+
+    func testDefaultIsSensorData() {
+        XCTAssertEqual(QoSProfile.default, QoSProfile.sensorData)
+    }
+
+    // MARK: - equatability
+
+    func testProfilesAreEqualWhenAllFieldsMatch() {
+        XCTAssertEqual(
+            QoSProfile(reliability: .reliable, durability: .volatile, history: .keepLast(5)),
+            QoSProfile(reliability: .reliable, durability: .volatile, history: .keepLast(5))
+        )
+    }
+
+    func testProfilesDifferOnHistoryDepth() {
+        XCTAssertNotEqual(
+            QoSProfile(history: .keepLast(5)),
+            QoSProfile(history: .keepLast(6))
+        )
+    }
+
+    // MARK: - toTransportQoS
+
+    func testToTransportQoSPreservesReliability() {
+        let profile = QoSProfile(reliability: .reliable, durability: .volatile, history: .keepLast(10))
+        XCTAssertEqual(profile.toTransportQoS().reliability, .reliable)
+    }
+
+    func testToTransportQoSMapsKeepAll() {
+        let profile = QoSProfile(reliability: .reliable, durability: .volatile, history: .keepAll)
+        let qos = profile.toTransportQoS()
+        if case .keepAll = qos.history {
+            // ok
+        } else {
+            XCTFail("Expected keepAll")
+        }
+    }
+
+    // MARK: - toQoSPolicy
+
+    func testToQoSPolicyKeepLast() {
+        let policy = QoSProfile(reliability: .bestEffort, durability: .volatile, history: .keepLast(10)).toQoSPolicy()
+        XCTAssertEqual(policy.reliability, .bestEffort)
+        XCTAssertEqual(policy.historyPolicy, .keepLast)
+        XCTAssertEqual(policy.historyDepth, 10)
+    }
+
+    func testToQoSPolicyKeepAllUsesUmbrellaSentinel() {
+        // The umbrella's sentinel for keepAll is 0 (depth = 0), see
+        // Sources/SwiftROS2/QoSProfile.swift toQoSPolicy(). This differs from
+        // TransportQoSMapper.toWireQoSPolicy which uses 1000 — both are
+        // intentional, history-of-the-codebase choices.
+        let policy = QoSProfile(history: .keepAll).toQoSPolicy()
+        XCTAssertEqual(policy.historyPolicy, .keepAll)
+        XCTAssertEqual(policy.historyDepth, 0)
+    }
+}


### PR DESCRIPTION
## Summary

Covers the public umbrella surface — `ROS2Context`, `ROS2Node`, `ROS2Publisher`, `ROS2Subscription`, `QoSProfile` — with 24 new unit tests driven by an in-memory `MockTransportSession`. Uses the existing `ROS2Context.init(transport:..., session:)` injection seam (Sources/SwiftROS2/Context.swift) so no production code change. No `@testable import` — every assertion exercises the public API.

## Spec

- `docs/superpowers/specs/2026-04-28-swift-ros2-1.0.0-runway-design.md` §5.1 (items 8–9), §5.2
- §8 PR 6

Depends on #59 (already merged).

## What's covered

| File | Tests |
|---|---|
| `Mocks/MockTransportSession.swift` | mock implementing `TransportSession` + `MockTransportPublisher` (`TransportPublisher`) + `MockTransportSubscriber` (`TransportSubscriber`); records publisher/subscriber creations; pub→sub fan-out so `pub.publish(...)` triggers matching subscribers' handlers |
| `QoSProfileTests.swift` | 11 — `sensorData` / `reliableSensor` / `latched` / `servicesDefault` / `default` presets, equatability (incl. history-depth differs), `toTransportQoS` reliability + keepAll mapping, `toQoSPolicy` keepLast + the documented `keepAll → depth = 0` umbrella sentinel (asymmetric with `TransportQoSMapper`'s `1000`) |
| `NodeLifecycleTests.swift` | 13 — context with injected session skips factory; context opens session when `isConnected == false`; `createNode` sets `name` / `namespace` / `fullyQualifiedName` (incl. root namespace `/n` join); publisher forwards to session with the namespace-prefixed topic; `publish` encodes CDR + delegates with sequence numbers `[0, 1, 2]`; absolute topics (`/abs/...`) bypass the namespace prefix; subscription registers; published message lands in `subscription.messages` AsyncStream; QoS flows through to the transport layer; `shutdown()` closes the session and invalidates outstanding publishers |

## Verification

- `swift build` — clean.
- `swift test --parallel` — 178 tests, zero failures (was 154; +24 new = 11 + 13).
- `swift format lint --recursive --strict` — clean over the new files.
- `swift package diagnose-api-breaking-changes 0.6.0` — no new breakages. Same 3 pre-existing breakages in `SwiftROS2Messages` (Services rename from #52) baseline.
- `MockTransportSession` conforms to public `TransportSession` only — no `@testable import`.
- Topic-prefix logic verified for both relative (`"chatter"` → `"/ns/chatter"`) and absolute (`"/abs/topic"` → `"/abs/topic"`) inputs.
- The `keepAll → 0` sentinel is documented in `testToQoSPolicyKeepAllUsesUmbrellaSentinel` so the asymmetry with `TransportQoSMapper` (`1000`) is not mistaken for a bug.

## Test plan

- [ ] CI: macOS, Linux (Humble/Jazzy/Rolling × x86_64/aarch64) matrices green. Windows / Android skip the `SwiftROS2Tests` target (it lives under `if !isWindowsBuild && !isAndroidBuild`), so this PR doesn't affect those.
- [ ] Coverage report shows `SwiftROS2` umbrella surface above the 70% gate (verified by PR 8's gate when it lands).