### PR TITLE
ci: enforce per-target line-coverage thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,42 +39,30 @@ jobs:
         run: swift build
       - name: Test (with coverage)
         run: swift test --parallel --enable-code-coverage
-      - name: Coverage report (informational)
+      - name: Coverage gate
         run: |
-          # Find the .xctest binary and the merged profdata produced by SwiftPM.
           BIN_PATH=$(swift build --show-bin-path)
           PROF_DATA="${BIN_PATH}/codecov/default.profdata"
           if [[ ! -f "$PROF_DATA" ]]; then
-            echo "No profdata found at $PROF_DATA — skipping coverage report"
-            exit 0
+            echo "ERROR: no profdata at $PROF_DATA" >&2
+            exit 1
           fi
-          # Locate every .xctest bundle that was just exercised. SwiftPM names them
-          # <package>PackageTests.xctest on macOS.
           XCTEST_BINS=()
           while IFS= read -r line; do
             XCTEST_BINS+=("$line")
           done < <(find "$BIN_PATH" -name "*.xctest" -type d)
-          if [[ ${#XCTEST_BINS[@]} -eq 0 ]]; then
-            echo "No xctest bundles found — skipping coverage report"
-            exit 0
-          fi
-          # The actual binary lives inside Contents/MacOS/<name>.
           BINARY_ARGS=()
           for bundle in "${XCTEST_BINS[@]}"; do
             name=$(basename "$bundle" .xctest)
             BINARY_ARGS+=("$bundle/Contents/MacOS/$name")
           done
-          echo "::group::Per-target line coverage"
-          # Coverage is informational — never gate the macOS job on it.
-          if ! xcrun llvm-cov report \
+          xcrun llvm-cov report \
             "${BINARY_ARGS[@]}" \
             -instr-profile="$PROF_DATA" \
-            -ignore-filename-regex="(\.build/|Tests/|vendor/)" \
+            -ignore-filename-regex="(\\.build/|Tests/|vendor/)" \
             -summary-only \
-            | tee coverage-summary.txt; then
-            echo "::warning::Coverage report generation failed; continuing because this step is informational"
-          fi
-          echo "::endgroup::"
+            | tee coverage-summary.txt \
+            | ./Scripts/coverage-gate.sh
       - name: Upload coverage summary
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
             -instr-profile="$PROF_DATA" \
             -ignore-filename-regex="(\\.build/|Tests/|vendor/)" \
             -summary-only \
-            | tee coverage-summary.txt \
-            | ./Scripts/coverage-gate.sh
+            > coverage-summary.txt
+          bash Scripts/coverage-gate.sh coverage-summary.txt
       - name: Upload coverage summary
         if: always()
         uses: actions/upload-artifact@v4

--- a/Scripts/coverage-gate.sh
+++ b/Scripts/coverage-gate.sh
@@ -4,8 +4,10 @@
 # Scripts/coverage-thresholds.txt and exit non-zero on any breach.
 #
 # Reads `xcrun llvm-cov report -summary-only` output on stdin or as the
-# first positional file argument. Output is the report itself (passed
-# through) plus a final pass/fail summary on stderr.
+# first positional file argument. Echoes the report through to stdout,
+# then prints a `=== Coverage gate ===` block: PASS lines on stdout,
+# FAIL lines on stderr. Exits 0 on all-pass, 1 on any breach, 2 on a
+# missing or malformed thresholds file.
 #
 # Usage:
 #   xcrun llvm-cov report ... -summary-only | Scripts/coverage-gate.sh
@@ -20,6 +22,33 @@ if [[ ! -f "$THRESHOLDS_FILE" ]]; then
   exit 2
 fi
 
+# Parse thresholds into parallel arrays (bash 3.2 compatible — no declare -A).
+# Validate up-front so a malformed file fails fast before we echo the report.
+THRESHOLD_KEYS=()
+THRESHOLD_VALS=()
+lineno=0
+while IFS='=' read -r key value; do
+  lineno=$((lineno + 1))
+  # Skip blank lines and full-line comments.
+  [[ -z "${key// }" || "$key" =~ ^[[:space:]]*# ]] && continue
+  key=$(echo "$key" | tr -d '[:space:]')
+  value=$(echo "$value" | tr -d '[:space:]')
+  if [[ -z "$key" ]]; then
+    echo "ERROR: $THRESHOLDS_FILE:$lineno has no key before '='" >&2
+    exit 2
+  fi
+  if [[ -z "$value" ]]; then
+    echo "ERROR: $THRESHOLDS_FILE:$lineno '$key' has no threshold value" >&2
+    exit 2
+  fi
+  if [[ ! "$value" =~ ^[0-9]+$ ]] || (( value < 0 || value > 100 )); then
+    echo "ERROR: $THRESHOLDS_FILE:$lineno '$key=$value' is not an integer percent in 0..100" >&2
+    exit 2
+  fi
+  THRESHOLD_KEYS+=("$key")
+  THRESHOLD_VALS+=("$value")
+done < "$THRESHOLDS_FILE"
+
 # Read the report — argument-or-stdin.
 if [[ $# -ge 1 ]]; then
   REPORT="$(cat "$1")"
@@ -29,29 +58,6 @@ fi
 
 # Echo the report so CI users can still see it.
 echo "$REPORT"
-
-# Parse thresholds into parallel arrays (bash 3.2 compatible — no declare -A).
-THRESHOLD_KEYS=()
-THRESHOLD_VALS=()
-while IFS='=' read -r key value; do
-  [[ -z "$key" || "$key" =~ ^[[:space:]]*# ]] && continue
-  key=$(echo "$key" | tr -d '[:space:]')
-  value=$(echo "$value" | tr -d '[:space:]')
-  THRESHOLD_KEYS+=("$key")
-  THRESHOLD_VALS+=("$value")
-done < "$THRESHOLDS_FILE"
-
-# Helper: look up threshold for a target name; prints empty string if absent.
-threshold_for() {
-  local name="$1"
-  local i
-  for i in "${!THRESHOLD_KEYS[@]}"; do
-    if [[ "${THRESHOLD_KEYS[$i]}" == "$name" ]]; then
-      echo "${THRESHOLD_VALS[$i]}"
-      return
-    fi
-  done
-}
 
 # llvm-cov -summary-only emits one line per source file plus a TOTAL line.
 # With -ignore-filename-regex stripping the leading path, filenames appear as

--- a/Scripts/coverage-gate.sh
+++ b/Scripts/coverage-gate.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# coverage-gate.sh
+# Compare per-target line coverage against the declared minimums in
+# Scripts/coverage-thresholds.txt and exit non-zero on any breach.
+#
+# Reads `xcrun llvm-cov report -summary-only` output on stdin or as the
+# first positional file argument. Output is the report itself (passed
+# through) plus a final pass/fail summary on stderr.
+#
+# Usage:
+#   xcrun llvm-cov report ... -summary-only | Scripts/coverage-gate.sh
+#   Scripts/coverage-gate.sh path/to/coverage-summary.txt
+
+set -euo pipefail
+
+THRESHOLDS_FILE="$(dirname "$0")/coverage-thresholds.txt"
+
+if [[ ! -f "$THRESHOLDS_FILE" ]]; then
+  echo "ERROR: thresholds file not found at $THRESHOLDS_FILE" >&2
+  exit 2
+fi
+
+# Read the report — argument-or-stdin.
+if [[ $# -ge 1 ]]; then
+  REPORT="$(cat "$1")"
+else
+  REPORT="$(cat)"
+fi
+
+# Echo the report so CI users can still see it.
+echo "$REPORT"
+
+# Parse thresholds into parallel arrays (bash 3.2 compatible — no declare -A).
+THRESHOLD_KEYS=()
+THRESHOLD_VALS=()
+while IFS='=' read -r key value; do
+  [[ -z "$key" || "$key" =~ ^[[:space:]]*# ]] && continue
+  key=$(echo "$key" | tr -d '[:space:]')
+  value=$(echo "$value" | tr -d '[:space:]')
+  THRESHOLD_KEYS+=("$key")
+  THRESHOLD_VALS+=("$value")
+done < "$THRESHOLDS_FILE"
+
+# Helper: look up threshold for a target name; prints empty string if absent.
+threshold_for() {
+  local name="$1"
+  local i
+  for i in "${!THRESHOLD_KEYS[@]}"; do
+    if [[ "${THRESHOLD_KEYS[$i]}" == "$name" ]]; then
+      echo "${THRESHOLD_VALS[$i]}"
+      return
+    fi
+  done
+}
+
+# llvm-cov -summary-only emits one line per source file plus a TOTAL line.
+# With -ignore-filename-regex stripping the leading path, filenames appear as
+# <Target>/File.swift (e.g. SwiftROS2CDR/CDREncoder.swift). We aggregate
+# per-target by the first path component. Coverage values shown by llvm-cov
+# in summary mode are the rightmost percentage column; for line coverage that
+# column matches the "Lines: %" header. We rely on the layout being:
+#
+#   Filename  Regions Missed Cover  Functions Missed Cover  Lines Missed Cover  Branches Missed Cover
+#
+# and pick columns from the right to stay robust across llvm-cov versions.
+
+# Per-target totals and covered counts (parallel arrays keyed by index in
+# THRESHOLD_KEYS so we reuse the already-parsed list).
+TARGET_TOTAL=()
+TARGET_COVERED=()
+for i in "${!THRESHOLD_KEYS[@]}"; do
+  TARGET_TOTAL+=(0)
+  TARGET_COVERED+=(0)
+done
+
+HAS_BRANCHES=$(echo "$REPORT" | head -1 | grep -c "Branches" || true)
+
+while IFS= read -r line; do
+  case "$line" in
+    Filename*|---*|TOTAL*|"") continue ;;
+  esac
+  # Lines appear as <Target>/File.swift ... — must contain a slash in field 1.
+  filename=$(echo "$line" | awk '{print $1}')
+  case "$filename" in
+    */*) ;;
+    *) continue ;;
+  esac
+
+  # Parse target = first path segment (SwiftROS2CDR from SwiftROS2CDR/CDREncoder.swift).
+  target=$(echo "$filename" | awk -F/ '{print $1}')
+  [[ -z "$target" ]] && continue
+
+  # Find index of this target in our threshold list; skip if not gated.
+  idx=-1
+  for i in "${!THRESHOLD_KEYS[@]}"; do
+    if [[ "${THRESHOLD_KEYS[$i]}" == "$target" ]]; then
+      idx=$i
+      break
+    fi
+  done
+  [[ "$idx" -eq -1 ]] && continue
+
+  if [[ "$HAS_BRANCHES" -ge 1 ]]; then
+    total=$(echo "$line" | awk '{print $(NF-5)}')
+    missed=$(echo "$line" | awk '{print $(NF-4)}')
+  else
+    total=$(echo "$line" | awk '{print $(NF-2)}')
+    missed=$(echo "$line" | awk '{print $(NF-1)}')
+  fi
+
+  # Defensive: total must be a non-negative integer.
+  [[ ! "$total" =~ ^[0-9]+$ ]] && continue
+  [[ ! "$missed" =~ ^[0-9]+$ ]] && continue
+
+  TARGET_TOTAL[$idx]=$(( TARGET_TOTAL[$idx] + total ))
+  TARGET_COVERED[$idx]=$(( TARGET_COVERED[$idx] + total - missed ))
+done <<< "$REPORT"
+
+echo
+echo "=== Coverage gate ==="
+exit_code=0
+for i in "${!THRESHOLD_KEYS[@]}"; do
+  target="${THRESHOLD_KEYS[$i]}"
+  total="${TARGET_TOTAL[$i]}"
+  covered="${TARGET_COVERED[$i]}"
+  threshold="${THRESHOLD_VALS[$i]}"
+  if [[ "$total" -eq 0 ]]; then
+    printf "FAIL  %-22s no source lines counted (target absent from report?)\n" "$target" >&2
+    exit_code=1
+    continue
+  fi
+  # Compute percentage as integer with one-decimal precision (covered*1000 / total).
+  pct_x10=$(( covered * 1000 / total ))
+  pct_int=$(( pct_x10 / 10 ))
+  pct_dec=$(( pct_x10 % 10 ))
+  if [[ "$pct_int" -ge "$threshold" ]]; then
+    printf "PASS  %-22s %d.%d%% >= %s%%\n" "$target" "$pct_int" "$pct_dec" "$threshold"
+  else
+    printf "FAIL  %-22s %d.%d%% < %s%%\n" "$target" "$pct_int" "$pct_dec" "$threshold" >&2
+    exit_code=1
+  fi
+done
+
+exit "$exit_code"

--- a/Scripts/coverage-thresholds.txt
+++ b/Scripts/coverage-thresholds.txt
@@ -1,0 +1,7 @@
+# Per-target line coverage minimums (percent). Edit a line, send a PR.
+# See docs/superpowers/specs/2026-04-28-swift-ros2-1.0.0-runway-design.md §6.2.
+SwiftROS2CDR=80
+SwiftROS2Wire=90
+SwiftROS2Messages=80
+SwiftROS2Transport=80
+SwiftROS2=70

--- a/Tests/SwiftROS2CDRTests/CDRRoundTripTests.swift
+++ b/Tests/SwiftROS2CDRTests/CDRRoundTripTests.swift
@@ -159,6 +159,106 @@ final class CDRRoundTripTests: XCTestCase {
         XCTAssertEqual(decoded, values)
     }
 
+    func testFloat32ArrayRoundTrip() throws {
+        let values: [Float] = [1.0, 2.5, -3.14, 0.0, 100.0, 200.0]
+
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        encoder.writeFloat32Array(values)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try decoder.readFloat32Array(count: 6)
+        XCTAssertEqual(decoded.count, values.count)
+        for (d, e) in zip(decoded, values) {
+            XCTAssertEqual(d, e, accuracy: 0.0001)
+        }
+    }
+
+    func testFloat32SequenceRoundTrip() throws {
+        let values: [Float] = [0.1, 0.2, 0.3]
+
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        encoder.writeFloat32Sequence(values)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try decoder.readFloat32Sequence()
+        XCTAssertEqual(decoded.count, values.count)
+        for (d, e) in zip(decoded, values) {
+            XCTAssertEqual(d, e, accuracy: 0.0001)
+        }
+    }
+
+    func testInt32SequenceRoundTrip() throws {
+        let values: [Int32] = [-1, 0, 1, Int32.max, Int32.min]
+
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        encoder.writeInt32Sequence(values)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try decoder.readInt32Sequence()
+        XCTAssertEqual(decoded, values)
+    }
+
+    func testUInt64RoundTrip() throws {
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        encoder.writeUInt64(UInt64.max)
+        encoder.writeUInt64(0)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        XCTAssertEqual(try decoder.readUInt64(), UInt64.max)
+        XCTAssertEqual(try decoder.readUInt64(), 0)
+    }
+
+    func testInt16RoundTrip() throws {
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        encoder.writeInt16(-32768)
+        encoder.writeInt16(32767)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        XCTAssertEqual(try decoder.readInt16(), -32768)
+        XCTAssertEqual(try decoder.readInt16(), 32767)
+    }
+
+    func testWritePaddingAndRawBytes() throws {
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        encoder.writeUInt8(0xAB)
+        encoder.writePadding(3)
+        encoder.writeRawBytes([UInt8]([0x01, 0x02, 0x03]))
+        encoder.writeRawBytes(Data([0xDE, 0xAD]))
+
+        // Verify total byte count: 4 (encap) + 1 + 3 + 3 + 2 = 13
+        XCTAssertEqual(encoder.count, 13)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        XCTAssertEqual(try decoder.readUInt8(), 0xAB)
+        // Skip the 3 padding bytes
+        try decoder.skipBytes(3)
+        let raw = try decoder.readRawBytes(count: 3)
+        XCTAssertEqual(Array(raw), [0x01, 0x02, 0x03])
+    }
+
+    func testEncoderReset() throws {
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        encoder.writeUInt32(42)
+        let countBefore = encoder.count
+
+        encoder.reset()
+        XCTAssertEqual(encoder.count, 0)
+        XCTAssertNotEqual(encoder.count, countBefore)
+
+        // After reset write fresh content and verify
+        encoder.writeEncapsulationHeader()
+        encoder.writeUInt32(99)
+        let decoder = try CDRDecoder(data: encoder.getData())
+        XCTAssertEqual(try decoder.readUInt32(), 99)
+    }
+
     func testUInt8SequenceRoundTrip() throws {
         let data = Data([0x00, 0x01, 0xFF, 0x42, 0x88])
 

--- a/Tests/SwiftROS2Tests/MessageRoundTripTests.swift
+++ b/Tests/SwiftROS2Tests/MessageRoundTripTests.swift
@@ -442,6 +442,209 @@ final class MessageRoundTripTests: XCTestCase {
         XCTAssertEqual(decoded.positionCovarianceType, NavSatFix.CovarianceType.diagonalKnown.rawValue)
     }
 
+    // MARK: - Geometry Messages (TF)
+
+    func testTFMessageEmptyRoundTrip() throws {
+        let original = TFMessage(transforms: [])
+
+        let encoder = CDREncoder()
+        try original.encode(to: encoder)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try TFMessage(from: decoder)
+
+        XCTAssertEqual(decoded.transforms.count, 0)
+    }
+
+    func testTFMessageRoundTrip() throws {
+        let original = TFMessage(transforms: [
+            TransformStamped(
+                header: Header(sec: 100, nanosec: 0, frameId: "world"),
+                childFrameId: "base_link",
+                transform: Transform(
+                    translation: Vector3(x: 1.0, y: 2.0, z: 3.0),
+                    rotation: Quaternion(x: 0.0, y: 0.0, z: 0.707, w: 0.707)
+                )
+            ),
+            TransformStamped(
+                header: Header(sec: 200, nanosec: 500000000, frameId: "base_link"),
+                childFrameId: "sensor_link",
+                transform: Transform(
+                    translation: Vector3(x: 0.1, y: 0.0, z: 0.5),
+                    rotation: Quaternion(x: 0.0, y: 0.0, z: 0.0, w: 1.0)
+                )
+            ),
+        ])
+
+        let encoder = CDREncoder()
+        try original.encode(to: encoder)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try TFMessage(from: decoder)
+
+        XCTAssertEqual(decoded.transforms.count, 2)
+        XCTAssertEqual(decoded.transforms[0].header.frameId, "world")
+        XCTAssertEqual(decoded.transforms[0].childFrameId, "base_link")
+        XCTAssertEqual(decoded.transforms[0].transform.translation, original.transforms[0].transform.translation)
+        XCTAssertEqual(decoded.transforms[0].transform.rotation, original.transforms[0].transform.rotation)
+        XCTAssertEqual(decoded.transforms[1].header.frameId, "base_link")
+        XCTAssertEqual(decoded.transforms[1].childFrameId, "sensor_link")
+    }
+
+    func testTFMessageTypeInfo() {
+        XCTAssertEqual(TFMessage.typeInfo.typeName, "tf2_msgs/msg/TFMessage")
+        XCTAssertNotNil(TFMessage.typeInfo.typeHash)
+        XCTAssertTrue(TFMessage.typeInfo.typeHash!.hasPrefix("RIHS01_"))
+    }
+
+    // MARK: - Sensor Messages (RegionOfInterest)
+
+    func testRegionOfInterestDefaultRoundTrip() throws {
+        let original = RegionOfInterest()
+
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        try original.encode(to: encoder)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try RegionOfInterest(from: decoder)
+
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.xOffset, 0)
+        XCTAssertEqual(decoded.yOffset, 0)
+        XCTAssertEqual(decoded.height, 0)
+        XCTAssertEqual(decoded.width, 0)
+        XCTAssertFalse(decoded.doRectify)
+    }
+
+    func testRegionOfInterestRoundTrip() throws {
+        let original = RegionOfInterest(xOffset: 10, yOffset: 20, height: 480, width: 640, doRectify: true)
+
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        try original.encode(to: encoder)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try RegionOfInterest(from: decoder)
+
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.xOffset, 10)
+        XCTAssertEqual(decoded.yOffset, 20)
+        XCTAssertEqual(decoded.height, 480)
+        XCTAssertEqual(decoded.width, 640)
+        XCTAssertTrue(decoded.doRectify)
+    }
+
+    func testRegionOfInterestFullFrameFactory() throws {
+        let roi = RegionOfInterest.fullFrame(width: 1920, height: 1080)
+
+        XCTAssertEqual(roi.xOffset, 0)
+        XCTAssertEqual(roi.yOffset, 0)
+        XCTAssertEqual(roi.width, 1920)
+        XCTAssertEqual(roi.height, 1080)
+        XCTAssertFalse(roi.doRectify)
+
+        let encoder = CDREncoder()
+        encoder.writeEncapsulationHeader()
+        try roi.encode(to: encoder)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try RegionOfInterest(from: decoder)
+
+        XCTAssertEqual(decoded, roi)
+    }
+
+    // MARK: - Sensor Messages (CameraInfo)
+
+    func testCameraInfoDefaultRoundTrip() throws {
+        let original = CameraInfo()
+
+        let encoder = CDREncoder()
+        try original.encode(to: encoder)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try CameraInfo(from: decoder)
+
+        XCTAssertEqual(decoded.height, 0)
+        XCTAssertEqual(decoded.width, 0)
+        XCTAssertEqual(decoded.distortionModel, "plumb_bob")
+        XCTAssertEqual(decoded.d.count, 0)
+        XCTAssertEqual(decoded.k.count, 9)
+        XCTAssertEqual(decoded.r, [1, 0, 0, 0, 1, 0, 0, 0, 1])
+        XCTAssertEqual(decoded.p.count, 12)
+        XCTAssertEqual(decoded.binningX, 0)
+        XCTAssertEqual(decoded.binningY, 0)
+    }
+
+    func testCameraInfoRoundTrip() throws {
+        let original = CameraInfo(
+            header: Header(sec: 1000, nanosec: 0, frameId: "camera_optical_frame"),
+            height: 480,
+            width: 640,
+            distortionModel: "plumb_bob",
+            d: [0.1, -0.2, 0.001, 0.0005, 0.0],
+            k: [500.0, 0.0, 320.0, 0.0, 500.0, 240.0, 0.0, 0.0, 1.0],
+            r: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            p: [500.0, 0.0, 320.0, 0.0, 0.0, 500.0, 240.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            binningX: 1,
+            binningY: 1,
+            roi: RegionOfInterest(xOffset: 0, yOffset: 0, height: 480, width: 640, doRectify: false)
+        )
+
+        let encoder = CDREncoder()
+        try original.encode(to: encoder)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try CameraInfo(from: decoder)
+
+        XCTAssertEqual(decoded.header.frameId, "camera_optical_frame")
+        XCTAssertEqual(decoded.height, 480)
+        XCTAssertEqual(decoded.width, 640)
+        XCTAssertEqual(decoded.distortionModel, "plumb_bob")
+        XCTAssertEqual(decoded.d.count, 5)
+        XCTAssertEqual(decoded.d[0], 0.1, accuracy: 1e-12)
+        XCTAssertEqual(decoded.d[1], -0.2, accuracy: 1e-12)
+        XCTAssertEqual(decoded.k, original.k)
+        XCTAssertEqual(decoded.r, original.r)
+        XCTAssertEqual(decoded.p, original.p)
+        XCTAssertEqual(decoded.binningX, 1)
+        XCTAssertEqual(decoded.binningY, 1)
+        XCTAssertEqual(decoded.roi, original.roi)
+    }
+
+    func testCameraInfoEmptyDistortionSequenceRoundTrip() throws {
+        let original = CameraInfo(
+            header: Header(sec: 2000, nanosec: 0, frameId: "cam"),
+            height: 720,
+            width: 1280,
+            distortionModel: "rational_polynomial",
+            d: [],
+            k: [600.0, 0.0, 640.0, 0.0, 600.0, 360.0, 0.0, 0.0, 1.0],
+            r: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            p: [600.0, 0.0, 640.0, 0.0, 0.0, 600.0, 360.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            binningX: 0,
+            binningY: 0,
+            roi: RegionOfInterest.fullFrame(width: 1280, height: 720)
+        )
+
+        let encoder = CDREncoder()
+        try original.encode(to: encoder)
+
+        let decoder = try CDRDecoder(data: encoder.getData())
+        let decoded = try CameraInfo(from: decoder)
+
+        XCTAssertEqual(decoded.d.count, 0)
+        XCTAssertEqual(decoded.distortionModel, "rational_polynomial")
+        XCTAssertEqual(decoded.roi.width, 1280)
+        XCTAssertEqual(decoded.roi.height, 720)
+    }
+
+    func testCameraInfoTypeInfo() {
+        XCTAssertEqual(CameraInfo.typeInfo.typeName, "sensor_msgs/msg/CameraInfo")
+        XCTAssertNotNil(CameraInfo.typeInfo.typeHash)
+        XCTAssertTrue(CameraInfo.typeInfo.typeHash!.hasPrefix("RIHS01_"))
+    }
+
     /// Locks the byte-level CDR layout of sensor_msgs/NavSatFix to the IDL offsets so
     /// stray manual padding cannot drift the fields again. Round-trip tests alone miss
     /// this class of bug because a buggy encoder pairs with a symmetrically-buggy

--- a/Tests/SwiftROS2WireTests/WireCodecTests.swift
+++ b/Tests/SwiftROS2WireTests/WireCodecTests.swift
@@ -198,4 +198,53 @@ final class WireCodecTests: XCTestCase {
         XCTAssertEqual(ROS2Distro.jazzy.formatTypeHash("RIHS01_abc"), "RIHS01_abc")
         XCTAssertEqual(ROS2Distro.jazzy.formatTypeHash(nil), "")
     }
+
+    func testDistroDisplayNames() {
+        XCTAssertEqual(ROS2Distro.humble.displayName, "Humble")
+        XCTAssertEqual(ROS2Distro.jazzy.displayName, "Jazzy")
+        XCTAssertEqual(ROS2Distro.kilted.displayName, "Kilted")
+        XCTAssertEqual(ROS2Distro.rolling.displayName, "Rolling")
+    }
+
+    func testDistroIsLegacySchema() {
+        XCTAssertTrue(ROS2Distro.humble.isLegacySchema)
+        XCTAssertFalse(ROS2Distro.jazzy.isLegacySchema)
+        XCTAssertFalse(ROS2Distro.kilted.isLegacySchema)
+        XCTAssertFalse(ROS2Distro.rolling.isLegacySchema)
+    }
+
+    func testDistroWireGroup() {
+        XCTAssertEqual(ROS2Distro.humble.wireGroup, .legacy)
+        XCTAssertEqual(ROS2Distro.jazzy.wireGroup, .modern)
+        XCTAssertEqual(ROS2Distro.kilted.wireGroup, .modern)
+        XCTAssertEqual(ROS2Distro.rolling.wireGroup, .modern)
+    }
+
+    func testDistroTypeHashPlaceholder() {
+        XCTAssertEqual(ROS2Distro.humble.typeHashPlaceholder, "TypeHashNotSupported")
+        XCTAssertEqual(ROS2Distro.jazzy.typeHashPlaceholder, "TypeHashNotSupported")
+    }
+
+    func testDistroAlwaysIncludeTypeHashInKey() {
+        XCTAssertTrue(ROS2Distro.humble.alwaysIncludeTypeHashInKey)
+        XCTAssertFalse(ROS2Distro.jazzy.alwaysIncludeTypeHashInKey)
+        XCTAssertFalse(ROS2Distro.kilted.alwaysIncludeTypeHashInKey)
+        XCTAssertFalse(ROS2Distro.rolling.alwaysIncludeTypeHashInKey)
+    }
+
+    func testWireGroupDistros() {
+        XCTAssertEqual(ROS2Distro.WireGroup.legacy.distros, [.humble])
+        XCTAssertEqual(ROS2Distro.WireGroup.modern.distros, [.jazzy, .kilted, .rolling])
+    }
+
+    func testWireGroupRawValues() {
+        XCTAssertEqual(ROS2Distro.WireGroup.legacy.rawValue, "Humble and earlier")
+        XCTAssertEqual(ROS2Distro.WireGroup.modern.rawValue, "Iron and later")
+    }
+
+    func testDistroAllCases() {
+        XCTAssertEqual(ROS2Distro.allCases.count, 4)
+        XCTAssertTrue(ROS2Distro.allCases.contains(.humble))
+        XCTAssertTrue(ROS2Distro.allCases.contains(.rolling))
+    }
 }


### PR DESCRIPTION
## Summary

Convert the informational coverage report from PR 7 (#61) into a gating check that fails the macOS CI job when any target's line coverage falls below its declared minimum. Thresholds live in `Scripts/coverage-thresholds.txt` so loosening them later is a one-line PR.

## Changes

**Tests added** (so all gated targets clear their thresholds):

- `Tests/SwiftROS2Tests/MessageRoundTripTests.swift`: round-trip tests for `TFMessage`, `CameraInfo`, `RegionOfInterest` (previously 0% coverage).
- `Tests/SwiftROS2CDRTests/CDRRoundTripTests.swift`: covers previously-untested `CDREncoder` methods (`writeFloat32Array`, `writeFloat32Sequence`, `writeInt32Sequence`, `writeUInt64`, `writeInt16`, `writePadding`, `writeRawBytes`, `reset`).
- `Tests/SwiftROS2WireTests/WireCodecTests.swift`: covers `ROS2Distro` properties (`displayName`, `isLegacySchema`, `wireGroup`, `typeHashPlaceholder`, `alwaysIncludeTypeHashInKey`) and `WireGroup.distros` / `WireGroup.rawValue`.

**Gate infrastructure**:

- `Scripts/coverage-thresholds.txt`: per-target line-coverage minimums.
  - `SwiftROS2CDR=80`, `SwiftROS2Wire=90`, `SwiftROS2Messages=80`, `SwiftROS2Transport=80`, `SwiftROS2=70`.
  - `SwiftROS2Zenoh` / `SwiftROS2DDS` are intentionally absent — covered by LAN integration tests.
- `Scripts/coverage-gate.sh`: parses `xcrun llvm-cov report -summary-only`, aggregates per target, exits non-zero on any breach. Echoes the original report to stdout so CI artifacts remain readable; FAIL summary to stderr.
- `.github/workflows/ci.yml`: replaces the `Coverage report (informational)` step in `build-macos` with `Coverage gate` that pipes the report through the script. Linux / Windows / Android jobs are unchanged — gating is macOS-only per the spec.

## Local verification

```
=== Coverage gate ===
PASS  SwiftROS2CDR           91.9% >= 80%
PASS  SwiftROS2Wire          97.9% >= 90%
PASS  SwiftROS2Messages      87.8% >= 80%
PASS  SwiftROS2Transport     86.9% >= 80%
PASS  SwiftROS2              93.5% >= 70%
```

All 203 tests pass under `swift test --parallel`.

## Test plan

- [ ] CI macOS job's `Coverage gate` step ends with `PASS` lines for all five targets.
- [ ] Linux / Windows / Android CI jobs remain green.
- [ ] `coverage-summary` artifact still uploads from the macOS job.