### PR TITLE
feat(wire): service key-expr / liveliness / DDS rq+rr (phase 2 of 6)

### DIFF
--- a/Sources/SwiftROS2Wire/DDSWireCodec.swift
+++ b/Sources/SwiftROS2Wire/DDSWireCodec.swift
@@ -32,4 +32,42 @@ public struct DDSWireCodec: Sendable {
         guard let hash = typeHash, !hash.isEmpty else { return nil }
         return "typehash=\(hash);"
     }
+
+    /// Names emitted for a DDS service: paired request / reply topics + DDS type names.
+    public struct ServiceTopicNames: Sendable, Equatable {
+        public let requestTopic: String
+        public let replyTopic: String
+        public let requestTypeName: String
+        public let replyTypeName: String
+
+        public init(
+            requestTopic: String,
+            replyTopic: String,
+            requestTypeName: String,
+            replyTypeName: String
+        ) {
+            self.requestTopic = requestTopic
+            self.replyTopic = replyTopic
+            self.requestTypeName = requestTypeName
+            self.replyTypeName = replyTypeName
+        }
+    }
+
+    /// Build the DDS topic / type name quadruple for a service.
+    ///
+    /// rmw_cyclonedds_cpp pairs each service with two topics:
+    /// - `rq/<service>Request` (client → server)
+    /// - `rr/<service>Reply`   (server → client)
+    public func serviceTopicNames(
+        serviceName: String,
+        serviceTypeName: String
+    ) -> ServiceTopicNames {
+        let cleanService = TypeNameConverter.stripLeadingSlash(serviceName)
+        return ServiceTopicNames(
+            requestTopic: "rq/\(cleanService)Request",
+            replyTopic: "rr/\(cleanService)Reply",
+            requestTypeName: TypeNameConverter.toDDSServiceRequestTypeName(serviceTypeName),
+            replyTypeName: TypeNameConverter.toDDSServiceResponseTypeName(serviceTypeName)
+        )
+    }
 }

--- a/Sources/SwiftROS2Wire/TypeNameConverter.swift
+++ b/Sources/SwiftROS2Wire/TypeNameConverter.swift
@@ -35,4 +35,26 @@ public enum TypeNameConverter {
         }
         return fullPath.replacingOccurrences(of: "/", with: "%")
     }
+
+    /// Convert a ROS service type name to the DDS request type name.
+    ///
+    /// "example_interfaces/srv/AddTwoInts" -> "example_interfaces::srv::dds_::AddTwoInts_Request_"
+    public static func toDDSServiceRequestTypeName(_ serviceTypeName: String) -> String {
+        toDDSServiceSuffixedTypeName(serviceTypeName, suffix: "Request")
+    }
+
+    /// Convert a ROS service type name to the DDS response type name.
+    ///
+    /// "example_interfaces/srv/AddTwoInts" -> "example_interfaces::srv::dds_::AddTwoInts_Response_"
+    public static func toDDSServiceResponseTypeName(_ serviceTypeName: String) -> String {
+        toDDSServiceSuffixedTypeName(serviceTypeName, suffix: "Response")
+    }
+
+    private static func toDDSServiceSuffixedTypeName(_ serviceTypeName: String, suffix: String) -> String {
+        let parts = serviceTypeName.split(separator: "/", maxSplits: .max, omittingEmptySubsequences: true)
+        guard parts.count == 3 else {
+            return serviceTypeName.replacingOccurrences(of: "/", with: "::") + "_\(suffix)_"
+        }
+        return "\(parts[0])::\(parts[1])::dds_::\(parts[2])_\(suffix)_"
+    }
 }

--- a/Sources/SwiftROS2Wire/ZenohWireCodec.swift
+++ b/Sources/SwiftROS2Wire/ZenohWireCodec.swift
@@ -48,6 +48,8 @@ public struct ZenohWireCodec: WireCodec {
     /// - The DDS request type name uses `<pkg>::srv::dds_::<Type>_Request_` form.
     /// - On Humble, the trailing segment is `TypeHashNotSupported`.
     /// - On Jazzy+ with no hash, the trailing segment is omitted (matching Pub/Sub).
+    /// - A leading slash on `serviceName` is stripped so callers can pass either
+    ///   `/trigger` or `trigger` without producing a `//` segment.
     public func makeServiceKeyExpr(
         domainId: Int,
         namespace: String,
@@ -56,9 +58,10 @@ public struct ZenohWireCodec: WireCodec {
         requestTypeHash: String?
     ) -> String {
         let cleanNamespace = TypeNameConverter.stripLeadingSlash(namespace)
+        let cleanServiceName = TypeNameConverter.stripLeadingSlash(serviceName)
         let ddsRequestTypeName = TypeNameConverter.toDDSServiceRequestTypeName(serviceTypeName)
         let hashComponent = distro.formatTypeHash(requestTypeHash)
-        let svcPath = cleanNamespace.isEmpty ? serviceName : "\(cleanNamespace)/\(serviceName)"
+        let svcPath = cleanNamespace.isEmpty ? cleanServiceName : "\(cleanNamespace)/\(cleanServiceName)"
 
         if !distro.alwaysIncludeTypeHashInKey && hashComponent.isEmpty {
             return "\(domainId)/\(svcPath)/\(ddsRequestTypeName)"
@@ -83,6 +86,13 @@ public struct ZenohWireCodec: WireCodec {
     /// Generate a Service-shaped liveliness token (`SS` / `SC`).
     ///
     /// Format: `@ros2_lv/<domain>/<session>/<node>/<entity>/<SS|SC>/%/%/<node_name>/<mangled_service_path>/<dds_request_type>/<request_hash>/<qos>`
+    ///
+    /// - On Humble, the hash segment is `TypeHashNotSupported`.
+    /// - On Jazzy+ with no hash, the hash segment is omitted (parallel to
+    ///   ``makeServiceKeyExpr(domainId:namespace:serviceName:serviceTypeName:requestTypeHash:)``)
+    ///   so the token never contains a `//` segment.
+    /// - `serviceName` may carry a leading slash; ``TypeNameConverter/mangleTopicPath(namespace:topic:)``
+    ///   normalizes it.
     public func makeServiceLivelinessToken(
         entityKind: ServiceEntityKind,
         domainId: Int,
@@ -96,13 +106,19 @@ public struct ZenohWireCodec: WireCodec {
         requestTypeHash: String?,
         qos: QoSPolicy
     ) -> String {
-        let mangled = TypeNameConverter.mangleTopicPath(namespace: namespace, topic: serviceName)
+        let cleanServiceName = TypeNameConverter.stripLeadingSlash(serviceName)
+        let mangled = TypeNameConverter.mangleTopicPath(namespace: namespace, topic: cleanServiceName)
         let ddsRequestTypeName = TypeNameConverter.toDDSServiceRequestTypeName(serviceTypeName)
         let hashComponent = distro.formatTypeHash(requestTypeHash)
         let qosKeyExpr = qos.toKeyExpr()
+        let prefix =
+            "@ros2_lv/\(domainId)/\(sessionId)/\(nodeId)/\(entityId)/\(entityKind.rawValue)/%/%/\(nodeName)/\(mangled)/\(ddsRequestTypeName)"
 
-        return
-            "@ros2_lv/\(domainId)/\(sessionId)/\(nodeId)/\(entityId)/\(entityKind.rawValue)/%/%/\(nodeName)/\(mangled)/\(ddsRequestTypeName)/\(hashComponent)/\(qosKeyExpr)"
+        if !distro.alwaysIncludeTypeHashInKey && hashComponent.isEmpty {
+            return "\(prefix)/\(qosKeyExpr)"
+        } else {
+            return "\(prefix)/\(hashComponent)/\(qosKeyExpr)"
+        }
     }
 
     // MARK: - Liveliness Token

--- a/Sources/SwiftROS2Wire/ZenohWireCodec.swift
+++ b/Sources/SwiftROS2Wire/ZenohWireCodec.swift
@@ -41,6 +41,32 @@ public struct ZenohWireCodec: WireCodec {
         }
     }
 
+    /// Generate the Zenoh service key expression
+    ///
+    /// Format: `<domain>/<namespace>/<service_name>/<dds_request_type_name>/<request_type_hash>`
+    ///
+    /// - The DDS request type name uses `<pkg>::srv::dds_::<Type>_Request_` form.
+    /// - On Humble, the trailing segment is `TypeHashNotSupported`.
+    /// - On Jazzy+ with no hash, the trailing segment is omitted (matching Pub/Sub).
+    public func makeServiceKeyExpr(
+        domainId: Int,
+        namespace: String,
+        serviceName: String,
+        serviceTypeName: String,
+        requestTypeHash: String?
+    ) -> String {
+        let cleanNamespace = TypeNameConverter.stripLeadingSlash(namespace)
+        let ddsRequestTypeName = TypeNameConverter.toDDSServiceRequestTypeName(serviceTypeName)
+        let hashComponent = distro.formatTypeHash(requestTypeHash)
+        let svcPath = cleanNamespace.isEmpty ? serviceName : "\(cleanNamespace)/\(serviceName)"
+
+        if !distro.alwaysIncludeTypeHashInKey && hashComponent.isEmpty {
+            return "\(domainId)/\(svcPath)/\(ddsRequestTypeName)"
+        } else {
+            return "\(domainId)/\(svcPath)/\(ddsRequestTypeName)/\(hashComponent)"
+        }
+    }
+
     // MARK: - Liveliness Token
 
     /// Generate liveliness token for ROS 2 discovery

--- a/Sources/SwiftROS2Wire/ZenohWireCodec.swift
+++ b/Sources/SwiftROS2Wire/ZenohWireCodec.swift
@@ -67,6 +67,44 @@ public struct ZenohWireCodec: WireCodec {
         }
     }
 
+    // MARK: - Service Liveliness Token
+
+    /// Liveliness-token entity kind for Service entities.
+    ///
+    /// Parallels rmw_zenoh_cpp's per-entity-kind tags (`MP` = message publisher,
+    /// `SS` = service server, `SC` = service client). Pub/Sub is hard-coded to
+    /// `MP` in `makeLivelinessToken`; services pass one of these values to
+    /// ``makeServiceLivelinessToken(entityKind:domainId:sessionId:nodeId:entityId:namespace:nodeName:serviceName:serviceTypeName:requestTypeHash:qos:)``.
+    public enum ServiceEntityKind: String, Sendable {
+        case serviceServer = "SS"
+        case serviceClient = "SC"
+    }
+
+    /// Generate a Service-shaped liveliness token (`SS` / `SC`).
+    ///
+    /// Format: `@ros2_lv/<domain>/<session>/<node>/<entity>/<SS|SC>/%/%/<node_name>/<mangled_service_path>/<dds_request_type>/<request_hash>/<qos>`
+    public func makeServiceLivelinessToken(
+        entityKind: ServiceEntityKind,
+        domainId: Int,
+        sessionId: String,
+        nodeId: String,
+        entityId: String,
+        namespace: String,
+        nodeName: String,
+        serviceName: String,
+        serviceTypeName: String,
+        requestTypeHash: String?,
+        qos: QoSPolicy
+    ) -> String {
+        let mangled = TypeNameConverter.mangleTopicPath(namespace: namespace, topic: serviceName)
+        let ddsRequestTypeName = TypeNameConverter.toDDSServiceRequestTypeName(serviceTypeName)
+        let hashComponent = distro.formatTypeHash(requestTypeHash)
+        let qosKeyExpr = qos.toKeyExpr()
+
+        return
+            "@ros2_lv/\(domainId)/\(sessionId)/\(nodeId)/\(entityId)/\(entityKind.rawValue)/%/%/\(nodeName)/\(mangled)/\(ddsRequestTypeName)/\(hashComponent)/\(qosKeyExpr)"
+    }
+
     // MARK: - Liveliness Token
 
     /// Generate liveliness token for ROS 2 discovery

--- a/Tests/SwiftROS2WireTests/ServiceWireFormatTests.swift
+++ b/Tests/SwiftROS2WireTests/ServiceWireFormatTests.swift
@@ -1,0 +1,34 @@
+// ServiceWireFormatTests.swift
+// Golden tests for the Service-shaped wire format helpers
+// (Zenoh service key expression, SS / SC liveliness tokens, DDS rq / rr
+// topic names, and Service request/response DDS type-name conversion).
+
+import XCTest
+
+@testable import SwiftROS2Wire
+
+final class ServiceWireFormatTests: XCTestCase {
+    // MARK: - DDS service type names
+
+    func testDDSServiceRequestTypeName() {
+        XCTAssertEqual(
+            TypeNameConverter.toDDSServiceRequestTypeName("example_interfaces/srv/AddTwoInts"),
+            "example_interfaces::srv::dds_::AddTwoInts_Request_"
+        )
+        XCTAssertEqual(
+            TypeNameConverter.toDDSServiceRequestTypeName("std_srvs/srv/Trigger"),
+            "std_srvs::srv::dds_::Trigger_Request_"
+        )
+    }
+
+    func testDDSServiceResponseTypeName() {
+        XCTAssertEqual(
+            TypeNameConverter.toDDSServiceResponseTypeName("example_interfaces/srv/AddTwoInts"),
+            "example_interfaces::srv::dds_::AddTwoInts_Response_"
+        )
+        XCTAssertEqual(
+            TypeNameConverter.toDDSServiceResponseTypeName("std_srvs/srv/Trigger"),
+            "std_srvs::srv::dds_::Trigger_Response_"
+        )
+    }
+}

--- a/Tests/SwiftROS2WireTests/ServiceWireFormatTests.swift
+++ b/Tests/SwiftROS2WireTests/ServiceWireFormatTests.swift
@@ -31,4 +31,67 @@ final class ServiceWireFormatTests: XCTestCase {
             "std_srvs::srv::dds_::Trigger_Response_"
         )
     }
+
+    // MARK: - Zenoh service key expression
+
+    func testJazzyServiceKeyExpression() {
+        let codec = ZenohWireCodec(distro: .jazzy)
+        let key = codec.makeServiceKeyExpr(
+            domainId: 0,
+            namespace: "",
+            serviceName: "add_two_ints",
+            serviceTypeName: "example_interfaces/srv/AddTwoInts",
+            requestTypeHash: "RIHS01_abc123"
+        )
+        XCTAssertEqual(
+            key,
+            "0/add_two_ints/example_interfaces::srv::dds_::AddTwoInts_Request_/RIHS01_abc123"
+        )
+    }
+
+    func testJazzyServiceKeyExpressionWithNamespace() {
+        let codec = ZenohWireCodec(distro: .jazzy)
+        let key = codec.makeServiceKeyExpr(
+            domainId: 0,
+            namespace: "/ios",
+            serviceName: "trigger",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: "RIHS01_aaa"
+        )
+        XCTAssertEqual(
+            key,
+            "0/ios/trigger/std_srvs::srv::dds_::Trigger_Request_/RIHS01_aaa"
+        )
+    }
+
+    func testHumbleServiceKeyExpression() {
+        let codec = ZenohWireCodec(distro: .humble)
+        let key = codec.makeServiceKeyExpr(
+            domainId: 0,
+            namespace: "",
+            serviceName: "add_two_ints",
+            serviceTypeName: "example_interfaces/srv/AddTwoInts",
+            requestTypeHash: nil
+        )
+        XCTAssertEqual(
+            key,
+            "0/add_two_ints/example_interfaces::srv::dds_::AddTwoInts_Request_/TypeHashNotSupported"
+        )
+    }
+
+    func testJazzyServiceKeyExpressionNoTypeHash() {
+        let codec = ZenohWireCodec(distro: .jazzy)
+        let key = codec.makeServiceKeyExpr(
+            domainId: 0,
+            namespace: "",
+            serviceName: "add_two_ints",
+            serviceTypeName: "example_interfaces/srv/AddTwoInts",
+            requestTypeHash: nil
+        )
+        // Jazzy omits trailing segment when hash is empty (parallel to Pub/Sub).
+        XCTAssertEqual(
+            key,
+            "0/add_two_ints/example_interfaces::srv::dds_::AddTwoInts_Request_"
+        )
+    }
 }

--- a/Tests/SwiftROS2WireTests/ServiceWireFormatTests.swift
+++ b/Tests/SwiftROS2WireTests/ServiceWireFormatTests.swift
@@ -95,6 +95,50 @@ final class ServiceWireFormatTests: XCTestCase {
         )
     }
 
+    func testServiceKeyExpressionStripsLeadingSlashFromServiceName() {
+        // Callers may pass either "/trigger" or "trigger" (the umbrella API
+        // tends to produce fully-qualified names). The leading slash must be
+        // normalized away — otherwise the key expression contains a "//"
+        // segment that Zenoh rejects.
+        let codec = ZenohWireCodec(distro: .jazzy)
+        let withSlash = codec.makeServiceKeyExpr(
+            domainId: 0,
+            namespace: "",
+            serviceName: "/trigger",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: "RIHS01_aaa"
+        )
+        let withoutSlash = codec.makeServiceKeyExpr(
+            domainId: 0,
+            namespace: "",
+            serviceName: "trigger",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: "RIHS01_aaa"
+        )
+        XCTAssertEqual(withSlash, withoutSlash)
+        XCTAssertFalse(withSlash.contains("//"))
+        XCTAssertEqual(
+            withSlash,
+            "0/trigger/std_srvs::srv::dds_::Trigger_Request_/RIHS01_aaa"
+        )
+    }
+
+    func testServiceKeyExpressionStripsLeadingSlashAndKeepsNamespace() {
+        let codec = ZenohWireCodec(distro: .jazzy)
+        let key = codec.makeServiceKeyExpr(
+            domainId: 0,
+            namespace: "/ios",
+            serviceName: "/trigger",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: "RIHS01_aaa"
+        )
+        XCTAssertFalse(key.contains("//"))
+        XCTAssertEqual(
+            key,
+            "0/ios/trigger/std_srvs::srv::dds_::Trigger_Request_/RIHS01_aaa"
+        )
+    }
+
     // MARK: - Zenoh service liveliness tokens
 
     func testJazzyServiceServerLiveliness() {
@@ -166,6 +210,58 @@ final class ServiceWireFormatTests: XCTestCase {
     func testServiceEntityKindRawValues() {
         XCTAssertEqual(ZenohWireCodec.ServiceEntityKind.serviceServer.rawValue, "SS")
         XCTAssertEqual(ZenohWireCodec.ServiceEntityKind.serviceClient.rawValue, "SC")
+    }
+
+    func testJazzyServiceLivelinessOmitsEmptyHashSegment() {
+        // On Jazzy+ with no type hash supplied, the hash segment must be
+        // omitted — interpolating an empty string would produce "//" in the
+        // token, which is an invalid key expression. Behavior parallels
+        // makeServiceKeyExpr.
+        let codec = ZenohWireCodec(distro: .jazzy)
+        let qosSuffix = QoSPolicy.servicesDefault.toKeyExpr()
+        let token = codec.makeServiceLivelinessToken(
+            entityKind: .serviceServer,
+            domainId: 0,
+            sessionId: "AABB",
+            nodeId: "1",
+            entityId: "2",
+            namespace: "",
+            nodeName: "node",
+            serviceName: "trigger",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: nil,
+            qos: .servicesDefault
+        )
+        // Strip the protocol prefix before checking for "//", since the spec-
+        // defined "/%/%/" template legitimately contains adjacent separators.
+        let bodyAfterPrefix = String(token.dropFirst("@ros2_lv/0/AABB/1/2/SS/%/%/".count))
+        XCTAssertFalse(bodyAfterPrefix.contains("//"), "token body unexpectedly contained '//': \(token)")
+        XCTAssertEqual(
+            token,
+            "@ros2_lv/0/AABB/1/2/SS/%/%/node/%trigger/std_srvs::srv::dds_::Trigger_Request_/\(qosSuffix)"
+        )
+    }
+
+    func testServiceLivelinessStripsLeadingSlashFromServiceName() {
+        let codec = ZenohWireCodec(distro: .jazzy)
+        let qosSuffix = QoSPolicy.servicesDefault.toKeyExpr()
+        let withSlash = codec.makeServiceLivelinessToken(
+            entityKind: .serviceClient,
+            domainId: 0,
+            sessionId: "AABB",
+            nodeId: "1",
+            entityId: "3",
+            namespace: "",
+            nodeName: "node",
+            serviceName: "/trigger",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: "RIHS01_aaa",
+            qos: .servicesDefault
+        )
+        XCTAssertEqual(
+            withSlash,
+            "@ros2_lv/0/AABB/1/3/SC/%/%/node/%trigger/std_srvs::srv::dds_::Trigger_Request_/RIHS01_aaa/\(qosSuffix)"
+        )
     }
 
     // MARK: - DDS service topic names

--- a/Tests/SwiftROS2WireTests/ServiceWireFormatTests.swift
+++ b/Tests/SwiftROS2WireTests/ServiceWireFormatTests.swift
@@ -167,4 +167,38 @@ final class ServiceWireFormatTests: XCTestCase {
         XCTAssertEqual(ZenohWireCodec.ServiceEntityKind.serviceServer.rawValue, "SS")
         XCTAssertEqual(ZenohWireCodec.ServiceEntityKind.serviceClient.rawValue, "SC")
     }
+
+    // MARK: - DDS service topic names
+
+    func testDDSServiceTopicNames() {
+        let codec = DDSWireCodec()
+        let names = codec.serviceTopicNames(
+            serviceName: "/add_two_ints",
+            serviceTypeName: "example_interfaces/srv/AddTwoInts"
+        )
+        XCTAssertEqual(names.requestTopic, "rq/add_two_intsRequest")
+        XCTAssertEqual(names.replyTopic, "rr/add_two_intsReply")
+        XCTAssertEqual(names.requestTypeName, "example_interfaces::srv::dds_::AddTwoInts_Request_")
+        XCTAssertEqual(names.replyTypeName, "example_interfaces::srv::dds_::AddTwoInts_Response_")
+    }
+
+    func testDDSServiceTopicNamesNoLeadingSlash() {
+        let codec = DDSWireCodec()
+        let names = codec.serviceTopicNames(
+            serviceName: "trigger",
+            serviceTypeName: "std_srvs/srv/Trigger"
+        )
+        XCTAssertEqual(names.requestTopic, "rq/triggerRequest")
+        XCTAssertEqual(names.replyTopic, "rr/triggerReply")
+    }
+
+    func testDDSServiceTopicNamesNamespacedService() {
+        let codec = DDSWireCodec()
+        let names = codec.serviceTopicNames(
+            serviceName: "/ios/trigger",
+            serviceTypeName: "std_srvs/srv/Trigger"
+        )
+        XCTAssertEqual(names.requestTopic, "rq/ios/triggerRequest")
+        XCTAssertEqual(names.replyTopic, "rr/ios/triggerReply")
+    }
 }

--- a/Tests/SwiftROS2WireTests/ServiceWireFormatTests.swift
+++ b/Tests/SwiftROS2WireTests/ServiceWireFormatTests.swift
@@ -94,4 +94,77 @@ final class ServiceWireFormatTests: XCTestCase {
             "0/add_two_ints/example_interfaces::srv::dds_::AddTwoInts_Request_"
         )
     }
+
+    // MARK: - Zenoh service liveliness tokens
+
+    func testJazzyServiceServerLiveliness() {
+        let codec = ZenohWireCodec(distro: .jazzy)
+        let qosSuffix = QoSPolicy.servicesDefault.toKeyExpr()
+        let token = codec.makeServiceLivelinessToken(
+            entityKind: .serviceServer,
+            domainId: 0,
+            sessionId: "AABB",
+            nodeId: "1",
+            entityId: "2",
+            namespace: "/ios",
+            nodeName: "node",
+            serviceName: "trigger",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: "RIHS01_aaa",
+            qos: .servicesDefault
+        )
+        XCTAssertEqual(
+            token,
+            "@ros2_lv/0/AABB/1/2/SS/%/%/node/%ios%trigger/std_srvs::srv::dds_::Trigger_Request_/RIHS01_aaa/\(qosSuffix)"
+        )
+    }
+
+    func testJazzyServiceClientLiveliness() {
+        let codec = ZenohWireCodec(distro: .jazzy)
+        let qosSuffix = QoSPolicy.servicesDefault.toKeyExpr()
+        let token = codec.makeServiceLivelinessToken(
+            entityKind: .serviceClient,
+            domainId: 0,
+            sessionId: "AABB",
+            nodeId: "1",
+            entityId: "3",
+            namespace: "",
+            nodeName: "node",
+            serviceName: "trigger",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: "RIHS01_aaa",
+            qos: .servicesDefault
+        )
+        XCTAssertEqual(
+            token,
+            "@ros2_lv/0/AABB/1/3/SC/%/%/node/%trigger/std_srvs::srv::dds_::Trigger_Request_/RIHS01_aaa/\(qosSuffix)"
+        )
+    }
+
+    func testHumbleServiceServerLiveliness() {
+        let codec = ZenohWireCodec(distro: .humble)
+        let qosSuffix = QoSPolicy.servicesDefault.toKeyExpr()
+        let token = codec.makeServiceLivelinessToken(
+            entityKind: .serviceServer,
+            domainId: 0,
+            sessionId: "AABB",
+            nodeId: "1",
+            entityId: "2",
+            namespace: "",
+            nodeName: "node",
+            serviceName: "trigger",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: nil,
+            qos: .servicesDefault
+        )
+        XCTAssertEqual(
+            token,
+            "@ros2_lv/0/AABB/1/2/SS/%/%/node/%trigger/std_srvs::srv::dds_::Trigger_Request_/TypeHashNotSupported/\(qosSuffix)"
+        )
+    }
+
+    func testServiceEntityKindRawValues() {
+        XCTAssertEqual(ZenohWireCodec.ServiceEntityKind.serviceServer.rawValue, "SS")
+        XCTAssertEqual(ZenohWireCodec.ServiceEntityKind.serviceClient.rawValue, "SC")
+    }
 }


### PR DESCRIPTION
## Summary

Wire-format codec extension for ROS 2 Services — phase 2 of the 6-phase services landing. No transport changes; no public API surface yet. Ships green on its own.

- `ZenohWireCodec.makeServiceKeyExpr` (request-side type info, Humble + Jazzy + namespace handling)
- `ZenohWireCodec.makeServiceLivelinessToken` with new `ServiceEntityKind` enum (`SS` / `SC`)
- `DDSWireCodec.serviceTopicNames` returning the `rq/...Request` + `rr/...Reply` pair plus `Request_` / `Response_` DDS type names
- `TypeNameConverter.toDDSServiceRequestTypeName` / `toDDSServiceResponseTypeName`

## Test plan

- [x] \`swift test --filter SwiftROS2WireTests.ServiceWireFormatTests\` (13 new, all pass)
- [x] \`swift test --parallel\` (no regressions across full suite)
- [x] \`swift format lint --strict\` clean