### PR TITLE
feat(transport): TransportService / TransportClient protocols (phase 3 of 6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Swift version
         run: swift --version
       - name: Diagnose API breaking changes
-        run: swift package diagnose-api-breaking-changes 0.6.1
+        run: swift package diagnose-api-breaking-changes --breakage-allowlist-path Scripts/api-breakage-allowlist.txt 0.6.1
 
   docs-build:
     name: DocC build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Swift version
         run: swift --version
       - name: Diagnose API breaking changes
-        run: swift package diagnose-api-breaking-changes --breakage-allowlist-path Scripts/api-breakage-allowlist.txt 0.6.1
+        run: bash Scripts/diagnose-api-breaking-changes.sh 0.6.1 Scripts/api-breakage-allowlist.txt
 
   docs-build:
     name: DocC build

--- a/Scripts/api-breakage-allowlist.txt
+++ b/Scripts/api-breakage-allowlist.txt
@@ -1,0 +1,12 @@
+# API breakages intentionally introduced post-0.6.1 (pre-1.0).
+#
+# Each line is matched verbatim against the diagnostic message emitted by
+# `swift package diagnose-api-breaking-changes`. Append new entries as
+# breakages land; remove entries once a release tag is cut whose baseline
+# already includes them.
+#
+# 0.7.0: ROS 2 Services landing — see CHANGELOG ## [0.7.0] (2026-05-01).
+API breakage: func TransportSession.createServiceServer(name:serviceTypeName:requestTypeHash:responseTypeHash:qos:handler:) has been added as a protocol requirement
+API breakage: func TransportSession.createServiceClient(name:serviceTypeName:requestTypeHash:responseTypeHash:qos:) has been added as a protocol requirement
+API breakage: enumelement TransportError.requestTimeout has been added as a new enum case
+API breakage: enumelement TransportError.requestCancelled has been added as a new enum case

--- a/Scripts/diagnose-api-breaking-changes.sh
+++ b/Scripts/diagnose-api-breaking-changes.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Wraps `swift package diagnose-api-breaking-changes` with a manual
+# allowlist filter. SwiftPM 6.0.x's built-in `--breakage-allowlist-path`
+# option does not reliably suppress matched breakages on macOS; this
+# script reads the allowlist itself (one literal diagnostic message per
+# line, comments / blank lines ignored) and exits 0 when every detected
+# breakage is allowlisted.
+#
+# Usage:
+#   diagnose-api-breaking-changes.sh <baseline-treeish> [allowlist-file]
+#
+# Without an allowlist, behaves exactly like the underlying SwiftPM
+# command.
+
+set -uo pipefail
+
+BASELINE="${1:?baseline treeish required}"
+ALLOWLIST="${2:-}"
+
+OUTPUT_FILE=$(mktemp)
+trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+set +e
+swift package diagnose-api-breaking-changes "$BASELINE" 2>&1 | tee "$OUTPUT_FILE"
+EXIT=${PIPESTATUS[0]}
+set -e
+
+if [[ $EXIT -eq 0 ]]; then
+    exit 0
+fi
+
+if [[ -z "$ALLOWLIST" || ! -f "$ALLOWLIST" ]]; then
+    exit "$EXIT"
+fi
+
+# Every reported breakage line. The CLI prefix is `  💔 `; strip leading
+# whitespace and the emoji so what remains starts with `API breakage:`,
+# matching the exact format of the allowlist file.
+DETECTED=$(grep -F 'API breakage:' "$OUTPUT_FILE" | sed -E 's/^[[:space:]]*💔[[:space:]]+//')
+
+# Allowed lines (drop comments and blank lines).
+ALLOWED=$(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST" || true)
+
+UNEXPECTED=$(echo "$DETECTED" | grep -vFx -f <(echo "$ALLOWED") || true)
+
+if [[ -z "$UNEXPECTED" ]]; then
+    echo
+    echo "All ${EXIT} detected breakages are allowlisted via $ALLOWLIST; passing." >&2
+    exit 0
+fi
+
+echo
+echo "Unexpected breakages (not allowlisted):" >&2
+echo "$UNEXPECTED" >&2
+exit "$EXIT"

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
@@ -1,0 +1,31 @@
+// DDSTransportSession+Service.swift
+// Service Server / Client stubs for the DDS transport.
+//
+// The real implementation lands in phase 4. For phase 3 these methods
+// throw `TransportError.unsupportedFeature` so the build is green and
+// callers get a clear error if they reach for services on DDS today.
+
+import Foundation
+
+extension DDSTransportSession {
+    public func createServiceServer(
+        name: String,
+        serviceTypeName: String,
+        requestTypeHash: String?,
+        responseTypeHash: String?,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data) async throws -> Data
+    ) throws -> any TransportService {
+        throw TransportError.unsupportedFeature("DDS service server (phase 4)")
+    }
+
+    public func createServiceClient(
+        name: String,
+        serviceTypeName: String,
+        requestTypeHash: String?,
+        responseTypeHash: String?,
+        qos: TransportQoS
+    ) throws -> any TransportClient {
+        throw TransportError.unsupportedFeature("DDS service client (phase 4)")
+    }
+}

--- a/Sources/SwiftROS2Transport/TransportSession.swift
+++ b/Sources/SwiftROS2Transport/TransportSession.swift
@@ -37,6 +37,35 @@ public protocol TransportSession: AnyObject, Sendable {
         qos: TransportQoS,
         handler: @escaping @Sendable (Data, UInt64) -> Void
     ) throws -> any TransportSubscriber
+
+    /// Create a Service Server.
+    ///
+    /// `serviceTypeName` is the ROS-format service type name (e.g.
+    /// `std_srvs/srv/Trigger`). The transport derives the DDS-format
+    /// `<pkg>::srv::dds_::<Type>_Request_` / `_Response_` topic / type names
+    /// internally via `TypeNameConverter`.
+    func createServiceServer(
+        name: String,
+        serviceTypeName: String,
+        requestTypeHash: String?,
+        responseTypeHash: String?,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data) async throws -> Data
+    ) throws -> any TransportService
+
+    /// Create a Service Client.
+    ///
+    /// `serviceTypeName` is the ROS-format service type name (e.g.
+    /// `std_srvs/srv/Trigger`). The transport derives the DDS-format
+    /// `<pkg>::srv::dds_::<Type>_Request_` / `_Response_` topic / type names
+    /// internally via `TypeNameConverter`.
+    func createServiceClient(
+        name: String,
+        serviceTypeName: String,
+        requestTypeHash: String?,
+        responseTypeHash: String?,
+        qos: TransportQoS
+    ) throws -> any TransportClient
 }
 
 // MARK: - Transport Publisher Protocol
@@ -61,6 +90,34 @@ public protocol TransportPublisher: Sendable {
 public protocol TransportSubscriber: Sendable {
     var topic: String { get }
     var isActive: Bool { get }
+    func close() throws
+}
+
+// MARK: - Transport Service / Client (Service Server / Service Client)
+
+/// An active Service Server handle.
+///
+/// The handler closure passed at creation time receives raw CDR request bytes
+/// and is expected to return raw CDR response bytes. The transport layer is
+/// untyped on purpose — `ROS2Service<S>` on top encodes / decodes typed values.
+public protocol TransportService: Sendable {
+    var name: String { get }
+    var isActive: Bool { get }
+    func close() throws
+}
+
+/// An active Service Client handle.
+///
+/// `call` operates on raw CDR. The `ROS2Client<S>` layer encodes the typed
+/// request, invokes this method, and decodes the typed response.
+public protocol TransportClient: Sendable {
+    var name: String { get }
+    var isActive: Bool { get }
+    func waitForService(timeout: Duration) async throws
+    /// Send pre-encoded CDR request, await pre-encoded CDR response.
+    /// Throws `TransportError.requestTimeout` on deadline,
+    /// `TransportError.requestCancelled` on parent-Task cancellation.
+    func call(requestCDR: Data, timeout: Duration) async throws -> Data
     func close() throws
 }
 
@@ -133,6 +190,8 @@ public enum TransportError: Error, LocalizedError {
     case sessionClosed
     case invalidConfiguration(String)
     case unsupportedFeature(String)
+    case requestTimeout(Duration)
+    case requestCancelled
 
     public var errorDescription: String? {
         switch self {
@@ -148,6 +207,8 @@ public enum TransportError: Error, LocalizedError {
         case .sessionClosed: return "Session is closed"
         case .invalidConfiguration(let msg): return "Invalid configuration: \(msg)"
         case .unsupportedFeature(let f): return "Unsupported feature: \(f)"
+        case .requestTimeout(let d): return "Service request timed out after \(d)"
+        case .requestCancelled: return "Service request was cancelled"
         }
     }
 

--- a/Sources/SwiftROS2Transport/TransportSession.swift
+++ b/Sources/SwiftROS2Transport/TransportSession.swift
@@ -41,9 +41,12 @@ public protocol TransportSession: AnyObject, Sendable {
     /// Create a Service Server.
     ///
     /// `serviceTypeName` is the ROS-format service type name (e.g.
-    /// `std_srvs/srv/Trigger`). The transport derives the DDS-format
-    /// `<pkg>::srv::dds_::<Type>_Request_` / `_Response_` topic / type names
-    /// internally via `TypeNameConverter`.
+    /// `std_srvs/srv/Trigger`). Each transport derives the wire-level naming
+    /// from this: DDS uses `DDSWireCodec.serviceTopicNames` to build the
+    /// `rq/<service>Request` / `rr/<service>Reply` topic pair plus
+    /// `<pkg>::srv::dds_::<Type>_Request_` / `_Response_` type names; Zenoh
+    /// uses `ZenohWireCodec.makeServiceKeyExpr` to build the queryable key
+    /// expression. Callers do not need to pre-derive any of this.
     func createServiceServer(
         name: String,
         serviceTypeName: String,
@@ -56,9 +59,10 @@ public protocol TransportSession: AnyObject, Sendable {
     /// Create a Service Client.
     ///
     /// `serviceTypeName` is the ROS-format service type name (e.g.
-    /// `std_srvs/srv/Trigger`). The transport derives the DDS-format
-    /// `<pkg>::srv::dds_::<Type>_Request_` / `_Response_` topic / type names
-    /// internally via `TypeNameConverter`.
+    /// `std_srvs/srv/Trigger`). Each transport derives the wire-level naming
+    /// from this: DDS uses `DDSWireCodec.serviceTopicNames`; Zenoh uses
+    /// `ZenohWireCodec.makeServiceKeyExpr`. Callers do not need to pre-derive
+    /// any of it.
     func createServiceClient(
         name: String,
         serviceTypeName: String,

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Service.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Service.swift
@@ -1,0 +1,31 @@
+// ZenohTransportSession+Service.swift
+// Service Server / Client stubs for the Zenoh transport.
+//
+// The real implementation lands in phase 6. For phase 3 these methods
+// throw `TransportError.unsupportedFeature` so the build is green and
+// callers get a clear error if they reach for services on Zenoh today.
+
+import Foundation
+
+extension ZenohTransportSession {
+    public func createServiceServer(
+        name: String,
+        serviceTypeName: String,
+        requestTypeHash: String?,
+        responseTypeHash: String?,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data) async throws -> Data
+    ) throws -> any TransportService {
+        throw TransportError.unsupportedFeature("Zenoh service server (phase 6)")
+    }
+
+    public func createServiceClient(
+        name: String,
+        serviceTypeName: String,
+        requestTypeHash: String?,
+        responseTypeHash: String?,
+        qos: TransportQoS
+    ) throws -> any TransportClient {
+        throw TransportError.unsupportedFeature("Zenoh service client (phase 6)")
+    }
+}

--- a/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
+++ b/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
@@ -1,5 +1,4 @@
 import Foundation
-
 import SwiftROS2Transport
 
 /// In-memory TransportSession used by SwiftROS2 umbrella unit tests.
@@ -167,6 +166,27 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
         )
         synchronized { _subscribers.append(sub) }
         return sub
+    }
+
+    func createServiceServer(
+        name: String,
+        serviceTypeName: String,
+        requestTypeHash: String?,
+        responseTypeHash: String?,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data) async throws -> Data
+    ) throws -> any TransportService {
+        throw TransportError.unsupportedFeature("MockTransportSession service server (override per test)")
+    }
+
+    func createServiceClient(
+        name: String,
+        serviceTypeName: String,
+        requestTypeHash: String?,
+        responseTypeHash: String?,
+        qos: TransportQoS
+    ) throws -> any TransportClient {
+        throw TransportError.unsupportedFeature("MockTransportSession service client (override per test)")
     }
 }
 

--- a/Tests/SwiftROS2TransportTests/Mocks/MockZenohClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockZenohClient.swift
@@ -1,5 +1,4 @@
 import Foundation
-
 import SwiftROS2Transport
 
 /// In-memory ZenohClientProtocol used by ZenohTransportSession unit tests.


### PR DESCRIPTION
## Summary

Adds the `TransportService` / `TransportClient` protocols, two factory methods on `TransportSession`, and `TransportError.requestTimeout` / `requestCancelled` cases. Concrete sessions throw `unsupportedFeature` for now; phase 4 wires DDS, phase 6 wires Zenoh.

Stacked PR series for ROS 2 Services landing (#52 / #66 already merged):
- **PR 1 of 4 (this)**: Phase 3 — protocols + stubs
- PR 2 of 4: Phase 4 — DDS service server / client
- PR 3 of 4: Phase 5 — Zenoh C-bridge queryable / get
- PR 4 of 4: Phase 6 — public umbrella API + Zenoh transport

## Test plan

- [x] swift build (clean)
- [x] swift test --parallel (no regressions, 220 tests pass)