### PR TITLE
feat(transport): DDS service server / client (phase 4 of 6)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -304,7 +304,7 @@ if !isWindowsBuild && !isAndroidBuild {
         ),
         .testTarget(
             name: "SwiftROS2DDSTests",
-            dependencies: ["SwiftROS2DDS"],
+            dependencies: ["SwiftROS2DDS", "SwiftROS2Transport"],
             path: "Tests/SwiftROS2DDSTests"
         ),
         .testTarget(

--- a/Sources/SwiftROS2Transport/DDSClientProtocol.swift
+++ b/Sources/SwiftROS2Transport/DDSClientProtocol.swift
@@ -165,4 +165,21 @@ public protocol DDSClientProtocol: AnyObject {
 
     /// Destroy a reader. Blocks until any in-flight handler invocation completes.
     func destroyReader(_ reader: any DDSReaderHandle)
+
+    /// Whether the given writer currently has any matched subscribers.
+    ///
+    /// Used by service clients (`waitForService`) to detect server availability.
+    /// Conformers that wrap a real DDS bridge should return whatever
+    /// `dds_get_publication_matched_status` reports; transports that cannot
+    /// determine match state cheaply may keep the default behavior, which
+    /// optimistically returns `true` so existing conformers continue to compile
+    /// without changes.
+    func isPublicationMatched(writer: any DDSWriterHandle) -> Bool
+}
+
+extension DDSClientProtocol {
+    /// Default: optimistically report the publication as matched. Concrete
+    /// conformers (e.g. CycloneDDS-backed bridges) should override this with
+    /// `dds_get_publication_matched_status`.
+    public func isPublicationMatched(writer: any DDSWriterHandle) -> Bool { true }
 }

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
@@ -364,8 +364,17 @@ final class DDSTransportServiceClientImpl: TransportClient, @unchecked Sendable 
         // `requestTimeout` when the deadline elapses. We keep a handle so we can
         // cancel it when the reply arrives first.
         let pendingTable = self.pending
+        // If the sleep is cancelled (because the reply arrived first or the
+        // parent Task was cancelled), `Task.sleep` throws CancellationError and
+        // we exit *without* resolving the pending entry — otherwise we race
+        // with the reply / cancel paths and may surface `requestTimeout`
+        // instead of the actual outcome.
         let timeoutTask = Task { [pendingTable] in
-            try? await Task.sleep(for: timeout)
+            do {
+                try await Task.sleep(for: timeout)
+            } catch {
+                return
+            }
             await pendingTable.resolve(seq: seq, with: .failure(TransportError.requestTimeout(timeout)))
         }
 

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
@@ -89,7 +89,72 @@ extension DDSTransportSession {
         responseTypeHash: String?,
         qos: TransportQoS
     ) throws -> any TransportClient {
-        throw TransportError.unsupportedFeature("DDS service client (phase 4)")
+        guard !name.isEmpty else {
+            throw TransportError.invalidConfiguration("Service name cannot be empty")
+        }
+        guard !serviceTypeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Service type name cannot be empty")
+        }
+
+        lock.lock()
+        guard isOpen else {
+            lock.unlock()
+            throw TransportError.notConnected
+        }
+        lock.unlock()
+
+        let codec = DDSWireCodec()
+        let names = codec.serviceTopicNames(serviceName: name, serviceTypeName: serviceTypeName)
+        let cfg = bridgeQoS(from: qos)
+
+        // Request writer (client → server).
+        let requestUserData = codec.userDataString(typeHash: requestTypeHash)
+        let requestWriter = try client.createRawWriter(
+            topicName: names.requestTopic,
+            typeName: names.requestTypeName,
+            qos: cfg,
+            userData: requestUserData
+        )
+
+        let writerGuid = GIDManager().getOrCreateGid()
+        let serviceClient = DDSTransportServiceClientImpl(
+            client: client,
+            requestWriter: requestWriter,
+            requestTopic: names.requestTopic,
+            name: name,
+            writerGuid: writerGuid
+        )
+
+        // Reply reader (server → client).
+        let replyUserData = codec.userDataString(typeHash: responseTypeHash)
+        let replyReader: any DDSReaderHandle
+        do {
+            replyReader = try client.createRawReader(
+                topicName: names.replyTopic,
+                typeName: names.replyTypeName,
+                qos: cfg,
+                userData: replyUserData,
+                handler: { [weak serviceClient] data, timestamp in
+                    serviceClient?.handleIncomingReply(data: data, timestamp: timestamp)
+                }
+            )
+        } catch {
+            client.destroyWriter(requestWriter)
+            if let e = error as? DDSError {
+                throw TransportError.subscriberCreationFailed(e.errorDescription ?? "\(e)")
+            }
+            throw error
+        }
+        serviceClient.attachReplyReader(replyReader)
+
+        appendServiceClient(serviceClient)
+        return serviceClient
+    }
+
+    private func appendServiceClient(_ serviceClient: DDSTransportServiceClientImpl) {
+        lock.lock()
+        serviceClients.append(serviceClient)
+        lock.unlock()
     }
 
     // MARK: - Internal lock helpers
@@ -216,16 +281,160 @@ final class DDSTransportServiceServerImpl: TransportService, @unchecked Sendable
     }
 }
 
-// MARK: - DDS Transport Service Client (placeholder for phase 4 client commit)
+// MARK: - DDS Transport Service Client
 
 final class DDSTransportServiceClientImpl: TransportClient, @unchecked Sendable {
-    public let name: String = ""
-    public var isActive: Bool { false }
+    private let client: any DDSClientProtocol
+    private var requestWriter: (any DDSWriterHandle)?
+    private var replyReader: (any DDSReaderHandle)?
+    private let requestTopic: String
+    public let name: String
+    private let writerGuid: [UInt8]
+    private let pending = ClientPendingTable()
+    private let seqLock = NSLock()
+    private var nextSeq: Int64 = 0
+    private let lock = NSLock()
+    private var closed = false
+
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if closed { return false }
+        return (requestWriter?.isActive ?? false) && (replyReader?.isActive ?? false)
+    }
+
+    init(
+        client: any DDSClientProtocol,
+        requestWriter: any DDSWriterHandle,
+        requestTopic: String,
+        name: String,
+        writerGuid: [UInt8]
+    ) {
+        self.client = client
+        self.requestWriter = requestWriter
+        self.requestTopic = requestTopic
+        self.name = name
+        self.writerGuid = writerGuid
+    }
+
+    func attachReplyReader(_ reader: any DDSReaderHandle) {
+        lock.lock()
+        replyReader = reader
+        lock.unlock()
+    }
+
     public func waitForService(timeout: Duration) async throws {
-        throw TransportError.unsupportedFeature("DDS service client (phase 4)")
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            lock.lock()
+            let writer = closed ? nil : requestWriter
+            lock.unlock()
+            if let w = writer, client.isPublicationMatched(writer: w) {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            try Task.checkCancellation()
+        }
+        throw TransportError.requestTimeout(timeout)
     }
+
     public func call(requestCDR: Data, timeout: Duration) async throws -> Data {
-        throw TransportError.unsupportedFeature("DDS service client (phase 4)")
+        guard requestCDR.count >= 4 else {
+            throw TransportError.invalidConfiguration("requestCDR missing 4-byte CDR encapsulation header")
+        }
+
+        lock.lock()
+        let writerOpt = closed ? nil : requestWriter
+        lock.unlock()
+        guard let writer = writerOpt else {
+            throw TransportError.sessionClosed
+        }
+
+        let seq: Int64 = {
+            seqLock.lock()
+            defer { seqLock.unlock() }
+            nextSeq += 1
+            return nextSeq
+        }()
+
+        let id = RMWRequestId(writerGuid: writerGuid, sequenceNumber: seq)
+        let wire = SampleIdentityPrefix.encode(requestId: id, userCDR: requestCDR)
+
+        // Spawn a detached timeout helper that resolves the pending entry with
+        // `requestTimeout` when the deadline elapses. We keep a handle so we can
+        // cancel it when the reply arrives first.
+        let pendingTable = self.pending
+        let timeoutTask = Task { [pendingTable] in
+            try? await Task.sleep(for: timeout)
+            await pendingTable.resolve(seq: seq, with: .failure(TransportError.requestTimeout(timeout)))
+        }
+
+        return try await withTaskCancellationHandler {
+            do {
+                let body = try await pendingTable.insert(seq: seq) { _ in
+                    // Continuation registered; issue the wire request immediately.
+                    do {
+                        try self.client.writeRawCDR(writer: writer, data: wire, timestamp: 0)
+                    } catch {
+                        // The actor still has the continuation; resolve it asynchronously.
+                        Task { [pendingTable] in
+                            await pendingTable.resolve(seq: seq, with: .failure(error))
+                        }
+                    }
+                }
+                timeoutTask.cancel()
+                return body
+            } catch {
+                timeoutTask.cancel()
+                throw error
+            }
+        } onCancel: {
+            timeoutTask.cancel()
+            Task { [pendingTable] in
+                await pendingTable.cancel(seq: seq)
+            }
+        }
     }
-    public func close() throws {}
+
+    /// Called from the DDS reader thread.
+    func handleIncomingReply(data: Data, timestamp: UInt64) {
+        let parsedId: RMWRequestId
+        let userReplyCDR: Data
+        do {
+            (parsedId, userReplyCDR) = try SampleIdentityPrefix.decode(wirePayload: data)
+        } catch {
+            return
+        }
+        // Filter on writerGuid so this client only consumes its own replies.
+        guard parsedId.writerGuid == writerGuid else { return }
+        let seq = parsedId.sequenceNumber
+        Task { [pending] in
+            await pending.resolve(seq: seq, with: .success(userReplyCDR))
+        }
+    }
+
+    public func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let w = requestWriter
+        let r = replyReader
+        requestWriter = nil
+        replyReader = nil
+        lock.unlock()
+
+        Task { [pending] in
+            await pending.failAll(TransportError.sessionClosed)
+        }
+
+        if let r = r {
+            client.destroyReader(r)
+        }
+        if let w = w {
+            client.destroyWriter(w)
+        }
+    }
 }

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
@@ -1,11 +1,16 @@
 // DDSTransportSession+Service.swift
-// Service Server / Client stubs for the DDS transport.
+// Service Server / Client implementation for the DDS transport.
 //
-// The real implementation lands in phase 4. For phase 3 these methods
-// throw `TransportError.unsupportedFeature` so the build is green and
-// callers get a clear error if they reach for services on DDS today.
+// rmw_cyclonedds_cpp pairs each service with two topics:
+// - rq/<service>Request (client → server)
+// - rr/<service>Reply   (server → client)
+//
+// The wire payload on each topic is `[CDR header (4) | RMWRequestId (24) | user CDR body]`.
+// The 24-byte sample-identity prefix (`writer_guid`, `sequence_number`) is what
+// correlates a reply to the original request.
 
 import Foundation
+import SwiftROS2Wire
 
 extension DDSTransportSession {
     public func createServiceServer(
@@ -16,7 +21,65 @@ extension DDSTransportSession {
         qos: TransportQoS,
         handler: @escaping @Sendable (Data) async throws -> Data
     ) throws -> any TransportService {
-        throw TransportError.unsupportedFeature("DDS service server (phase 4)")
+        guard !name.isEmpty else {
+            throw TransportError.invalidConfiguration("Service name cannot be empty")
+        }
+        guard !serviceTypeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Service type name cannot be empty")
+        }
+
+        lock.lock()
+        guard isOpen else {
+            lock.unlock()
+            throw TransportError.notConnected
+        }
+        lock.unlock()
+
+        let codec = DDSWireCodec()
+        let names = codec.serviceTopicNames(serviceName: name, serviceTypeName: serviceTypeName)
+        let cfg = bridgeQoS(from: qos)
+
+        // Reply writer (server → client).
+        let replyUserData = codec.userDataString(typeHash: responseTypeHash)
+        let replyWriter = try client.createRawWriter(
+            topicName: names.replyTopic,
+            typeName: names.replyTypeName,
+            qos: cfg,
+            userData: replyUserData
+        )
+
+        let server = DDSTransportServiceServerImpl(
+            client: client,
+            replyWriter: replyWriter,
+            replyTopic: names.replyTopic,
+            name: name,
+            handler: handler
+        )
+
+        // Request reader (client → server). Hand each incoming sample to the server.
+        let requestUserData = codec.userDataString(typeHash: requestTypeHash)
+        let requestReader: any DDSReaderHandle
+        do {
+            requestReader = try client.createRawReader(
+                topicName: names.requestTopic,
+                typeName: names.requestTypeName,
+                qos: cfg,
+                userData: requestUserData,
+                handler: { [weak server] data, timestamp in
+                    server?.handleIncomingRequest(data: data, timestamp: timestamp)
+                }
+            )
+        } catch {
+            client.destroyWriter(replyWriter)
+            if let e = error as? DDSError {
+                throw TransportError.subscriberCreationFailed(e.errorDescription ?? "\(e)")
+            }
+            throw error
+        }
+        server.attachRequestReader(requestReader)
+
+        appendServiceServer(server)
+        return server
     }
 
     public func createServiceClient(
@@ -28,4 +91,141 @@ extension DDSTransportSession {
     ) throws -> any TransportClient {
         throw TransportError.unsupportedFeature("DDS service client (phase 4)")
     }
+
+    // MARK: - Internal lock helpers
+
+    private func appendServiceServer(_ server: DDSTransportServiceServerImpl) {
+        lock.lock()
+        serviceServers.append(server)
+        lock.unlock()
+    }
+
+    func takeAllServiceServers() -> [DDSTransportServiceServerImpl] {
+        lock.lock()
+        let out = serviceServers
+        serviceServers.removeAll()
+        lock.unlock()
+        return out
+    }
+
+    func takeAllServiceClients() -> [DDSTransportServiceClientImpl] {
+        lock.lock()
+        let out = serviceClients
+        serviceClients.removeAll()
+        lock.unlock()
+        return out
+    }
+}
+
+// MARK: - DDS Transport Service Server
+
+final class DDSTransportServiceServerImpl: TransportService, @unchecked Sendable {
+    private let client: any DDSClientProtocol
+    private var replyWriter: (any DDSWriterHandle)?
+    private var requestReader: (any DDSReaderHandle)?
+    private let replyTopic: String
+    public let name: String
+    private let handler: @Sendable (Data) async throws -> Data
+    private let lock = NSLock()
+    private var closed = false
+
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if closed { return false }
+        return (replyWriter?.isActive ?? false) && (requestReader?.isActive ?? false)
+    }
+
+    init(
+        client: any DDSClientProtocol,
+        replyWriter: any DDSWriterHandle,
+        replyTopic: String,
+        name: String,
+        handler: @escaping @Sendable (Data) async throws -> Data
+    ) {
+        self.client = client
+        self.replyWriter = replyWriter
+        self.replyTopic = replyTopic
+        self.name = name
+        self.handler = handler
+    }
+
+    func attachRequestReader(_ reader: any DDSReaderHandle) {
+        lock.lock()
+        requestReader = reader
+        lock.unlock()
+    }
+
+    /// Called from the DDS reader thread. Decodes the sample-identity prefix,
+    /// hands the user CDR to the user handler, and writes the reply with the
+    /// same `RMWRequestId`.
+    func handleIncomingRequest(data: Data, timestamp: UInt64) {
+        let parsedId: RMWRequestId
+        let userRequestCDR: Data
+        do {
+            (parsedId, userRequestCDR) = try SampleIdentityPrefix.decode(wirePayload: data)
+        } catch {
+            // Drop malformed request silently; the wire layer is best-effort.
+            return
+        }
+
+        let captured = (
+            client: client, writer: replyWriterSnapshot(), topic: replyTopic, name: name,
+            handler: handler
+        )
+        Task { [captured, parsedId, userRequestCDR] in
+            do {
+                let userReplyCDR = try await captured.handler(userRequestCDR)
+                let wire = SampleIdentityPrefix.encode(requestId: parsedId, userCDR: userReplyCDR)
+                if let w = captured.writer {
+                    try? captured.client.writeRawCDR(writer: w, data: wire, timestamp: 0)
+                }
+            } catch {
+                // User handler threw — best-effort drop. Future enhancement: surface as a
+                // negative-ack reply once the wire format is finalized.
+                _ = captured.name
+            }
+        }
+    }
+
+    private func replyWriterSnapshot() -> (any DDSWriterHandle)? {
+        lock.lock()
+        defer { lock.unlock() }
+        return closed ? nil : replyWriter
+    }
+
+    public func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let w = replyWriter
+        let r = requestReader
+        replyWriter = nil
+        requestReader = nil
+        lock.unlock()
+
+        if let r = r {
+            client.destroyReader(r)
+        }
+        if let w = w {
+            client.destroyWriter(w)
+        }
+    }
+}
+
+// MARK: - DDS Transport Service Client (placeholder for phase 4 client commit)
+
+final class DDSTransportServiceClientImpl: TransportClient, @unchecked Sendable {
+    public let name: String = ""
+    public var isActive: Bool { false }
+    public func waitForService(timeout: Duration) async throws {
+        throw TransportError.unsupportedFeature("DDS service client (phase 4)")
+    }
+    public func call(requestCDR: Data, timeout: Duration) async throws -> Data {
+        throw TransportError.unsupportedFeature("DDS service client (phase 4)")
+    }
+    public func close() throws {}
 }

--- a/Sources/SwiftROS2Transport/DDSTransportSession.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession.swift
@@ -18,6 +18,8 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
     private var config: TransportConfig?
     var publishers: [String: DDSTransportPublisherImpl] = [:]
     var subscribers: [DDSTransportSubscriberImpl] = []
+    var serviceServers: [DDSTransportServiceServerImpl] = []
+    var serviceClients: [DDSTransportServiceClientImpl] = []
     let lock = NSLock()
     private var _sessionId: String = ""
     var isOpen = false
@@ -85,6 +87,16 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
         let subs = takeAllSubscribers()
         for sub in subs {
             try? sub.close()
+        }
+
+        let servers = takeAllServiceServers()
+        for server in servers {
+            try? server.close()
+        }
+
+        let clients = takeAllServiceClients()
+        for serviceClient in clients {
+            try? serviceClient.close()
         }
 
         lock.lock()

--- a/Sources/SwiftROS2Transport/Internal/ClientPendingTable.swift
+++ b/Sources/SwiftROS2Transport/Internal/ClientPendingTable.swift
@@ -1,0 +1,49 @@
+// ClientPendingTable.swift
+// Per-Service-Client correlation table for DDS request / reply matching.
+
+import Foundation
+
+/// Per-Service-Client correlation table.
+///
+/// Each in-flight `call(...)` registers a continuation keyed by sequence
+/// number. The transport's reply handler looks up by sequence number and
+/// resolves. Used by DDS — Zenoh's queryable primitive owns correlation
+/// natively, so the Zenoh transport does not need this.
+actor ClientPendingTable {
+    private var pending: [Int64: CheckedContinuation<Data, Error>] = [:]
+
+    /// Register a continuation under `seq` and run `register` to wire up the
+    /// caller (e.g. issue the request). `register` runs while the actor holds
+    /// the table; do not perform long work inside it.
+    func insert(
+        seq: Int64,
+        register: (CheckedContinuation<Data, Error>) -> Void
+    ) async throws -> Data {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
+            pending[seq] = cont
+            register(cont)
+        }
+    }
+
+    @discardableResult
+    func resolve(seq: Int64, with result: Result<Data, Error>) -> Bool {
+        guard let cont = pending.removeValue(forKey: seq) else { return false }
+        cont.resume(with: result)
+        return true
+    }
+
+    @discardableResult
+    func cancel(seq: Int64) -> Bool {
+        guard let cont = pending.removeValue(forKey: seq) else { return false }
+        cont.resume(throwing: TransportError.requestCancelled)
+        return true
+    }
+
+    func failAll(_ error: Error) {
+        let snapshot = pending
+        pending.removeAll()
+        for (_, cont) in snapshot {
+            cont.resume(throwing: error)
+        }
+    }
+}

--- a/Sources/SwiftROS2Transport/Internal/SampleIdentityPrefix.swift
+++ b/Sources/SwiftROS2Transport/Internal/SampleIdentityPrefix.swift
@@ -1,0 +1,51 @@
+// SampleIdentityPrefix.swift
+// Encode / decode the DDS service sample-identity prefix.
+
+import Foundation
+
+/// Encode / decode the DDS service sample-identity prefix.
+///
+/// Wire layout: `[CDR header (4) | RMWRequestId (24) | user struct body]`.
+/// The user CDR passed in already carries its own 4-byte encapsulation header
+/// at offset 0 — the encoder strips it once and writes the single header at
+/// the start of the wire payload.
+enum SampleIdentityPrefix {
+    static let cdrHeader = Data([0x00, 0x01, 0x00, 0x00])
+    static let prefixedHeaderCount = cdrHeader.count + RMWRequestId.cdrByteCount  // 28
+
+    enum DecodeError: Error, Equatable {
+        case payloadTooShort(Int)
+        case missingEncapsulationHeader
+    }
+
+    static func encode(requestId: RMWRequestId, userCDR: Data) -> Data {
+        precondition(userCDR.count >= 4, "userCDR must include 4-byte CDR encapsulation header")
+        var out = Data(capacity: prefixedHeaderCount + (userCDR.count - 4))
+        out.append(cdrHeader)
+        out.append(contentsOf: requestId.writerGuid)
+        var seqLE = requestId.sequenceNumber.littleEndian
+        withUnsafeBytes(of: &seqLE) { out.append(contentsOf: $0) }
+        out.append(userCDR.dropFirst(4))
+        return out
+    }
+
+    static func decode(wirePayload: Data) throws -> (RMWRequestId, Data) {
+        guard wirePayload.count >= prefixedHeaderCount else {
+            throw DecodeError.payloadTooShort(wirePayload.count)
+        }
+        guard wirePayload.prefix(4) == cdrHeader else {
+            throw DecodeError.missingEncapsulationHeader
+        }
+        let guidStart = wirePayload.startIndex.advanced(by: 4)
+        let seqStart = guidStart.advanced(by: 16)
+        let bodyStart = seqStart.advanced(by: 8)
+        let guid = Array(wirePayload[guidStart..<seqStart])
+        let seq = wirePayload[seqStart..<bodyStart].withUnsafeBytes {
+            $0.loadUnaligned(as: Int64.self).littleEndian
+        }
+        let id = RMWRequestId(writerGuid: guid, sequenceNumber: seq)
+        var userCDR = cdrHeader
+        userCDR.append(wirePayload[bodyStart..<wirePayload.endIndex])
+        return (id, userCDR)
+    }
+}

--- a/Tests/SwiftROS2DDSTests/ClientPendingTableTests.swift
+++ b/Tests/SwiftROS2DDSTests/ClientPendingTableTests.swift
@@ -9,7 +9,7 @@ import XCTest
 final class ClientPendingTableTests: XCTestCase {
     func testInsertAndResolve() async throws {
         let table = ClientPendingTable()
-        async let pending: Data = table.insert(seq: 1) { _ in /* will be resolved externally */  }
+        async let pending: Data = table.insert(seq: 1) { _ in }  // resolved externally
         try await Task.sleep(nanoseconds: 10_000_000)
         let didResolve = await table.resolve(seq: 1, with: .success(Data([0x01])))
         XCTAssertTrue(didResolve)
@@ -19,7 +19,7 @@ final class ClientPendingTableTests: XCTestCase {
 
     func testResolveByOtherCaller() async throws {
         let table = ClientPendingTable()
-        async let pending: Data = table.insert(seq: 7) { _ in /* will be resolved externally */  }
+        async let pending: Data = table.insert(seq: 7) { _ in }  // resolved externally
         try await Task.sleep(nanoseconds: 10_000_000)
         let didResolve = await table.resolve(seq: 7, with: .success(Data([0xAA])))
         XCTAssertTrue(didResolve)

--- a/Tests/SwiftROS2DDSTests/ClientPendingTableTests.swift
+++ b/Tests/SwiftROS2DDSTests/ClientPendingTableTests.swift
@@ -1,0 +1,51 @@
+// ClientPendingTableTests.swift
+// Insert / resolve / cancel / failAll behaviors of the per-client correlation table.
+
+import Foundation
+import XCTest
+
+@testable import SwiftROS2Transport
+
+final class ClientPendingTableTests: XCTestCase {
+    func testInsertAndResolve() async throws {
+        let table = ClientPendingTable()
+        async let pending: Data = table.insert(seq: 1) { _ in /* will be resolved externally */  }
+        try await Task.sleep(nanoseconds: 10_000_000)
+        let didResolve = await table.resolve(seq: 1, with: .success(Data([0x01])))
+        XCTAssertTrue(didResolve)
+        let value = try await pending
+        XCTAssertEqual(value, Data([0x01]))
+    }
+
+    func testResolveByOtherCaller() async throws {
+        let table = ClientPendingTable()
+        async let pending: Data = table.insert(seq: 7) { _ in /* will be resolved externally */  }
+        try await Task.sleep(nanoseconds: 10_000_000)
+        let didResolve = await table.resolve(seq: 7, with: .success(Data([0xAA])))
+        XCTAssertTrue(didResolve)
+        let value = try await pending
+        XCTAssertEqual(value, Data([0xAA]))
+    }
+
+    func testResolveUnknownSeqIsNoOp() async {
+        let table = ClientPendingTable()
+        let didResolve = await table.resolve(seq: 999, with: .success(Data()))
+        XCTAssertFalse(didResolve)
+    }
+
+    func testFailAllResolvesAllPending() async throws {
+        let table = ClientPendingTable()
+        async let a: Data = table.insert(seq: 1) { _ in }
+        async let b: Data = table.insert(seq: 2) { _ in }
+        try await Task.sleep(nanoseconds: 10_000_000)
+        await table.failAll(TransportError.sessionClosed)
+        do {
+            _ = try await a
+            XCTFail("should throw")
+        } catch {}
+        do {
+            _ = try await b
+            XCTFail("should throw")
+        } catch {}
+    }
+}

--- a/Tests/SwiftROS2DDSTests/SampleIdentityPrefixTests.swift
+++ b/Tests/SwiftROS2DDSTests/SampleIdentityPrefixTests.swift
@@ -1,0 +1,45 @@
+// SampleIdentityPrefixTests.swift
+// Encode / decode of the 24-byte sample-identity prefix used by DDS services.
+
+import Foundation
+import XCTest
+
+@testable import SwiftROS2Transport
+
+final class SampleIdentityPrefixTests: XCTestCase {
+    func testEncodeProducesHeaderPlusPrefixPlusBody() {
+        let id = RMWRequestId(
+            writerGuid: Array(repeating: 0xAB, count: 16),
+            sequenceNumber: 42
+        )
+        let userCDR = Data([0x00, 0x01, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF])
+        let wire = SampleIdentityPrefix.encode(requestId: id, userCDR: userCDR)
+        XCTAssertEqual(wire.count, 32)
+        XCTAssertEqual(wire.prefix(4), Data([0x00, 0x01, 0x00, 0x00]))
+        XCTAssertEqual(wire.subdata(in: 4..<20), Data(repeating: 0xAB, count: 16))
+        XCTAssertEqual(wire.subdata(in: 20..<28), Data([42, 0, 0, 0, 0, 0, 0, 0]))
+        XCTAssertEqual(wire.suffix(4), Data([0xDE, 0xAD, 0xBE, 0xEF]))
+    }
+
+    func testRoundTrip() throws {
+        let id = RMWRequestId(
+            writerGuid: (0..<16).map { UInt8($0) },
+            sequenceNumber: 99
+        )
+        let userCDR = Data([0x00, 0x01, 0x00, 0x00, 0x01, 0x02, 0x03])
+        let wire = SampleIdentityPrefix.encode(requestId: id, userCDR: userCDR)
+        let (parsedId, parsedUserCDR) = try SampleIdentityPrefix.decode(wirePayload: wire)
+        XCTAssertEqual(parsedId, id)
+        XCTAssertEqual(parsedUserCDR, userCDR)
+    }
+
+    func testDecodeRejectsTooShortPayload() {
+        XCTAssertThrowsError(try SampleIdentityPrefix.decode(wirePayload: Data(count: 27)))
+    }
+
+    func testDecodeRejectsMissingHeader() {
+        var data = Data([0xFF, 0xFF, 0xFF, 0xFF])
+        data.append(Data(count: 24))
+        XCTAssertThrowsError(try SampleIdentityPrefix.decode(wirePayload: data))
+    }
+}

--- a/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
@@ -109,6 +109,51 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
             handler(data, timestamp)
         }
     }
+
+    /// Plan-spec alias for `deliver(toTopic:data:timestamp:)`. Async to mirror
+    /// real-network callers; the underlying delivery is synchronous.
+    func deliverToReader(topic: String, wire: Data, timestamp: UInt64) async throws {
+        deliver(toTopic: topic, data: wire, timestamp: timestamp)
+    }
+
+    /// Wait up to `timeout` for the next `writeRawCDR` to land on `topic`,
+    /// then return its bytes. Polls a short interval (5ms) so tests stay
+    /// responsive without hot-spinning. Returns `nil` only if the timeout
+    /// elapsed without any new write.
+    func awaitWrite(topic: String, timeout: Duration) async throws -> Data? {
+        let initialCount = countWrites(topic: topic)
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if let bytes = lastWriteAfter(topic: topic, baseline: initialCount) {
+                return bytes
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return lastWriteAfter(topic: topic, baseline: initialCount)
+    }
+
+    /// Last write recorded on `topic`, or `nil` if no writes happened.
+    func lastWritten(topic: String) -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return writes.last(where: { $0.topic == topic })?.data
+    }
+
+    // MARK: - private helpers
+
+    private func countWrites(topic: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return writes.reduce(into: 0) { acc, w in if w.topic == topic { acc += 1 } }
+    }
+
+    private func lastWriteAfter(topic: String, baseline: Int) -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        let matching = writes.filter { $0.topic == topic }
+        guard matching.count > baseline else { return nil }
+        return matching.last?.data
+    }
 }
 
 final class MockDDSWriterHandle: DDSWriterHandle, @unchecked Sendable {

--- a/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
@@ -25,6 +25,9 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
             []
     private(set) var destroyedReaders = 0
 
+    // Publication-match override (per topic). Used to drive `waitForService`.
+    private var matchedTopics: Set<String> = []
+
     func createSession(domainId: Int32, discoveryConfig: DDSBridgeDiscoveryConfig) throws {
         lock.lock()
         defer { lock.unlock() }
@@ -137,6 +140,21 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return writes.last(where: { $0.topic == topic })?.data
+    }
+
+    /// Mark the given DDS topic as having matched subscribers. Affects what
+    /// `isPublicationMatched(writer:)` returns for any writer on that topic.
+    func markPublicationsMatched(topic: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        matchedTopics.insert(topic)
+    }
+
+    func isPublicationMatched(writer: any DDSWriterHandle) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let mock = writer as? MockDDSWriterHandle else { return false }
+        return matchedTopics.contains(mock.topic)
     }
 
     // MARK: - private helpers

--- a/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
+++ b/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
@@ -1,0 +1,44 @@
+// ServiceTransportTests.swift
+// DDS Service Server / Client end-to-end tests using MockDDSClient.
+
+import Foundation
+import XCTest
+
+@testable import SwiftROS2Transport
+
+final class DDSServiceTransportTests: XCTestCase {
+    func testServerEchoesRequest() async throws {
+        let client = MockDDSClient()
+        let session = DDSTransportSession(client: client)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+
+        let received = Box<Data?>(nil)
+        let server = try session.createServiceServer(
+            name: "/echo",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: nil,
+            responseTypeHash: nil,
+            qos: .sensorData,
+            handler: { req in
+                received.value = req
+                return Data([0x00, 0x01, 0x00, 0x00, 0xCC])
+            }
+        )
+
+        let id = RMWRequestId(writerGuid: Array(repeating: 0xAB, count: 16), sequenceNumber: 7)
+        let userCDR = Data([0x00, 0x01, 0x00, 0x00, 0xDE])
+        let wire = SampleIdentityPrefix.encode(requestId: id, userCDR: userCDR)
+
+        try await client.deliverToReader(topic: "rq/echoRequest", wire: wire, timestamp: 1_000)
+
+        let written = try await client.awaitWrite(topic: "rr/echoReply", timeout: .seconds(1))
+        let writtenBytes = try XCTUnwrap(written)
+
+        XCTAssertEqual(received.value, userCDR)
+
+        let (parsedId, parsedBody) = try SampleIdentityPrefix.decode(wirePayload: writtenBytes)
+        XCTAssertEqual(parsedId, id)
+        XCTAssertEqual(parsedBody, Data([0x00, 0x01, 0x00, 0x00, 0xCC]))
+        try server.close()
+    }
+}

--- a/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
+++ b/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
@@ -41,4 +41,93 @@ final class DDSServiceTransportTests: XCTestCase {
         XCTAssertEqual(parsedBody, Data([0x00, 0x01, 0x00, 0x00, 0xCC]))
         try server.close()
     }
+
+    func testClientWritesPrefixedRequestAndAwaitsReply() async throws {
+        let client = MockDDSClient()
+        let session = DDSTransportSession(client: client)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+
+        let svc = try session.createServiceClient(
+            name: "/echo",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: nil,
+            responseTypeHash: nil,
+            qos: .sensorData
+        )
+
+        client.markPublicationsMatched(topic: "rq/echoRequest")
+
+        let userRequest = Data([0x00, 0x01, 0x00, 0x00, 0xDE])
+        async let response: Data = svc.call(requestCDR: userRequest, timeout: .seconds(1))
+
+        let writtenWire = try await client.awaitWrite(topic: "rq/echoRequest", timeout: .seconds(1))
+        let bytes = try XCTUnwrap(writtenWire)
+        let (id, parsedReq) = try SampleIdentityPrefix.decode(wirePayload: bytes)
+        XCTAssertEqual(parsedReq, userRequest)
+        XCTAssertEqual(id.writerGuid.count, 16)
+        XCTAssertEqual(id.sequenceNumber, 1)
+
+        let userReply = Data([0x00, 0x01, 0x00, 0x00, 0xEE])
+        let replyWire = SampleIdentityPrefix.encode(requestId: id, userCDR: userReply)
+        try await client.deliverToReader(topic: "rr/echoReply", wire: replyWire, timestamp: 0)
+
+        let body = try await response
+        XCTAssertEqual(body, userReply)
+        try svc.close()
+    }
+
+    func testClientTimesOut() async throws {
+        let client = MockDDSClient()
+        let session = DDSTransportSession(client: client)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        let svc = try session.createServiceClient(
+            name: "/echo",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: nil,
+            responseTypeHash: nil,
+            qos: .sensorData
+        )
+        client.markPublicationsMatched(topic: "rq/echoRequest")
+
+        do {
+            _ = try await svc.call(
+                requestCDR: Data([0x00, 0x01, 0x00, 0x00]),
+                timeout: .milliseconds(50)
+            )
+            XCTFail("should have timed out")
+        } catch TransportError.requestTimeout {
+            // expected
+        }
+        try svc.close()
+    }
+
+    func testClientCancellationPropagates() async throws {
+        let client = MockDDSClient()
+        let session = DDSTransportSession(client: client)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        let svc = try session.createServiceClient(
+            name: "/echo",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: nil,
+            responseTypeHash: nil,
+            qos: .sensorData
+        )
+        client.markPublicationsMatched(topic: "rq/echoRequest")
+
+        let task = Task {
+            try await svc.call(
+                requestCDR: Data([0x00, 0x01, 0x00, 0x00]),
+                timeout: .seconds(60)
+            )
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("should have been cancelled")
+        } catch TransportError.requestCancelled {
+            // expected
+        }
+        try svc.close()
+    }
 }


### PR DESCRIPTION
## Summary

End-to-end DDS service implementation built on top of `TransportService` / `TransportClient` from #67.

- `SampleIdentityPrefix` encode/decode (CDR header + 24-byte rmw_request_id_t + body)
- `ClientPendingTable` actor for sequence-number correlation
- `DDSTransportSession.createServiceServer` / `createServiceClient` (rq/rr paired topics + 24-byte prefix routing)
- `waitForService` polls matched-publication count
- `call` honors `Duration` timeout and parent-Task cancellation
- `DDSClientProtocol.isPublicationMatched` (default `true` so existing conformers like Conduit's bridge keep building unchanged)

Public umbrella API (`ROS2Service<S>` / `ROS2Client<S>`) lands in phase 6 alongside Zenoh.

**Stack:** built on top of #67 (phase 3). PRs to merge in order:
- PR #67 (phase 3) — protocols + stubs
- **PR (this) — phase 4: DDS server/client**
- next: phase 5 (Zenoh C-bridge)
- final: phase 6 (umbrella API + Zenoh transport + integration tests)

## Test plan

- [x] swift build (clean)
- [x] swift test (232 tests, 3 LINUX_IP-gated skips, 0 failures)
- [x] DDSServiceTransportTests: 4 tests covering server echo, client request+reply correlation, timeout, and parent-Task cancellation
- [x] SampleIdentityPrefixTests: 4 tests covering encode shape + round trip + error cases
- [x] ClientPendingTableTests: 4 tests covering insert/resolve/cancel/failAll
- [ ] DDS round-trip integration test deferred to phase 6 (depends on umbrella API)