### PR TITLE
feat(czenoh, zenoh): queryable + get primitives (phase 5 of 6)

### DIFF
--- a/Sources/CZenohBridge/include/zenoh_bridge.h
+++ b/Sources/CZenohBridge/include/zenoh_bridge.h
@@ -177,6 +177,128 @@ zenoh_result_t zenoh_undeclare_liveliness_token(zenoh_session_t* session,
                                                 zenoh_liveliness_token_t** token);
 
 // ============================================================================
+// Queryable (Service Server side)
+// ============================================================================
+
+typedef struct zenoh_queryable_t zenoh_queryable_t;
+typedef struct zenoh_query_t zenoh_query_t;
+
+/// Callback invoked when a query is received on a declared queryable.
+/// The query handle is owned by the bridge and remains valid until the
+/// Swift side calls `zenoh_query_reply` or `zenoh_query_reply_err`, both of
+/// which consume it. If neither is called before the queryable is undeclared,
+/// the bridge drops the cloned query when the queryable is freed.
+/// @param query Owned query handle (consumed by the first reply call)
+/// @param keyexpr_str The key expression the query was issued against
+/// @param payload Pointer to the query payload (NULL if empty)
+/// @param payload_len Length of the query payload (0 if empty)
+/// @param attachment Pointer to the query attachment (NULL if not present)
+/// @param attachment_len Length of the attachment (0 if not present)
+/// @param context User-provided context pointer
+typedef void (*zenoh_queryable_callback_t)(zenoh_query_t* query,
+                                            const char* keyexpr_str,
+                                            const uint8_t* payload,
+                                            size_t payload_len,
+                                            const uint8_t* attachment,
+                                            size_t attachment_len,
+                                            void* context);
+
+/// Declares a queryable on the given key expression
+/// @param session The zenoh session
+/// @param keyexpr_str The key expression to expose as a queryable
+/// @param callback Callback invoked once per incoming query
+/// @param context User context pointer passed to the callback
+/// @param out_queryable Output parameter for the queryable handle
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_declare_queryable(zenoh_session_t* session,
+                                       const char* keyexpr_str,
+                                       zenoh_queryable_callback_t callback,
+                                       void* context,
+                                       zenoh_queryable_t** out_queryable);
+
+/// Undeclares and frees a queryable
+/// @param session The zenoh session
+/// @param queryable Queryable handle to undeclare (will be set to NULL)
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_undeclare_queryable(zenoh_session_t* session,
+                                         zenoh_queryable_t** queryable);
+
+/// Replies to a query with a successful payload and optional attachment.
+/// Consumes the query handle: after this call returns, *query is freed and
+/// the Swift side must drop its pointer.
+/// @param query Query handle (consumed)
+/// @param payload Pointer to the reply payload (may be NULL if payload_len == 0)
+/// @param payload_len Length of the reply payload
+/// @param attachment Optional attachment data (NULL for none)
+/// @param attachment_len Length of the attachment (0 for none)
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_query_reply(zenoh_query_t* query,
+                                 const uint8_t* payload,
+                                 size_t payload_len,
+                                 const uint8_t* attachment,
+                                 size_t attachment_len);
+
+/// Replies to a query with an error payload (UTF-8 encoded message).
+/// Consumes the query handle: after this call returns, *query is freed and
+/// the Swift side must drop its pointer.
+/// @param query Query handle (consumed)
+/// @param message_utf8 Pointer to UTF-8 error message bytes (may be NULL if len == 0)
+/// @param len Length of the error message in bytes
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_query_reply_err(zenoh_query_t* query,
+                                     const char* message_utf8,
+                                     size_t len);
+
+// ============================================================================
+// Get (Service Client side)
+// ============================================================================
+
+/// Per-reply callback invoked once for each reply received from a get.
+/// `is_error` indicates whether this is an error reply.
+/// @param keyexpr_str The key expression the reply is associated with
+/// @param payload Pointer to the reply payload (NULL if empty)
+/// @param payload_len Length of the reply payload (0 if empty)
+/// @param attachment Pointer to the reply attachment (NULL if not present)
+/// @param attachment_len Length of the attachment (0 if not present)
+/// @param is_error true if this is an error reply, false if it is an OK reply
+/// @param context User-provided context pointer
+typedef void (*zenoh_get_reply_callback_t)(const char* keyexpr_str,
+                                            const uint8_t* payload,
+                                            size_t payload_len,
+                                            const uint8_t* attachment,
+                                            size_t attachment_len,
+                                            bool is_error,
+                                            void* context);
+
+/// Finish callback invoked exactly once after the final reply is delivered
+/// (or the timeout has elapsed). Use this to free any user-side context.
+/// @param context User-provided context pointer
+typedef void (*zenoh_get_finish_callback_t)(void* context);
+
+/// Issues a query against the given key expression
+/// @param session The zenoh session
+/// @param keyexpr_str The key expression to query
+/// @param payload Pointer to the request payload (NULL for none)
+/// @param payload_len Length of the request payload (0 for none)
+/// @param attachment Pointer to the request attachment (NULL for none)
+/// @param attachment_len Length of the attachment (0 for none)
+/// @param timeout_ms Query timeout in milliseconds (0 = library default)
+/// @param reply_callback Callback invoked once per reply
+/// @param finish_callback Callback invoked once after all replies are delivered
+/// @param context User context pointer passed to both callbacks
+/// @return 0 on success, negative error code otherwise
+zenoh_result_t zenoh_get(zenoh_session_t* session,
+                         const char* keyexpr_str,
+                         const uint8_t* payload,
+                         size_t payload_len,
+                         const uint8_t* attachment,
+                         size_t attachment_len,
+                         uint32_t timeout_ms,
+                         zenoh_get_reply_callback_t reply_callback,
+                         zenoh_get_finish_callback_t finish_callback,
+                         void* context);
+
+// ============================================================================
 // Utility functions
 // ============================================================================
 

--- a/Sources/CZenohBridge/zenoh_bridge.c
+++ b/Sources/CZenohBridge/zenoh_bridge.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <pthread.h>
 
 #ifdef __APPLE__
   #include <os/log.h>
@@ -49,14 +50,27 @@ struct zenoh_liveliness_token_t {
     z_owned_liveliness_token_t token;
 };
 
+// Forward declarations for the linked-list cross-references between
+// zenoh_query_t and zenoh_queryable_t.
+struct zenoh_queryable_t;
+
+struct zenoh_query_t {
+    z_owned_query_t query;
+    struct zenoh_queryable_t* owner;  // queryable that produced this query (for unlink)
+    struct zenoh_query_t* next;       // singly-linked list of outstanding queries
+    struct zenoh_query_t* prev;
+};
+
 struct zenoh_queryable_t {
     z_owned_queryable_t queryable;
     zenoh_queryable_callback_t callback;
     void* context;
-};
-
-struct zenoh_query_t {
-    z_owned_query_t query;
+    // Outstanding queries that the Swift side hasn't replied to yet. The
+    // C bridge owns them; on undeclare, we walk this list and drop+free
+    // every entry so a Swift handler that returns without replying does
+    // not leak bridge state.
+    struct zenoh_query_t* outstanding_head;
+    pthread_mutex_t outstanding_lock;
 };
 
 typedef struct {
@@ -563,6 +577,40 @@ zenoh_result_t zenoh_undeclare_liveliness_token(zenoh_session_t* session,
 // Queryable (Service Server side)
 // ============================================================================
 
+// Link a query into the queryable's outstanding-list head. Caller must NOT
+// hold the lock.
+static void zenoh_queryable_link_query(zenoh_queryable_t* qbl, zenoh_query_t* q) {
+    pthread_mutex_lock(&qbl->outstanding_lock);
+    q->owner = qbl;
+    q->prev = NULL;
+    q->next = qbl->outstanding_head;
+    if (qbl->outstanding_head) {
+        qbl->outstanding_head->prev = q;
+    }
+    qbl->outstanding_head = q;
+    pthread_mutex_unlock(&qbl->outstanding_lock);
+}
+
+// Unlink a query from its owner's outstanding-list. Caller must NOT hold
+// the lock. Safe to call at most once per query (no-op if already unlinked).
+static void zenoh_queryable_unlink_query(zenoh_query_t* q) {
+    if (!q->owner) return;
+    zenoh_queryable_t* qbl = q->owner;
+    pthread_mutex_lock(&qbl->outstanding_lock);
+    if (q->prev) {
+        q->prev->next = q->next;
+    } else if (qbl->outstanding_head == q) {
+        qbl->outstanding_head = q->next;
+    }
+    if (q->next) {
+        q->next->prev = q->prev;
+    }
+    q->prev = NULL;
+    q->next = NULL;
+    q->owner = NULL;
+    pthread_mutex_unlock(&qbl->outstanding_lock);
+}
+
 // Internal closure handler that translates a loaned query into a cloned,
 // owned query handle and dispatches to the user-supplied callback.
 static void zenoh_query_handler(z_loaned_query_t* query, void* context) {
@@ -576,11 +624,16 @@ static void zenoh_query_handler(z_loaned_query_t* query, void* context) {
     if (!q) {
         return;
     }
+    q->owner = NULL;
+    q->next = NULL;
+    q->prev = NULL;
 
     if (z_query_clone(&q->query, query) < 0) {
         free(q);
         return;
     }
+
+    zenoh_queryable_link_query(qbl, q);
 
     // Extract keyexpr as a null-terminated string.
     const z_loaned_keyexpr_t* keyexpr = z_query_keyexpr(query);
@@ -649,6 +702,8 @@ zenoh_result_t zenoh_declare_queryable(zenoh_session_t* session,
 
     qbl->callback = callback;
     qbl->context = context;
+    qbl->outstanding_head = NULL;
+    pthread_mutex_init(&qbl->outstanding_lock, NULL);
 
     // Create a view keyexpr from the string.
     z_view_keyexpr_t view_ke;
@@ -666,6 +721,7 @@ zenoh_result_t zenoh_declare_queryable(zenoh_session_t* session,
 
     if (z_declare_queryable(z_loan(session->session), &qbl->queryable,
                             z_loan(view_ke), z_move(closure), &options) < 0) {
+        pthread_mutex_destroy(&qbl->outstanding_lock);
         free(qbl);
         return -1;
     }
@@ -684,6 +740,21 @@ zenoh_result_t zenoh_undeclare_queryable(zenoh_session_t* session,
 
     z_undeclare_queryable(z_move(qbl->queryable));
 
+    // Drop and free any outstanding queries the Swift handler abandoned
+    // without replying. After undeclare, no new queries can arrive on this
+    // queryable, so a single drain is sufficient.
+    pthread_mutex_lock(&qbl->outstanding_lock);
+    zenoh_query_t* q = qbl->outstanding_head;
+    qbl->outstanding_head = NULL;
+    pthread_mutex_unlock(&qbl->outstanding_lock);
+    while (q) {
+        zenoh_query_t* next = q->next;
+        z_drop(z_move(q->query));
+        free(q);
+        q = next;
+    }
+
+    pthread_mutex_destroy(&qbl->outstanding_lock);
     free(qbl);
     *queryable = NULL;
 
@@ -702,6 +773,7 @@ zenoh_result_t zenoh_query_reply(zenoh_query_t* query,
     z_owned_bytes_t payload_bytes;
     if (z_bytes_from_buf(&payload_bytes, (uint8_t*)payload, payload_len, NULL, NULL) < 0) {
         // Drop the query on error so the caller does not double-free.
+        zenoh_queryable_unlink_query(query);
         z_drop(z_move(query->query));
         free(query);
         return -1;
@@ -714,6 +786,7 @@ zenoh_result_t zenoh_query_reply(zenoh_query_t* query,
     if (attachment && attachment_len > 0) {
         if (z_bytes_from_buf(&attachment_bytes, (uint8_t*)attachment, attachment_len, NULL, NULL) < 0) {
             z_drop(z_move(payload_bytes));
+            zenoh_queryable_unlink_query(query);
             z_drop(z_move(query->query));
             free(query);
             return -1;
@@ -725,6 +798,7 @@ zenoh_result_t zenoh_query_reply(zenoh_query_t* query,
     const z_loaned_keyexpr_t* keyexpr = z_query_keyexpr(loaned);
     int result = z_query_reply(loaned, keyexpr, z_move(payload_bytes), &options);
 
+    zenoh_queryable_unlink_query(query);
     z_drop(z_move(query->query));
     free(query);
 
@@ -740,6 +814,7 @@ zenoh_result_t zenoh_query_reply_err(zenoh_query_t* query,
 
     z_owned_bytes_t payload_bytes;
     if (z_bytes_from_buf(&payload_bytes, (uint8_t*)message_utf8, len, NULL, NULL) < 0) {
+        zenoh_queryable_unlink_query(query);
         z_drop(z_move(query->query));
         free(query);
         return -1;
@@ -751,6 +826,7 @@ zenoh_result_t zenoh_query_reply_err(zenoh_query_t* query,
     const z_loaned_query_t* loaned = z_loan(query->query);
     int result = z_query_reply_err(loaned, z_move(payload_bytes), &options);
 
+    zenoh_queryable_unlink_query(query);
     z_drop(z_move(query->query));
     free(query);
 

--- a/Sources/CZenohBridge/zenoh_bridge.c
+++ b/Sources/CZenohBridge/zenoh_bridge.c
@@ -10,7 +10,28 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include <pthread.h>
+
+// Portable mutex shim. Windows does not ship <pthread.h>; the rest of the
+// supported platforms (Apple, Linux, Android Bionic) all do. The C bridge
+// only needs a non-recursive mutex for the queryable outstanding-query
+// list, so we map the small surface to either pthread or Win32
+// CRITICAL_SECTION.
+#ifdef _WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+typedef CRITICAL_SECTION zenoh_mutex_t;
+#  define zenoh_mutex_init(m)    InitializeCriticalSection(m)
+#  define zenoh_mutex_destroy(m) DeleteCriticalSection(m)
+#  define zenoh_mutex_lock(m)    EnterCriticalSection(m)
+#  define zenoh_mutex_unlock(m)  LeaveCriticalSection(m)
+#else
+#  include <pthread.h>
+typedef pthread_mutex_t zenoh_mutex_t;
+#  define zenoh_mutex_init(m)    pthread_mutex_init(m, NULL)
+#  define zenoh_mutex_destroy(m) pthread_mutex_destroy(m)
+#  define zenoh_mutex_lock(m)    pthread_mutex_lock(m)
+#  define zenoh_mutex_unlock(m)  pthread_mutex_unlock(m)
+#endif
 
 #ifdef __APPLE__
   #include <os/log.h>
@@ -70,7 +91,7 @@ struct zenoh_queryable_t {
     // every entry so a Swift handler that returns without replying does
     // not leak bridge state.
     struct zenoh_query_t* outstanding_head;
-    pthread_mutex_t outstanding_lock;
+    zenoh_mutex_t outstanding_lock;
 };
 
 typedef struct {
@@ -580,7 +601,7 @@ zenoh_result_t zenoh_undeclare_liveliness_token(zenoh_session_t* session,
 // Link a query into the queryable's outstanding-list head. Caller must NOT
 // hold the lock.
 static void zenoh_queryable_link_query(zenoh_queryable_t* qbl, zenoh_query_t* q) {
-    pthread_mutex_lock(&qbl->outstanding_lock);
+    zenoh_mutex_lock(&qbl->outstanding_lock);
     q->owner = qbl;
     q->prev = NULL;
     q->next = qbl->outstanding_head;
@@ -588,7 +609,7 @@ static void zenoh_queryable_link_query(zenoh_queryable_t* qbl, zenoh_query_t* q)
         qbl->outstanding_head->prev = q;
     }
     qbl->outstanding_head = q;
-    pthread_mutex_unlock(&qbl->outstanding_lock);
+    zenoh_mutex_unlock(&qbl->outstanding_lock);
 }
 
 // Unlink a query from its owner's outstanding-list. Caller must NOT hold
@@ -596,7 +617,7 @@ static void zenoh_queryable_link_query(zenoh_queryable_t* qbl, zenoh_query_t* q)
 static void zenoh_queryable_unlink_query(zenoh_query_t* q) {
     if (!q->owner) return;
     zenoh_queryable_t* qbl = q->owner;
-    pthread_mutex_lock(&qbl->outstanding_lock);
+    zenoh_mutex_lock(&qbl->outstanding_lock);
     if (q->prev) {
         q->prev->next = q->next;
     } else if (qbl->outstanding_head == q) {
@@ -608,7 +629,7 @@ static void zenoh_queryable_unlink_query(zenoh_query_t* q) {
     q->prev = NULL;
     q->next = NULL;
     q->owner = NULL;
-    pthread_mutex_unlock(&qbl->outstanding_lock);
+    zenoh_mutex_unlock(&qbl->outstanding_lock);
 }
 
 // Internal closure handler that translates a loaned query into a cloned,
@@ -703,7 +724,7 @@ zenoh_result_t zenoh_declare_queryable(zenoh_session_t* session,
     qbl->callback = callback;
     qbl->context = context;
     qbl->outstanding_head = NULL;
-    pthread_mutex_init(&qbl->outstanding_lock, NULL);
+    zenoh_mutex_init(&qbl->outstanding_lock);
 
     // Create a view keyexpr from the string.
     z_view_keyexpr_t view_ke;
@@ -721,7 +742,7 @@ zenoh_result_t zenoh_declare_queryable(zenoh_session_t* session,
 
     if (z_declare_queryable(z_loan(session->session), &qbl->queryable,
                             z_loan(view_ke), z_move(closure), &options) < 0) {
-        pthread_mutex_destroy(&qbl->outstanding_lock);
+        zenoh_mutex_destroy(&qbl->outstanding_lock);
         free(qbl);
         return -1;
     }
@@ -743,10 +764,10 @@ zenoh_result_t zenoh_undeclare_queryable(zenoh_session_t* session,
     // Drop and free any outstanding queries the Swift handler abandoned
     // without replying. After undeclare, no new queries can arrive on this
     // queryable, so a single drain is sufficient.
-    pthread_mutex_lock(&qbl->outstanding_lock);
+    zenoh_mutex_lock(&qbl->outstanding_lock);
     zenoh_query_t* q = qbl->outstanding_head;
     qbl->outstanding_head = NULL;
-    pthread_mutex_unlock(&qbl->outstanding_lock);
+    zenoh_mutex_unlock(&qbl->outstanding_lock);
     while (q) {
         zenoh_query_t* next = q->next;
         z_drop(z_move(q->query));
@@ -754,7 +775,7 @@ zenoh_result_t zenoh_undeclare_queryable(zenoh_session_t* session,
         q = next;
     }
 
-    pthread_mutex_destroy(&qbl->outstanding_lock);
+    zenoh_mutex_destroy(&qbl->outstanding_lock);
     free(qbl);
     *queryable = NULL;
 

--- a/Sources/CZenohBridge/zenoh_bridge.c
+++ b/Sources/CZenohBridge/zenoh_bridge.c
@@ -49,6 +49,22 @@ struct zenoh_liveliness_token_t {
     z_owned_liveliness_token_t token;
 };
 
+struct zenoh_queryable_t {
+    z_owned_queryable_t queryable;
+    zenoh_queryable_callback_t callback;
+    void* context;
+};
+
+struct zenoh_query_t {
+    z_owned_query_t query;
+};
+
+typedef struct {
+    zenoh_get_reply_callback_t reply_callback;
+    zenoh_get_finish_callback_t finish_callback;
+    void* context;
+} zenoh_get_callback_state_t;
+
 // ============================================================================
 // Session management
 // ============================================================================
@@ -539,6 +555,371 @@ zenoh_result_t zenoh_undeclare_liveliness_token(zenoh_session_t* session,
 
     free(t);
     *token = NULL;
+
+    return 0;
+}
+
+// ============================================================================
+// Queryable (Service Server side)
+// ============================================================================
+
+// Internal closure handler that translates a loaned query into a cloned,
+// owned query handle and dispatches to the user-supplied callback.
+static void zenoh_query_handler(z_loaned_query_t* query, void* context) {
+    zenoh_queryable_t* qbl = (zenoh_queryable_t*)context;
+    if (!qbl || !qbl->callback) {
+        return;
+    }
+
+    // Allocate the wrapper that will outlive the C closure scope.
+    zenoh_query_t* q = (zenoh_query_t*)malloc(sizeof(zenoh_query_t));
+    if (!q) {
+        return;
+    }
+
+    if (z_query_clone(&q->query, query) < 0) {
+        free(q);
+        return;
+    }
+
+    // Extract keyexpr as a null-terminated string.
+    const z_loaned_keyexpr_t* keyexpr = z_query_keyexpr(query);
+    z_view_string_t keyexpr_str;
+    z_keyexpr_as_view_string(keyexpr, &keyexpr_str);
+    const char* ke_cstr = z_string_data(z_loan(keyexpr_str));
+
+    // Extract payload (may be NULL).
+    const z_loaned_bytes_t* payload_bytes = z_query_payload(query);
+    uint8_t* payload_data = NULL;
+    size_t payload_len = 0;
+    if (payload_bytes) {
+        payload_len = z_bytes_len(payload_bytes);
+        if (payload_len > 0) {
+            payload_data = (uint8_t*)malloc(payload_len);
+            if (!payload_data) {
+                z_drop(z_move(q->query));
+                free(q);
+                return;
+            }
+            z_bytes_reader_t reader = z_bytes_get_reader(payload_bytes);
+            z_bytes_reader_read(&reader, payload_data, payload_len);
+        }
+    }
+
+    // Extract attachment if present.
+    const z_loaned_bytes_t* attachment_bytes = z_query_attachment(query);
+    uint8_t* attachment_data = NULL;
+    size_t attachment_len = 0;
+    if (attachment_bytes) {
+        attachment_len = z_bytes_len(attachment_bytes);
+        if (attachment_len > 0) {
+            attachment_data = (uint8_t*)malloc(attachment_len);
+            if (!attachment_data) {
+                attachment_len = 0;
+            } else {
+                z_bytes_reader_t att_reader = z_bytes_get_reader(attachment_bytes);
+                z_bytes_reader_read(&att_reader, attachment_data, attachment_len);
+            }
+        }
+    }
+
+    // Hand off ownership of `q` to Swift. Swift must call zenoh_query_reply or
+    // zenoh_query_reply_err to consume it; otherwise the bridge frees it on
+    // queryable undeclare via the closure drop_fn.
+    qbl->callback(q, ke_cstr, payload_data, payload_len,
+                  attachment_data, attachment_len, qbl->context);
+
+    if (payload_data) free(payload_data);
+    if (attachment_data) free(attachment_data);
+}
+
+zenoh_result_t zenoh_declare_queryable(zenoh_session_t* session,
+                                       const char* keyexpr_str,
+                                       zenoh_queryable_callback_t callback,
+                                       void* context,
+                                       zenoh_queryable_t** out_queryable) {
+    if (!session || !keyexpr_str || !callback || !out_queryable) {
+        return -1;
+    }
+
+    zenoh_queryable_t* qbl = (zenoh_queryable_t*)malloc(sizeof(zenoh_queryable_t));
+    if (!qbl) {
+        return -1;
+    }
+
+    qbl->callback = callback;
+    qbl->context = context;
+
+    // Create a view keyexpr from the string.
+    z_view_keyexpr_t view_ke;
+    if (z_view_keyexpr_from_str(&view_ke, keyexpr_str) < 0) {
+        free(qbl);
+        return -1;
+    }
+
+    // Build the closure with our static handler.
+    z_owned_closure_query_t closure;
+    z_closure(&closure, zenoh_query_handler, NULL, qbl);
+
+    z_queryable_options_t options;
+    z_queryable_options_default(&options);
+
+    if (z_declare_queryable(z_loan(session->session), &qbl->queryable,
+                            z_loan(view_ke), z_move(closure), &options) < 0) {
+        free(qbl);
+        return -1;
+    }
+
+    *out_queryable = qbl;
+    return 0;
+}
+
+zenoh_result_t zenoh_undeclare_queryable(zenoh_session_t* session,
+                                         zenoh_queryable_t** queryable) {
+    if (!session || !queryable || !*queryable) {
+        return -1;
+    }
+
+    zenoh_queryable_t* qbl = *queryable;
+
+    z_undeclare_queryable(z_move(qbl->queryable));
+
+    free(qbl);
+    *queryable = NULL;
+
+    return 0;
+}
+
+zenoh_result_t zenoh_query_reply(zenoh_query_t* query,
+                                 const uint8_t* payload,
+                                 size_t payload_len,
+                                 const uint8_t* attachment,
+                                 size_t attachment_len) {
+    if (!query) {
+        return -1;
+    }
+
+    z_owned_bytes_t payload_bytes;
+    if (z_bytes_from_buf(&payload_bytes, (uint8_t*)payload, payload_len, NULL, NULL) < 0) {
+        // Drop the query on error so the caller does not double-free.
+        z_drop(z_move(query->query));
+        free(query);
+        return -1;
+    }
+
+    z_query_reply_options_t options;
+    z_query_reply_options_default(&options);
+
+    z_owned_bytes_t attachment_bytes;
+    if (attachment && attachment_len > 0) {
+        if (z_bytes_from_buf(&attachment_bytes, (uint8_t*)attachment, attachment_len, NULL, NULL) < 0) {
+            z_drop(z_move(payload_bytes));
+            z_drop(z_move(query->query));
+            free(query);
+            return -1;
+        }
+        options.attachment = z_move(attachment_bytes);
+    }
+
+    const z_loaned_query_t* loaned = z_loan(query->query);
+    const z_loaned_keyexpr_t* keyexpr = z_query_keyexpr(loaned);
+    int result = z_query_reply(loaned, keyexpr, z_move(payload_bytes), &options);
+
+    z_drop(z_move(query->query));
+    free(query);
+
+    return (zenoh_result_t)result;
+}
+
+zenoh_result_t zenoh_query_reply_err(zenoh_query_t* query,
+                                     const char* message_utf8,
+                                     size_t len) {
+    if (!query) {
+        return -1;
+    }
+
+    z_owned_bytes_t payload_bytes;
+    if (z_bytes_from_buf(&payload_bytes, (uint8_t*)message_utf8, len, NULL, NULL) < 0) {
+        z_drop(z_move(query->query));
+        free(query);
+        return -1;
+    }
+
+    z_query_reply_err_options_t options;
+    z_query_reply_err_options_default(&options);
+
+    const z_loaned_query_t* loaned = z_loan(query->query);
+    int result = z_query_reply_err(loaned, z_move(payload_bytes), &options);
+
+    z_drop(z_move(query->query));
+    free(query);
+
+    return (zenoh_result_t)result;
+}
+
+// ============================================================================
+// Get (Service Client side)
+// ============================================================================
+
+// Per-reply handler that translates a loaned reply into the user callback.
+static void zenoh_get_reply_handler(z_loaned_reply_t* reply, void* context) {
+    zenoh_get_callback_state_t* state = (zenoh_get_callback_state_t*)context;
+    if (!state || !state->reply_callback) {
+        return;
+    }
+
+    bool is_error = !z_reply_is_ok(reply);
+    const z_loaned_bytes_t* payload_bytes = NULL;
+    const z_loaned_bytes_t* attachment_bytes = NULL;
+    const z_loaned_keyexpr_t* keyexpr = NULL;
+
+    if (is_error) {
+        const z_loaned_reply_err_t* err = z_reply_err(reply);
+        if (err) {
+            payload_bytes = z_reply_err_payload(err);
+        }
+    } else {
+        const z_loaned_sample_t* sample = z_reply_ok(reply);
+        if (sample) {
+            keyexpr = z_sample_keyexpr(sample);
+            payload_bytes = z_sample_payload(sample);
+            attachment_bytes = z_sample_attachment(sample);
+        }
+    }
+
+    // Marshal keyexpr.
+    const char* ke_cstr = "";
+    z_view_string_t keyexpr_str;
+    if (keyexpr) {
+        z_keyexpr_as_view_string(keyexpr, &keyexpr_str);
+        ke_cstr = z_string_data(z_loan(keyexpr_str));
+    }
+
+    // Marshal payload.
+    uint8_t* payload_data = NULL;
+    size_t payload_len = 0;
+    if (payload_bytes) {
+        payload_len = z_bytes_len(payload_bytes);
+        if (payload_len > 0) {
+            payload_data = (uint8_t*)malloc(payload_len);
+            if (!payload_data) {
+                payload_len = 0;
+            } else {
+                z_bytes_reader_t reader = z_bytes_get_reader(payload_bytes);
+                z_bytes_reader_read(&reader, payload_data, payload_len);
+            }
+        }
+    }
+
+    // Marshal attachment.
+    uint8_t* attachment_data = NULL;
+    size_t attachment_len = 0;
+    if (attachment_bytes) {
+        attachment_len = z_bytes_len(attachment_bytes);
+        if (attachment_len > 0) {
+            attachment_data = (uint8_t*)malloc(attachment_len);
+            if (!attachment_data) {
+                attachment_len = 0;
+            } else {
+                z_bytes_reader_t att_reader = z_bytes_get_reader(attachment_bytes);
+                z_bytes_reader_read(&att_reader, attachment_data, attachment_len);
+            }
+        }
+    }
+
+    state->reply_callback(ke_cstr, payload_data, payload_len,
+                          attachment_data, attachment_len, is_error,
+                          state->context);
+
+    if (payload_data) free(payload_data);
+    if (attachment_data) free(attachment_data);
+}
+
+// Drop handler invoked once when the reply closure is dropped (after the
+// final reply or the timeout). Frees the heap-allocated state.
+static void zenoh_get_finish_handler(void* context) {
+    zenoh_get_callback_state_t* state = (zenoh_get_callback_state_t*)context;
+    if (!state) {
+        return;
+    }
+    if (state->finish_callback) {
+        state->finish_callback(state->context);
+    }
+    free(state);
+}
+
+zenoh_result_t zenoh_get(zenoh_session_t* session,
+                         const char* keyexpr_str,
+                         const uint8_t* payload,
+                         size_t payload_len,
+                         const uint8_t* attachment,
+                         size_t attachment_len,
+                         uint32_t timeout_ms,
+                         zenoh_get_reply_callback_t reply_callback,
+                         zenoh_get_finish_callback_t finish_callback,
+                         void* context) {
+    if (!session || !keyexpr_str || !reply_callback) {
+        return -1;
+    }
+
+    if (z_session_is_closed(z_loan(session->session))) {
+        return ZENOH_ERROR_SESSION_CLOSED;
+    }
+
+    z_view_keyexpr_t view_ke;
+    if (z_view_keyexpr_from_str(&view_ke, keyexpr_str) < 0) {
+        return -1;
+    }
+
+    zenoh_get_callback_state_t* state = (zenoh_get_callback_state_t*)malloc(sizeof(zenoh_get_callback_state_t));
+    if (!state) {
+        return -1;
+    }
+    state->reply_callback = reply_callback;
+    state->finish_callback = finish_callback;
+    state->context = context;
+
+    z_get_options_t options;
+    z_get_options_default(&options);
+    if (timeout_ms > 0) {
+        options.timeout_ms = (uint64_t)timeout_ms;
+    }
+
+    z_owned_bytes_t payload_bytes;
+    bool payload_built = false;
+    if (payload && payload_len > 0) {
+        if (z_bytes_from_buf(&payload_bytes, (uint8_t*)payload, payload_len, NULL, NULL) < 0) {
+            free(state);
+            return -1;
+        }
+        options.payload = z_move(payload_bytes);
+        payload_built = true;
+    }
+
+    z_owned_bytes_t attachment_bytes;
+    if (attachment && attachment_len > 0) {
+        if (z_bytes_from_buf(&attachment_bytes, (uint8_t*)attachment, attachment_len, NULL, NULL) < 0) {
+            if (payload_built) {
+                z_drop(z_move(payload_bytes));
+            }
+            free(state);
+            return -1;
+        }
+        options.attachment = z_move(attachment_bytes);
+    }
+
+    z_owned_closure_reply_t closure;
+    z_closure(&closure, zenoh_get_reply_handler, zenoh_get_finish_handler, state);
+
+    int result = z_get(z_loan(session->session), z_loan(view_ke), "",
+                       z_move(closure), &options);
+
+    if (result < 0) {
+        // The closure drop handler already frees `state` even on z_get failure
+        // (zenoh-pico drops the moved closure when it cannot accept it). Do
+        // not double-free here.
+        return (zenoh_result_t)result;
+    }
 
     return 0;
 }

--- a/Sources/SwiftROS2Transport/ZenohClientProtocol.swift
+++ b/Sources/SwiftROS2Transport/ZenohClientProtocol.swift
@@ -22,6 +22,33 @@ public protocol ZenohLivelinessTokenHandle: AnyObject {
     func close() throws
 }
 
+/// Handle to a declared Zenoh queryable (Service Server side)
+public protocol ZenohQueryableHandle: AnyObject {
+    func close() throws
+}
+
+/// A live in-flight Zenoh query held by the C bridge until reply.
+///
+/// Consumed by the first call to `reply(payload:attachment:)` or
+/// `replyError(message:)`. After consumption further reply calls throw
+/// `ZenohError.invalidParameter`.
+public protocol ZenohQueryHandle: AnyObject, Sendable {
+    /// The key expression the query was issued against.
+    var keyExpr: String { get }
+
+    /// The query payload (empty if the query carried none).
+    var payload: Data { get }
+
+    /// The query attachment (nil if the query carried none).
+    var attachment: Data? { get }
+
+    /// Reply with a successful payload. Consumes the handle.
+    func reply(payload: Data, attachment: Data?) throws
+
+    /// Reply with an error message. Consumes the handle.
+    func replyError(message: String) throws
+}
+
 // MARK: - Zenoh Sample
 
 /// Data received by a Zenoh subscriber
@@ -109,4 +136,49 @@ public protocol ZenohClientProtocol: AnyObject {
 
     /// Declare a liveliness token for ROS 2 discovery
     func declareLivelinessToken(_ keyExpr: String) throws -> any ZenohLivelinessTokenHandle
+
+    /// Declare a queryable on the given key expression. The handler runs on a
+    /// zenoh-pico-owned thread; do not block. Each query handle is consumed by
+    /// the first `reply(...)` or `replyError(...)` call. If neither is invoked
+    /// before the queryable is closed, the bridge drops the query.
+    func declareQueryable(
+        _ keyExpr: String,
+        handler: @escaping @Sendable (any ZenohQueryHandle) -> Void
+    ) throws -> any ZenohQueryableHandle
+
+    /// Issue a query against the given key expression, awaiting replies via
+    /// `handler`. `onFinish` fires once after the final reply is delivered (or
+    /// the timeout elapses). All callbacks run on a zenoh-pico-owned thread.
+    func get(
+        keyExpr: String,
+        payload: Data?,
+        attachment: Data?,
+        timeoutMs: UInt32,
+        handler: @escaping @Sendable (Result<ZenohSample, ZenohError>) -> Void,
+        onFinish: @escaping @Sendable () -> Void
+    ) throws
+}
+
+extension ZenohClientProtocol {
+    /// Default stub — implementations that don't yet support queryables can
+    /// fall back to this until they wire in the C bridge.
+    public func declareQueryable(
+        _ keyExpr: String,
+        handler: @escaping @Sendable (any ZenohQueryHandle) -> Void
+    ) throws -> any ZenohQueryableHandle {
+        throw ZenohError.invalidParameter("declareQueryable not implemented")
+    }
+
+    /// Default stub — implementations that don't yet support get queries can
+    /// fall back to this until they wire in the C bridge.
+    public func get(
+        keyExpr: String,
+        payload: Data?,
+        attachment: Data?,
+        timeoutMs: UInt32,
+        handler: @escaping @Sendable (Result<ZenohSample, ZenohError>) -> Void,
+        onFinish: @escaping @Sendable () -> Void
+    ) throws {
+        throw ZenohError.invalidParameter("get not implemented")
+    }
 }

--- a/Sources/SwiftROS2Zenoh/ZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/ZenohClient.swift
@@ -161,6 +161,7 @@ public class ZenohClient: ZenohClientProtocol {
     private var declaredKeyExprs: [DeclaredKeyExpr] = []
     private var subscribers: [ZenohSubscriber] = []
     private var livelinessTokens: [LivelinessToken] = []
+    private var queryables: [ZenohQueryable] = []
     private let resourceLock = NSLock()
 
     // Internal access for nested types
@@ -219,13 +220,16 @@ public class ZenohClient: ZenohClientProtocol {
         // scope at the end of this method.
         let tokensToClose: [LivelinessToken]
         let subscribersToClose: [ZenohSubscriber]
+        let queryablesToClose: [ZenohQueryable]
         let keyExprsToRelease: [DeclaredKeyExpr]
         resourceLock.lock()
         tokensToClose = livelinessTokens
         subscribersToClose = subscribers
+        queryablesToClose = queryables
         keyExprsToRelease = declaredKeyExprs
         livelinessTokens.removeAll()
         subscribers.removeAll()
+        queryables.removeAll()
         declaredKeyExprs.removeAll()
         resourceLock.unlock()
 
@@ -237,6 +241,11 @@ public class ZenohClient: ZenohClientProtocol {
         // Clean up subscribers
         for subscriber in subscribersToClose {
             try? subscriber.close()
+        }
+
+        // Clean up queryables
+        for queryable in queryablesToClose {
+            try? queryable.close()
         }
 
         // keyExprsToRelease is intentionally kept alive until method exit.
@@ -806,7 +815,11 @@ extension ZenohClient {
             throw ZenohError.internalError("Failed to declare queryable: error code \(result)")
         }
 
-        return ZenohQueryable(handle: queryableHandle, session: self, contextBox: contextBox)
+        let queryable = ZenohQueryable(handle: queryableHandle, session: self, contextBox: contextBox)
+        resourceLock.lock()
+        queryables.append(queryable)
+        resourceLock.unlock()
+        return queryable
     }
 
     // MARK: - Get
@@ -851,6 +864,13 @@ extension ZenohClient {
             // closure, which includes the failure path of z_get. Releasing
             // here would double-free the box, so we leave it to the C drop
             // hook. Instead surface the error to Swift.
+            if result == ZENOH_ERROR_SESSION_CLOSED {
+                // Mirror put / putDeclared: clear the session pointer so
+                // higher layers see `sessionDisconnected` and can transition
+                // to the unhealthy / reconnect path.
+                session = nil
+                throw ZenohError.sessionDisconnected("Router connection lost")
+            }
             throw ZenohError.internalError("zenoh_get failed: error code \(result)")
         }
     }

--- a/Sources/SwiftROS2Zenoh/ZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/ZenohClient.swift
@@ -543,3 +543,329 @@ private func subscriberCallbackBridge(
 extension DeclaredKeyExpr: ZenohKeyExprHandle {}
 extension ZenohSubscriber: ZenohSubscriberHandle {}
 extension LivelinessToken: ZenohLivelinessTokenHandle {}
+
+// MARK: - Queryable / Query / Get (Services)
+
+/// Internal context for passing a Swift queryable handler to the C closure.
+private final class QueryableContext {
+    let handler: @Sendable (any ZenohQueryHandle) -> Void
+
+    init(handler: @escaping @Sendable (any ZenohQueryHandle) -> Void) {
+        self.handler = handler
+    }
+}
+
+/// Internal context for passing Swift get callbacks (per-reply + finish) to
+/// the C closure.
+private final class GetContext {
+    let handler: @Sendable (Result<ZenohSample, ZenohError>) -> Void
+    let onFinish: @Sendable () -> Void
+
+    init(
+        handler: @escaping @Sendable (Result<ZenohSample, ZenohError>) -> Void,
+        onFinish: @escaping @Sendable () -> Void
+    ) {
+        self.handler = handler
+        self.onFinish = onFinish
+    }
+}
+
+/// Concrete `ZenohQueryHandle` backed by a `zenoh_query_t*`. The bridge frees
+/// the underlying query exactly once: on the first successful reply / replyError
+/// call. After consumption, this wrapper marks itself as consumed so further
+/// reply attempts throw.
+final class QueryHandleImpl: ZenohQueryHandle, @unchecked Sendable {
+    let keyExpr: String
+    let payload: Data
+    let attachment: Data?
+
+    private let lock = NSLock()
+    private var queryHandle: OpaquePointer?
+
+    init(handle: OpaquePointer, keyExpr: String, payload: Data, attachment: Data?) {
+        self.queryHandle = handle
+        self.keyExpr = keyExpr
+        self.payload = payload
+        self.attachment = attachment
+    }
+
+    func reply(payload: Data, attachment: Data?) throws {
+        lock.lock()
+        guard let handle = queryHandle else {
+            lock.unlock()
+            throw ZenohError.invalidParameter("query already replied")
+        }
+        // Mark consumed up-front; the C call frees the handle whether it
+        // succeeds or fails.
+        queryHandle = nil
+        lock.unlock()
+
+        let result = payload.withUnsafeBytes { payloadPtr -> Int8 in
+            let payloadBase = payloadPtr.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            if let attachment = attachment {
+                return attachment.withUnsafeBytes { attPtr in
+                    zenoh_query_reply(
+                        handle,
+                        payloadBase,
+                        payload.count,
+                        attPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        attachment.count
+                    )
+                }
+            } else {
+                return zenoh_query_reply(handle, payloadBase, payload.count, nil, 0)
+            }
+        }
+
+        if result < 0 {
+            throw ZenohError.internalError("zenoh_query_reply failed: error code \(result)")
+        }
+    }
+
+    func replyError(message: String) throws {
+        lock.lock()
+        guard let handle = queryHandle else {
+            lock.unlock()
+            throw ZenohError.invalidParameter("query already replied")
+        }
+        queryHandle = nil
+        lock.unlock()
+
+        let result = message.withCString { ptr -> Int8 in
+            zenoh_query_reply_err(handle, ptr, strlen(ptr))
+        }
+
+        if result < 0 {
+            throw ZenohError.internalError("zenoh_query_reply_err failed: error code \(result)")
+        }
+    }
+}
+
+/// Represents a declared queryable handle. Mirrors `ZenohSubscriber`.
+public final class ZenohQueryable: ZenohQueryableHandle {
+    private var handle: OpaquePointer?
+    private weak var session: ZenohClient?
+    private var contextBox: Unmanaged<QueryableContext>?
+
+    fileprivate init(
+        handle: OpaquePointer,
+        session: ZenohClient,
+        contextBox: Unmanaged<QueryableContext>
+    ) {
+        self.handle = handle
+        self.session = session
+        self.contextBox = contextBox
+    }
+
+    public func close() throws {
+        guard let h = handle else {
+            throw ZenohError.internalError("Queryable already closed")
+        }
+
+        // Always release Swift-side resources, even if the C-side undeclare
+        // fails, so we don't leak the retained context box.
+        defer {
+            handle = nil
+            contextBox?.release()
+            contextBox = nil
+        }
+
+        guard let sess = session, let sessionHandle = sess.sessionHandle else {
+            throw ZenohError.internalError("Session is no longer valid")
+        }
+
+        var mutableHandle: OpaquePointer? = h
+        let result = zenoh_undeclare_queryable(sessionHandle, &mutableHandle)
+        if result < 0 {
+            throw ZenohError.internalError("Failed to undeclare queryable: error code \(result)")
+        }
+    }
+
+    deinit {
+        try? close()
+    }
+}
+
+/// C bridge for the queryable callback. Reconstructs Swift types and calls the
+/// user handler with a `QueryHandleImpl` wrapping the bridge-owned query.
+private func queryableCallbackBridge(
+    query: OpaquePointer?,
+    keyExpr: UnsafePointer<CChar>?,
+    payload: UnsafePointer<UInt8>?,
+    payloadLen: Int,
+    attachment: UnsafePointer<UInt8>?,
+    attachmentLen: Int,
+    context: UnsafeMutableRawPointer?
+) {
+    guard let query = query, let context = context else { return }
+
+    let contextBox = Unmanaged<QueryableContext>.fromOpaque(context)
+    let queryableContext = contextBox.takeUnretainedValue()
+
+    let keyExprString = keyExpr.flatMap { String(cString: $0) } ?? ""
+
+    let payloadData: Data
+    if let payload = payload, payloadLen > 0 {
+        payloadData = Data(bytes: payload, count: payloadLen)
+    } else {
+        payloadData = Data()
+    }
+
+    let attachmentData: Data?
+    if let attachment = attachment, attachmentLen > 0 {
+        attachmentData = Data(bytes: attachment, count: attachmentLen)
+    } else {
+        attachmentData = nil
+    }
+
+    let queryHandle = QueryHandleImpl(
+        handle: query,
+        keyExpr: keyExprString,
+        payload: payloadData,
+        attachment: attachmentData
+    )
+
+    queryableContext.handler(queryHandle)
+}
+
+/// C bridge for per-reply notifications from a get. Builds a `ZenohSample` (or
+/// a `ZenohError` for error replies) and dispatches to the Swift handler.
+private func getReplyBridge(
+    keyExpr: UnsafePointer<CChar>?,
+    payload: UnsafePointer<UInt8>?,
+    payloadLen: Int,
+    attachment: UnsafePointer<UInt8>?,
+    attachmentLen: Int,
+    isError: Bool,
+    context: UnsafeMutableRawPointer?
+) {
+    guard let context = context else { return }
+
+    let contextBox = Unmanaged<GetContext>.fromOpaque(context)
+    let getContext = contextBox.takeUnretainedValue()
+
+    let keyExprString = keyExpr.flatMap { String(cString: $0) } ?? ""
+
+    let payloadData: Data
+    if let payload = payload, payloadLen > 0 {
+        payloadData = Data(bytes: payload, count: payloadLen)
+    } else {
+        payloadData = Data()
+    }
+
+    let attachmentData: Data?
+    if let attachment = attachment, attachmentLen > 0 {
+        attachmentData = Data(bytes: attachment, count: attachmentLen)
+    } else {
+        attachmentData = nil
+    }
+
+    if isError {
+        let message = String(data: payloadData, encoding: .utf8) ?? "<non-UTF8 error payload>"
+        getContext.handler(.failure(.internalError("query reply error: \(message)")))
+    } else {
+        let sample = ZenohSample(keyExpr: keyExprString, payload: payloadData, attachment: attachmentData)
+        getContext.handler(.success(sample))
+    }
+}
+
+/// C bridge for the closure-drop signal. Fires exactly once per get when the
+/// reply closure is dropped (after the final reply or the timeout). Also
+/// frees the retained Swift context box.
+private func getFinishBridge(context: UnsafeMutableRawPointer?) {
+    guard let context = context else { return }
+
+    let contextBox = Unmanaged<GetContext>.fromOpaque(context)
+    let getContext = contextBox.takeUnretainedValue()
+    getContext.onFinish()
+    contextBox.release()
+}
+
+extension ZenohClient {
+    // MARK: - Queryable
+
+    /// Declares a queryable on the given key expression. Mirrors `subscribe`.
+    public func declareQueryable(
+        _ keyExpr: String,
+        handler: @escaping @Sendable (any ZenohQueryHandle) -> Void
+    ) throws -> any ZenohQueryableHandle {
+        guard let sess = sessionHandle else {
+            throw ZenohError.invalidParameter("Session not open")
+        }
+
+        let contextBox = Unmanaged.passRetained(QueryableContext(handler: handler))
+        let context = UnsafeMutableRawPointer(contextBox.toOpaque())
+
+        var queryablePtr: OpaquePointer?
+        let result = keyExpr.withCString { keyExprCStr in
+            zenoh_declare_queryable(sess, keyExprCStr, queryableCallbackBridge, context, &queryablePtr)
+        }
+
+        guard result >= 0, let queryableHandle = queryablePtr else {
+            contextBox.release()
+            throw ZenohError.internalError("Failed to declare queryable: error code \(result)")
+        }
+
+        return ZenohQueryable(handle: queryableHandle, session: self, contextBox: contextBox)
+    }
+
+    // MARK: - Get
+
+    /// Issues a query (Service Client side) against the given key expression.
+    public func get(
+        keyExpr: String,
+        payload: Data?,
+        attachment: Data?,
+        timeoutMs: UInt32,
+        handler: @escaping @Sendable (Result<ZenohSample, ZenohError>) -> Void,
+        onFinish: @escaping @Sendable () -> Void
+    ) throws {
+        guard let sess = sessionHandle else {
+            throw ZenohError.invalidParameter("Session not open")
+        }
+
+        let contextBox = Unmanaged.passRetained(GetContext(handler: handler, onFinish: onFinish))
+        let context = UnsafeMutableRawPointer(contextBox.toOpaque())
+
+        let result = keyExpr.withCString { keyExprCStr -> Int8 in
+            withOptionalUnsafeBytes(payload) { payloadPtr, payloadLen in
+                withOptionalUnsafeBytes(attachment) { attachmentPtr, attachmentLen in
+                    zenoh_get(
+                        sess,
+                        keyExprCStr,
+                        payloadPtr,
+                        payloadLen,
+                        attachmentPtr,
+                        attachmentLen,
+                        timeoutMs,
+                        getReplyBridge,
+                        getFinishBridge,
+                        context
+                    )
+                }
+            }
+        }
+
+        if result < 0 {
+            // The bridge calls the finish handler whenever zenoh-pico drops the
+            // closure, which includes the failure path of z_get. Releasing
+            // here would double-free the box, so we leave it to the C drop
+            // hook. Instead surface the error to Swift.
+            throw ZenohError.internalError("zenoh_get failed: error code \(result)")
+        }
+    }
+}
+
+/// Helper that runs `body` with `(ptr, count)` for an optional `Data`,
+/// or `(nil, 0)` if the data is nil/empty.
+private func withOptionalUnsafeBytes<R>(
+    _ data: Data?,
+    _ body: (UnsafePointer<UInt8>?, Int) -> R
+) -> R {
+    guard let data = data, !data.isEmpty else {
+        return body(nil, 0)
+    }
+    return data.withUnsafeBytes { raw in
+        body(raw.baseAddress?.assumingMemoryBound(to: UInt8.self), data.count)
+    }
+}

--- a/Tests/SwiftROS2ZenohTests/ZenohQueryableSmokeTests.swift
+++ b/Tests/SwiftROS2ZenohTests/ZenohQueryableSmokeTests.swift
@@ -9,9 +9,8 @@ import XCTest
 /// is unset.
 final class ZenohQueryableSmokeTests: XCTestCase {
     private var skipReason: String? {
-        ProcessInfo.processInfo.environment["LINUX_IP"] == nil
-            ? "LINUX_IP unset; skipping live zenoh router test"
-            : nil
+        let linuxIP = ProcessInfo.processInfo.environment["LINUX_IP"] ?? ""
+        return linuxIP.isEmpty ? "LINUX_IP unset or empty; skipping live zenoh router test" : nil
     }
 
     func testDeclareReplyUndeclare() async throws {

--- a/Tests/SwiftROS2ZenohTests/ZenohQueryableSmokeTests.swift
+++ b/Tests/SwiftROS2ZenohTests/ZenohQueryableSmokeTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+
+@testable import SwiftROS2Transport
+@testable import SwiftROS2Zenoh
+
+/// LAN-gated smoke test that exercises `declareQueryable` + `get` against a
+/// live `rmw_zenohd` router on `tcp/<LINUX_IP>:7447`. Skipped when `LINUX_IP`
+/// is unset.
+final class ZenohQueryableSmokeTests: XCTestCase {
+    private var skipReason: String? {
+        ProcessInfo.processInfo.environment["LINUX_IP"] == nil
+            ? "LINUX_IP unset; skipping live zenoh router test"
+            : nil
+    }
+
+    func testDeclareReplyUndeclare() async throws {
+        try XCTSkipIf(skipReason != nil, skipReason ?? "")
+        let linuxIP = ProcessInfo.processInfo.environment["LINUX_IP"] ?? ""
+
+        let z = ZenohClient()
+        try z.open(locator: "tcp/\(linuxIP):7447")
+        defer { try? z.close() }
+
+        let queryable = try z.declareQueryable("swift_srv_smoke/echo") { query in
+            try? query.reply(payload: Data([0x01, 0x02]), attachment: nil)
+        }
+
+        let exp = expectation(description: "reply")
+        try z.get(
+            keyExpr: "swift_srv_smoke/echo",
+            payload: nil,
+            attachment: nil,
+            timeoutMs: 1_000,
+            handler: { result in
+                if case .success(let sample) = result, sample.payload == Data([0x01, 0x02]) {
+                    exp.fulfill()
+                }
+            },
+            onFinish: {}
+        )
+        await fulfillment(of: [exp], timeout: 2)
+        try queryable.close()
+    }
+}


### PR DESCRIPTION
## Summary

C-bridge and Swift-side plumbing for Zenoh service primitives.

- `CZenohBridge`: `zenoh_declare_queryable` / `zenoh_undeclare_queryable` / `zenoh_query_reply` / `zenoh_query_reply_err` / `zenoh_get` on top of zenoh-pico 1.x (`z_declare_queryable`, `z_get`, `z_query_reply*`).
- The queryable bridge clones the loaned query via `z_query_clone` so it survives the closure-callback boundary; `zenoh_query_reply` / `_err` consume the cloned query unconditionally on both success and error paths.
- The get bridge uses `z_closure(call=reply, drop=finish, ctx=heap-state)` so zenoh-pico owns the heap state across the call/drop pair — the drop hook fires once on completion or timeout and frees the box.
- `ZenohClientProtocol`: `ZenohQueryableHandle` / `ZenohQueryHandle` protocols + `declareQueryable` / `get` methods, with default-extension throwing stubs so existing conformers (e.g. `MockZenohClient`) compile unchanged.
- `ZenohClient` (SwiftROS2Zenoh) overrides both with real impls. `QueryHandleImpl` is a one-shot consume guarded by `NSLock` so a second reply/replyError throws `invalidParameter("query already replied")` and never double-frees.
- LINUX_IP-gated smoke test: declare → reply → get → undeclare round trip against a live `rmw_zenohd`.

Service transport layer + public umbrella API land in phase 6 (next PR in the stack).

**Stack (PR #67 → #68 → this → next):**
- #67 (phase 3) — protocols + stubs
- #68 (phase 4) — DDS server/client
- **this (phase 5) — Zenoh C bridge**
- next (phase 6) — Zenoh transport + umbrella API + integration tests

## Test plan

- [x] swift build (clean on Apple)
- [x] swift test --parallel (233 tests, 4 LINUX_IP-gated skips, 0 failures)
- [x] swift format lint --strict (clean)
- [ ] LINUX_IP=… smoke test against a local `rmw_zenohd` (deferred — exercised in phase 6 integration)