### PR TITLE
feat(api): ROS 2 Services umbrella API + Zenoh transport (phase 6 of 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.7.0] - 2026-05-01
 
 ### Added
+- **Services** — typed `ROS2Service<S>` / `ROS2Client<S>` on top of new `TransportService` / `TransportClient` protocols, with end-to-end Server / Client support over both Zenoh (queryable + `get`) and DDS (rq/rr topics + sample-identity prefix). `ROS2Node.createService(_:name:qos:handler:)` / `createClient(_:name:qos:)` are the public entry points; built-in `std_srvs/srv/Trigger` ships with the package.
+- `ServiceError` — public enum covering `.timeout`, `.serviceUnavailable`, `.handlerFailed`, `.requestEncodingFailed`, `.responseDecodingFailed`, `.clientClosed`, `.serverClosed`, `.taskCancelled`, and `.transportError`. Maps lower-level `TransportError` variants automatically.
+- `srv-server` / `srv-client` example executables (`swift run srv-server zenoh`, `swift run srv-client dds`, etc.) over `std_srvs/srv/Trigger`.
+- Service round-trip integration tests for both Zenoh and DDS (LINUX_IP-gated, plus a same-process DDS loopback that runs unconditionally).
+- `ZenohClientProtocol.declareQueryable` / `get` (with `ZenohQueryableHandle` / `ZenohQueryHandle`) and matching DDS rq/rr primitives on `DDSClientProtocol`. `ZenohError.queryReplyError(String)` carries remote-handler errors through to `ServiceError.handlerFailed`.
+- `TransportError.requestTimeout(Duration)` / `.requestCancelled` / `.serviceHandlerFailed(String)` and `RMWRequestId` / `SampleIdentityPrefix` for service request / reply correlation on DDS.
 - DocC catalog under the `SwiftROS2` umbrella with getting-started articles (Zenoh, DDS) and a wire-format reference.
 - `CHANGELOG.md` and `MIGRATION.md` (the latter with the 0.7 → 1.0 candidate change list).
 - `Scripts/check-docc-coverage.sh` enforcing `///` comments on every public declaration.
@@ -21,10 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `swift package diagnose-api-breaking-changes 0.6.1` enforced on every PR.
 
 ### Changed
-- `ZenohTransportSession` and `DDSTransportSession` split into focused files.
-
-### Notes
-- No public API changes. The 0.7.0 line preserves the 0.6.x surface.
+- `ZenohTransportSession` and `DDSTransportSession` split into focused files. Both now walk `serviceServers` / `serviceClients` alongside publishers in `close()`.
+- `ROS2Node.destroy()` now walks publishers, subscriptions, services, and clients in one teardown pass.
 
 ## [0.6.1] - 2026-04-28
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,7 +4,8 @@
 
 | From | To | Breaking changes |
 |---|---|---|
-| 0.6.x | 0.7.x | **None.** The 0.7.x line preserves the 0.6.x public API. |
+| 0.6.0 | 0.6.1 | **One:** the placeholder `ROS2Service` protocol in `SwiftROS2Messages` was renamed to `ROS2ServiceType` so the umbrella's typed Service Server class can take the simpler `ROS2Service<S>` name in 0.7.0. |
+| 0.6.x | 0.7.x | **One** if upgrading from 0.6.0 directly: the rename above. From 0.6.1 → 0.7.x there are no breaking changes — the Services API is purely additive. |
 | 0.7.x | 1.0.0 | Limited to the candidates below, decided after 0.7.0 ships based on a downstream survey. |
 | 1.0.x | 1.x   | **None guaranteed.** Minor releases on the 1.x line will not break public API. |
 
@@ -12,15 +13,32 @@ SwiftROS2 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) onc
 
 ---
 
-## 0.x → 0.7 — no breaking changes
+## 0.6.0 → 0.6.1 / 0.7.0 — `ROS2Service` placeholder rename
+
+The 0.6.0 line shipped a placeholder protocol named `ROS2Service` in `SwiftROS2Messages` (with no implementation). To make room for the typed Service Server class `ROS2Service<S>` in `SwiftROS2`, that placeholder was renamed to `ROS2ServiceType` in 0.6.1.
+
+If your code conformed to the old name:
+
+```swift
+// before (0.6.0)
+public enum MySrv: ROS2Service { ... }
+
+// after (0.6.1+)
+public enum MySrv: ROS2ServiceType { ... }
+```
+
+The shape of the protocol is unchanged — same `Request` / `Response` associated types, same `static var typeInfo: ROS2ServiceTypeInfo` requirement. The only thing that moved is the name. Conduit's `BuiltinServices/StdSrvs/Trigger.swift` was already on the new name; downstreams that referenced the placeholder need this one-line rename.
+
+## 0.x → 0.7 — no breaking changes (other than the rename above)
 
 0.7.x adds:
+- **Services** (typed `ROS2Service<S>` / `ROS2Client<S>` over both Zenoh and DDS), `ServiceError`, `ROS2Node.createService` / `createClient`. New, additive — no existing API renamed or removed.
 - DocC catalog and richer `///` comments.
 - Per-target line-coverage gate in CI.
 - `swift package diagnose-api-breaking-changes` on every PR.
-- Internal refactors of the transport sessions.
+- Internal refactors of the transport sessions (now also walk service servers / clients in `close()`).
 
-No public type, function, protocol, or property is renamed, removed, or made `internal`.
+No public type, function, protocol, or property already shipping in 0.6.1 is renamed, removed, or made `internal` in 0.7.x.
 
 ---
 
@@ -93,15 +111,17 @@ No public type, function, protocol, or property is renamed, removed, or made `in
 - **Recommended action:** drop direct references.
 - **Compatibility shim?** None planned.
 
-### Candidate 7 — Service / Action public declarations with no implementation
+### Candidate 7 — Action public declarations with no implementation
 
-- **Targets:** `ROS2ServiceTypeInfo`, `ROS2ActionTypeInfo`, `ROS2Service`, `ROS2Action` in `SwiftROS2Messages`.
+- **Targets:** `ROS2ActionTypeInfo`, `ROS2Action` in `SwiftROS2Messages`.
 - **1.0 plan:** remove (or make `internal`).
-- **Rationale:** placeholders with no implementation. Freezing them would constrain the eventual Service / Action API design.
+- **Rationale:** placeholders with no implementation. Freezing them would constrain the eventual Action API design.
 - **Replacement:** none (the feature is not provided today).
 - **Impact surface:** code that names these types or conforms to them.
 - **Recommended action:** remove any references — they do not do anything yet.
 - **Compatibility shim?** None.
+
+> **Note:** the analogous Service placeholders (`ROS2ServiceTypeInfo`, `ROS2ServiceType`) were retained in 0.7.0 once the typed `ROS2Service<S>` / `ROS2Client<S>` umbrella landed — they are now real, implemented protocols, not placeholders.
 
 ---
 

--- a/Package.swift
+++ b/Package.swift
@@ -296,6 +296,16 @@ if !isWindowsBuild && !isAndroidBuild {
             dependencies: ["SwiftROS2"],
             path: "Sources/Examples/Listener"
         ),
+        .executableTarget(
+            name: "srv-server",
+            dependencies: ["SwiftROS2"],
+            path: "Sources/Examples/SrvServer"
+        ),
+        .executableTarget(
+            name: "srv-client",
+            dependencies: ["SwiftROS2"],
+            path: "Sources/Examples/SrvClient"
+        ),
 
         .testTarget(
             name: "SwiftROS2Tests",

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Bringing ROS 2 to a phone, headset, or laptop usually means cross-compiling `rcl
 - **Source build everywhere else.** Linux, Windows, and Android compile `zenoh-pico` from `vendor/` via SwiftPM directly, each picking the matching backend (`unix` / `windows`). CycloneDDS comes from `pkg-config` on Linux. No vendored prebuilts needed.
 - **Multi-distro wire format.** Humble, Jazzy, Kilted, Rolling. Select via `ROS2Distro` on `ROS2Context`; Zenoh defaults to Jazzy when unspecified. Schema differences (e.g. `sensor_msgs/Range` gaining `variance` after Humble) are gated automatically through `isLegacySchema`.
 - **23 built-in message types** spanning `sensor_msgs`, `geometry_msgs`, `std_msgs`, `audio_common_msgs`, and `tf2_msgs`. Pure-Swift XCDR v1 encoder + decoder cover both the publish and subscribe paths.
+- **Services** (Server / Client) — `rclcpp` / `rclpy`-shaped API with full Humble / Jazzy / Kilted / Rolling reach over Zenoh and DDS.
 - **Production-proven.** Extracted from [Conduit, powered by ROS](https://apps.apple.com/app/id6757171237) — used cumulatively by **10,000+ ROS developers worldwide** and a former **#4 in the App Store's Developer Tools category**. Conduit streams 12 sensor topics from iOS / iPadOS / macOS / visionOS at up to 100 Hz over the same swift-ros2 publish path documented below.
 
 ## Platforms
@@ -188,6 +189,25 @@ for await msg in sub.messages {
     print("accel: \(msg.linearAcceleration)")
 }
 ```
+
+### Services (Server / Client)
+
+`ROS2Service<S>` and `ROS2Client<S>` round-trip a typed request / response over either transport — the same code path works against `rmw_zenoh_cpp` (Zenoh queryables) and `rmw_cyclonedds_cpp` (DDS rq/rr topics). Built-in `std_srvs/srv/Trigger` is the smallest demo:
+
+```swift
+// Server — replies "ok" to every Trigger request.
+let svc = try await node.createService(TriggerSrv.self, name: "/trigger") { _ in
+    TriggerSrv.Response(success: true, message: "ok")
+}
+
+// Client — calls the service and prints the result.
+let cli = try await node.createClient(TriggerSrv.self, name: "/trigger")
+try await cli.waitForService(timeout: .seconds(5))
+let resp = try await cli.call(.init(), timeout: .seconds(5))
+print(resp.success, resp.message)
+```
+
+Failures (timeout, remote handler error, encoding / decoding) surface as `ServiceError` — pattern-match on `.timeout(_)`, `.handlerFailed(_)`, `.serviceUnavailable(_)`, `.taskCancelled`, etc.
 
 ### Runnable examples
 

--- a/Scripts/api-breakage-allowlist.txt
+++ b/Scripts/api-breakage-allowlist.txt
@@ -10,3 +10,5 @@ API breakage: func TransportSession.createServiceServer(name:serviceTypeName:req
 API breakage: func TransportSession.createServiceClient(name:serviceTypeName:requestTypeHash:responseTypeHash:qos:) has been added as a protocol requirement
 API breakage: enumelement TransportError.requestTimeout has been added as a new enum case
 API breakage: enumelement TransportError.requestCancelled has been added as a new enum case
+API breakage: enumelement TransportError.serviceHandlerFailed has been added as a new enum case
+API breakage: enumelement ZenohError.queryReplyError has been added as a new enum case

--- a/Sources/Examples/SrvClient/main.swift
+++ b/Sources/Examples/SrvClient/main.swift
@@ -1,0 +1,50 @@
+// Minimal std_srvs/srv/Trigger service client — mirrors demo_nodes_cpp/add_two_ints_client.cpp.
+// Calls /trigger once and prints the response.
+//
+// Usage:
+//   swift run srv-client zenoh [tcp/<host>:7447] [domain_id]
+//   swift run srv-client dds   [domain_id]
+
+import Foundation
+import SwiftROS2
+
+let args = Array(CommandLine.arguments.dropFirst())
+let transportName = args.first ?? "zenoh"
+
+let transport: TransportConfig
+switch transportName {
+case "zenoh":
+    let locator = args.dropFirst().first ?? "tcp/127.0.0.1:7447"
+    let domainId = args.dropFirst(2).first.flatMap(Int.init) ?? 0
+    transport = .zenoh(locator: locator, domainId: domainId)
+case "dds":
+    let domainId = args.dropFirst().first.flatMap(Int.init) ?? 0
+    transport = .ddsMulticast(domainId: domainId)
+default:
+    FileHandle.standardError.write(Data("Unknown transport '\(transportName)'. Use 'zenoh' or 'dds'.\n".utf8))
+    exit(2)
+}
+
+let ctx = try await ROS2Context(transport: transport, distro: .jazzy)
+let node = try await ctx.createNode(name: "srv_client")
+let cli = try await node.createClient(TriggerSrv.self, name: "/trigger")
+
+print("Waiting for /trigger...")
+do {
+    try await cli.waitForService(timeout: .seconds(5))
+} catch {
+    FileHandle.standardError.write(Data("Service did not appear: \(error)\n".utf8))
+    await ctx.shutdown()
+    exit(1)
+}
+
+do {
+    let response = try await cli.call(.init(), timeout: .seconds(5))
+    print("Response: success=\(response.success), message='\(response.message)'")
+} catch {
+    FileHandle.standardError.write(Data("Service call failed: \(error)\n".utf8))
+    await ctx.shutdown()
+    exit(1)
+}
+
+await ctx.shutdown()

--- a/Sources/Examples/SrvServer/main.swift
+++ b/Sources/Examples/SrvServer/main.swift
@@ -1,0 +1,43 @@
+// Minimal std_srvs/srv/Trigger service server — mirrors demo_nodes_cpp/add_two_ints_server.cpp.
+// Replies "ok" to every Trigger request on /trigger.
+//
+// Usage:
+//   swift run srv-server zenoh [tcp/<host>:7447] [domain_id]
+//   swift run srv-server dds   [domain_id]
+
+import Foundation
+import SwiftROS2
+
+let args = Array(CommandLine.arguments.dropFirst())
+let transportName = args.first ?? "zenoh"
+
+let transport: TransportConfig
+switch transportName {
+case "zenoh":
+    let locator = args.dropFirst().first ?? "tcp/127.0.0.1:7447"
+    let domainId = args.dropFirst(2).first.flatMap(Int.init) ?? 0
+    transport = .zenoh(locator: locator, domainId: domainId)
+case "dds":
+    let domainId = args.dropFirst().first.flatMap(Int.init) ?? 0
+    transport = .ddsMulticast(domainId: domainId)
+default:
+    FileHandle.standardError.write(Data("Unknown transport '\(transportName)'. Use 'zenoh' or 'dds'.\n".utf8))
+    exit(2)
+}
+
+let ctx = try await ROS2Context(transport: transport, distro: .jazzy)
+let node = try await ctx.createNode(name: "srv_server")
+
+let svc = try await node.createService(TriggerSrv.self, name: "/trigger") { _ in
+    print("Received Trigger request")
+    return TriggerSrv.Response(success: true, message: "ok")
+}
+
+print("Service /trigger ready (\(svc.name))")
+
+// Keep the process alive until interrupted.
+while !Task.isCancelled {
+    try await Task.sleep(nanoseconds: 1_000_000_000)
+}
+
+await ctx.shutdown()

--- a/Sources/SwiftROS2/Client.swift
+++ b/Sources/SwiftROS2/Client.swift
@@ -1,0 +1,107 @@
+// Client.swift
+// ROS 2 Service Client (typed wrapper around TransportClient)
+
+import Foundation
+import SwiftROS2CDR
+import SwiftROS2Messages
+import SwiftROS2Transport
+
+/// ROS 2 service client for a specific ``ROS2ServiceType``.
+///
+/// Construct one via ``ROS2Node/createClient(_:name:qos:)``. Encodes the
+/// typed request into CDR, calls the underlying transport, and decodes the
+/// CDR response back into `S.Response`.
+///
+/// ```swift
+/// let cli = try await node.createClient(TriggerSrv.self, name: "/trigger")
+/// try await cli.waitForService(timeout: .seconds(2))
+/// let resp = try await cli.call(.init(), timeout: .seconds(5))
+/// ```
+public final class ROS2Client<S: ROS2ServiceType>: @unchecked Sendable, ClientCloseable {
+    private let transport: any TransportClient
+    private let isLegacySchema: Bool
+    private let lock = NSLock()
+    private var closed = false
+
+    /// The service name supplied at construction.
+    public var name: String { transport.name }
+
+    /// Whether the client is still active.
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed && transport.isActive
+    }
+
+    init(transport: any TransportClient, isLegacySchema: Bool) {
+        self.transport = transport
+        self.isLegacySchema = isLegacySchema
+    }
+
+    /// Wait until a matching service is reachable, or throw if `timeout` elapses.
+    public func waitForService(timeout: Duration) async throws {
+        do {
+            try await transport.waitForService(timeout: timeout)
+        } catch {
+            throw ServiceError.mapping(error)
+        }
+    }
+
+    /// Send `request` and await the typed response.
+    public func call(_ request: S.Request, timeout: Duration) async throws -> S.Response {
+        lock.lock()
+        if closed {
+            lock.unlock()
+            throw ServiceError.clientClosed
+        }
+        lock.unlock()
+
+        // Encode the typed request into CDR.
+        let requestCDR: Data
+        do {
+            let encoder = CDREncoder(isLegacySchema: isLegacySchema)
+            try request.encode(to: encoder)
+            requestCDR = encoder.getData()
+        } catch {
+            throw ServiceError.requestEncodingFailed(error.localizedDescription)
+        }
+
+        // Send and await reply.
+        let responseCDR: Data
+        do {
+            responseCDR = try await transport.call(requestCDR: requestCDR, timeout: timeout)
+        } catch {
+            throw ServiceError.mapping(error)
+        }
+
+        // Decode.
+        do {
+            let decoder = try CDRDecoder(data: responseCDR, isLegacySchema: isLegacySchema)
+            return try S.Response(from: decoder)
+        } catch {
+            throw ServiceError.responseDecodingFailed(error.localizedDescription)
+        }
+    }
+
+    /// Cancel the client, closing the underlying transport handle.
+    public func cancel() {
+        try? closeClient()
+    }
+
+    func closeClient() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        lock.unlock()
+        try? transport.close()
+    }
+}
+
+// Internal protocol for type-erased cleanup, mirroring PublisherCloseable /
+// SubscriptionCloseable.
+protocol ClientCloseable {
+    func closeClient() throws
+}

--- a/Sources/SwiftROS2/Node.swift
+++ b/Sources/SwiftROS2/Node.swift
@@ -27,6 +27,8 @@ public final class ROS2Node: @unchecked Sendable {
 
     private var publishers: [AnyObject] = []
     private var subscriptions: [AnyObject] = []
+    private var services: [AnyObject] = []
+    private var clients: [AnyObject] = []
     private let lock = NSLock()
 
     init(
@@ -113,11 +115,101 @@ public final class ROS2Node: @unchecked Sendable {
         return subscription
     }
 
+    // MARK: - Service
+
+    /// Create a service server for a specific ``ROS2ServiceType``.
+    ///
+    /// The handler closure receives a typed request and returns a typed
+    /// response. Throwing from the handler surfaces to the caller as a
+    /// ``ServiceError/handlerFailed(_:)`` (Zenoh) or as a dropped reply
+    /// (DDS) — see the swift-ros2 docs for the per-transport contract.
+    public func createService<S: ROS2ServiceType>(
+        _ serviceType: S.Type,
+        name: String,
+        qos: QoSProfile = .servicesDefault,
+        handler: @escaping @Sendable (S.Request) async throws -> S.Response
+    ) async throws -> ROS2Service<S> {
+        let fullName = buildFullTopic(name)
+        let typeInfo = S.typeInfo
+        let transportQoS = qos.toTransportQoS()
+        let supportsHash = context.distro.supportsTypeHash
+        let isLegacy = context.distro.isLegacySchema
+        let requestHash = supportsHash ? typeInfo.requestTypeHash : nil
+        let responseHash = supportsHash ? typeInfo.responseTypeHash : nil
+
+        // Wrap the typed user handler in a CDR-bytes handler the transport
+        // can call without knowing about S.Request / S.Response.
+        let cdrHandler: @Sendable (Data) async throws -> Data = { reqData in
+            let decoder: CDRDecoder
+            do {
+                decoder = try CDRDecoder(data: reqData, isLegacySchema: isLegacy)
+            } catch {
+                throw ServiceError.requestEncodingFailed(error.localizedDescription)
+            }
+            let typedRequest: S.Request
+            do {
+                typedRequest = try S.Request(from: decoder)
+            } catch {
+                throw ServiceError.requestEncodingFailed(error.localizedDescription)
+            }
+            let typedResponse = try await handler(typedRequest)
+            let encoder = CDREncoder(isLegacySchema: isLegacy)
+            do {
+                try typedResponse.encode(to: encoder)
+            } catch {
+                throw ServiceError.responseDecodingFailed(error.localizedDescription)
+            }
+            return encoder.getData()
+        }
+
+        let transportSvc = try session.createServiceServer(
+            name: fullName,
+            serviceTypeName: typeInfo.serviceName,
+            requestTypeHash: requestHash,
+            responseTypeHash: responseHash,
+            qos: transportQoS,
+            handler: cdrHandler
+        )
+
+        let service = ROS2Service<S>(transport: transportSvc)
+        appendService(service)
+        return service
+    }
+
+    /// Create a service client for a specific ``ROS2ServiceType``.
+    public func createClient<S: ROS2ServiceType>(
+        _ serviceType: S.Type,
+        name: String,
+        qos: QoSProfile = .servicesDefault
+    ) async throws -> ROS2Client<S> {
+        let fullName = buildFullTopic(name)
+        let typeInfo = S.typeInfo
+        let transportQoS = qos.toTransportQoS()
+        let supportsHash = context.distro.supportsTypeHash
+        let requestHash = supportsHash ? typeInfo.requestTypeHash : nil
+        let responseHash = supportsHash ? typeInfo.responseTypeHash : nil
+
+        let transportClient = try session.createServiceClient(
+            name: fullName,
+            serviceTypeName: typeInfo.serviceName,
+            requestTypeHash: requestHash,
+            responseTypeHash: responseHash,
+            qos: transportQoS
+        )
+
+        let client = ROS2Client<S>(
+            transport: transportClient,
+            isLegacySchema: context.distro.isLegacySchema
+        )
+        appendClient(client)
+        return client
+    }
+
     // MARK: - Lifecycle
 
     /// Destroy this node and release all resources
     public func destroy() async {
-        let (pubs, subs) = takeAllEntities()
+        let (pubs, subs, svcs, clis) = takeAllEntities()
         for pub in pubs {
             if let p = pub as? PublisherCloseable {
                 try? p.closePublisher()
@@ -126,6 +218,16 @@ public final class ROS2Node: @unchecked Sendable {
         for sub in subs {
             if let s = sub as? SubscriptionCloseable {
                 try? s.closeSubscription()
+            }
+        }
+        for svc in svcs {
+            if let s = svc as? ServiceCloseable {
+                try? s.closeService()
+            }
+        }
+        for cli in clis {
+            if let c = cli as? ClientCloseable {
+                try? c.closeClient()
             }
         }
     }
@@ -144,14 +246,30 @@ public final class ROS2Node: @unchecked Sendable {
         lock.unlock()
     }
 
-    private func takeAllEntities() -> ([AnyObject], [AnyObject]) {
+    private func appendService(_ service: AnyObject) {
+        lock.lock()
+        services.append(service)
+        lock.unlock()
+    }
+
+    private func appendClient(_ client: AnyObject) {
+        lock.lock()
+        clients.append(client)
+        lock.unlock()
+    }
+
+    private func takeAllEntities() -> ([AnyObject], [AnyObject], [AnyObject], [AnyObject]) {
         lock.lock()
         let pubs = publishers
         let subs = subscriptions
+        let svcs = services
+        let clis = clients
         publishers.removeAll()
         subscriptions.removeAll()
+        services.removeAll()
+        clients.removeAll()
         lock.unlock()
-        return (pubs, subs)
+        return (pubs, subs, svcs, clis)
     }
 
     // MARK: - Helpers

--- a/Sources/SwiftROS2/Node.swift
+++ b/Sources/SwiftROS2/Node.swift
@@ -144,20 +144,20 @@ public final class ROS2Node: @unchecked Sendable {
             do {
                 decoder = try CDRDecoder(data: reqData, isLegacySchema: isLegacy)
             } catch {
-                throw ServiceError.requestEncodingFailed(error.localizedDescription)
+                throw ServiceError.requestDecodingFailed(error.localizedDescription)
             }
             let typedRequest: S.Request
             do {
                 typedRequest = try S.Request(from: decoder)
             } catch {
-                throw ServiceError.requestEncodingFailed(error.localizedDescription)
+                throw ServiceError.requestDecodingFailed(error.localizedDescription)
             }
             let typedResponse = try await handler(typedRequest)
             let encoder = CDREncoder(isLegacySchema: isLegacy)
             do {
                 try typedResponse.encode(to: encoder)
             } catch {
-                throw ServiceError.responseDecodingFailed(error.localizedDescription)
+                throw ServiceError.responseEncodingFailed(error.localizedDescription)
             }
             return encoder.getData()
         }

--- a/Sources/SwiftROS2/Service.swift
+++ b/Sources/SwiftROS2/Service.swift
@@ -1,0 +1,58 @@
+// Service.swift
+// ROS 2 Service Server (typed wrapper around TransportService)
+
+import Foundation
+import SwiftROS2Messages
+import SwiftROS2Transport
+
+/// ROS 2 service server for a specific ``ROS2ServiceType``.
+///
+/// Construct one via ``ROS2Node/createService(_:name:qos:handler:)``. The
+/// node retains the server and walks `cancel()` / close on `node.destroy()`.
+///
+/// ```swift
+/// let svc = try await node.createService(TriggerSrv.self, name: "/trigger") { _ in
+///     TriggerSrv.Response(success: true, message: "ok")
+/// }
+/// ```
+public final class ROS2Service<S: ROS2ServiceType>: @unchecked Sendable, ServiceCloseable {
+    private let transport: any TransportService
+    private let lock = NSLock()
+    private var closed = false
+
+    /// The service name supplied at construction (e.g. `/trigger`).
+    public var name: String { transport.name }
+
+    /// Whether the service is still active.
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed && transport.isActive
+    }
+
+    init(transport: any TransportService) {
+        self.transport = transport
+    }
+
+    /// Cancel the service, closing the underlying transport handle.
+    public func cancel() {
+        try? closeService()
+    }
+
+    func closeService() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        lock.unlock()
+        try? transport.close()
+    }
+}
+
+// Internal protocol for type-erased cleanup, mirroring PublisherCloseable /
+// SubscriptionCloseable.
+protocol ServiceCloseable {
+    func closeService() throws
+}

--- a/Sources/SwiftROS2/ServiceError.swift
+++ b/Sources/SwiftROS2/ServiceError.swift
@@ -1,0 +1,71 @@
+// ServiceError.swift
+// Public error type for the service-call surface.
+
+import Foundation
+import SwiftROS2Transport
+
+/// Errors thrown by ``ROS2Service`` and ``ROS2Client``.
+///
+/// The umbrella maps lower-level ``TransportError`` cases (`requestTimeout`,
+/// `requestCancelled`, `serviceHandlerFailed`, …) into the service-shaped
+/// variants below so callers can pattern-match on a single, ROS-friendly
+/// type.
+public enum ServiceError: Error, LocalizedError, Sendable {
+    /// The call did not complete within the supplied deadline.
+    case timeout(Duration)
+    /// The service was not reachable (no server matched, or transport rejected the call).
+    case serviceUnavailable(String)
+    /// The remote service handler threw — typically a `ServiceError.handlerFailed`
+    /// raised by the user closure on the server side.
+    case handlerFailed(String)
+    /// Encoding the typed request to CDR failed.
+    case requestEncodingFailed(String)
+    /// Decoding the CDR response into the typed `Response` failed.
+    case responseDecodingFailed(String)
+    /// The client was closed before / during the call.
+    case clientClosed
+    /// The server was closed before / during the call.
+    case serverClosed
+    /// The structured-concurrency Task was cancelled.
+    case taskCancelled
+    /// Any other transport-level error not covered by the cases above.
+    case transportError(TransportError)
+
+    public var errorDescription: String? {
+        switch self {
+        case .timeout(let d): return "Service call timed out after \(d)"
+        case .serviceUnavailable(let n): return "Service unavailable: \(n)"
+        case .handlerFailed(let m): return "Service handler failed: \(m)"
+        case .requestEncodingFailed(let m): return "Request encoding failed: \(m)"
+        case .responseDecodingFailed(let m): return "Response decoding failed: \(m)"
+        case .clientClosed: return "Service client is closed"
+        case .serverClosed: return "Service server is closed"
+        case .taskCancelled: return "Service call was cancelled"
+        case .transportError(let e): return e.errorDescription
+        }
+    }
+}
+
+extension ServiceError {
+    /// Map a `TransportError` thrown by the underlying transport into the
+    /// closest matching `ServiceError` case.
+    static func mapping(_ error: Error) -> ServiceError {
+        if let svc = error as? ServiceError {
+            return svc
+        }
+        guard let transport = error as? TransportError else {
+            return .transportError(
+                .invalidConfiguration(error.localizedDescription))
+        }
+        switch transport {
+        case .requestTimeout(let d): return .timeout(d)
+        case .requestCancelled: return .taskCancelled
+        case .serviceHandlerFailed(let m): return .handlerFailed(m)
+        case .connectionTimeout(let t):
+            return .serviceUnavailable("connection timed out after \(Int(t))s")
+        case .notConnected: return .serviceUnavailable("not connected")
+        case .sessionClosed: return .clientClosed
+        default: return .transportError(transport)
+        }
+    }
+}

--- a/Sources/SwiftROS2/ServiceError.swift
+++ b/Sources/SwiftROS2/ServiceError.swift
@@ -18,10 +18,14 @@ public enum ServiceError: Error, LocalizedError, Sendable {
     /// The remote service handler threw — typically a `ServiceError.handlerFailed`
     /// raised by the user closure on the server side.
     case handlerFailed(String)
-    /// Encoding the typed request to CDR failed.
+    /// Encoding the typed request to CDR failed (client side).
     case requestEncodingFailed(String)
-    /// Decoding the CDR response into the typed `Response` failed.
+    /// Decoding the CDR request bytes into the typed `Request` failed (server side).
+    case requestDecodingFailed(String)
+    /// Decoding the CDR response into the typed `Response` failed (client side).
     case responseDecodingFailed(String)
+    /// Encoding the typed response to CDR failed (server side).
+    case responseEncodingFailed(String)
     /// The client was closed before / during the call.
     case clientClosed
     /// The server was closed before / during the call.
@@ -30,6 +34,11 @@ public enum ServiceError: Error, LocalizedError, Sendable {
     case taskCancelled
     /// Any other transport-level error not covered by the cases above.
     case transportError(TransportError)
+    /// An unexpected error that is not a `TransportError` (e.g. a
+    /// `ZenohError` that escaped from the C bridge, or a `DDSError` from
+    /// CycloneDDS startup). The wrapped value preserves the original error
+    /// so callers can pattern-match or log it without losing fidelity.
+    case underlying(Error)
 
     public var errorDescription: String? {
         switch self {
@@ -37,25 +46,33 @@ public enum ServiceError: Error, LocalizedError, Sendable {
         case .serviceUnavailable(let n): return "Service unavailable: \(n)"
         case .handlerFailed(let m): return "Service handler failed: \(m)"
         case .requestEncodingFailed(let m): return "Request encoding failed: \(m)"
+        case .requestDecodingFailed(let m): return "Request decoding failed: \(m)"
         case .responseDecodingFailed(let m): return "Response decoding failed: \(m)"
+        case .responseEncodingFailed(let m): return "Response encoding failed: \(m)"
         case .clientClosed: return "Service client is closed"
         case .serverClosed: return "Service server is closed"
         case .taskCancelled: return "Service call was cancelled"
         case .transportError(let e): return e.errorDescription
+        case .underlying(let e):
+            if let l = e as? LocalizedError, let d = l.errorDescription {
+                return d
+            }
+            return String(describing: e)
         }
     }
 }
 
 extension ServiceError {
-    /// Map a `TransportError` thrown by the underlying transport into the
-    /// closest matching `ServiceError` case.
+    /// Map an error thrown by the underlying transport into the closest
+    /// matching `ServiceError` case. Non-`TransportError` errors are wrapped
+    /// in `.underlying` so the original error survives the mapping —
+    /// previously they were misreported as `.invalidConfiguration`.
     static func mapping(_ error: Error) -> ServiceError {
         if let svc = error as? ServiceError {
             return svc
         }
         guard let transport = error as? TransportError else {
-            return .transportError(
-                .invalidConfiguration(error.localizedDescription))
+            return .underlying(error)
         }
         switch transport {
         case .requestTimeout(let d): return .timeout(d)

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
@@ -238,7 +238,11 @@ final class DDSTransportServiceServerImpl: TransportService, @unchecked Sendable
             client: client, writer: replyWriterSnapshot(), topic: replyTopic, name: name,
             handler: handler
         )
-        Task { [captured, parsedId, userRequestCDR] in
+        // Detached so the user handler runs on the global executor regardless
+        // of the DDS reader thread's task-local context. Linux x86_64 / aarch64
+        // under `swift test --parallel` had unstructured `Task { ... }`
+        // starving here; detached scheduling clears the issue.
+        Task.detached(priority: .userInitiated) { [captured, parsedId, userRequestCDR] in
             do {
                 let userReplyCDR = try await captured.handler(userRequestCDR)
                 let wire = SampleIdentityPrefix.encode(requestId: parsedId, userCDR: userReplyCDR)

--- a/Sources/SwiftROS2Transport/TransportSession.swift
+++ b/Sources/SwiftROS2Transport/TransportSession.swift
@@ -196,6 +196,7 @@ public enum TransportError: Error, LocalizedError {
     case unsupportedFeature(String)
     case requestTimeout(Duration)
     case requestCancelled
+    case serviceHandlerFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -213,6 +214,7 @@ public enum TransportError: Error, LocalizedError {
         case .unsupportedFeature(let f): return "Unsupported feature: \(f)"
         case .requestTimeout(let d): return "Service request timed out after \(d)"
         case .requestCancelled: return "Service request was cancelled"
+        case .serviceHandlerFailed(let msg): return "Service handler failed: \(msg)"
         }
     }
 

--- a/Sources/SwiftROS2Transport/ZenohClientProtocol.swift
+++ b/Sources/SwiftROS2Transport/ZenohClientProtocol.swift
@@ -77,6 +77,10 @@ public enum ZenohError: Error, LocalizedError {
     case invalidParameter(String)
     case internalError(String)
     case sessionDisconnected(String)
+    /// Reply with `is_error == true` from a `get`. Carries the remote error
+    /// payload decoded as UTF-8 so the transport layer can surface it as a
+    /// `serviceHandlerFailed` without parsing prefixed strings.
+    case queryReplyError(String)
 
     public var errorDescription: String? {
         switch self {
@@ -89,6 +93,7 @@ public enum ZenohError: Error, LocalizedError {
         case .invalidParameter(let msg): return "Invalid parameter: \(msg)"
         case .internalError(let msg): return "Internal error: \(msg)"
         case .sessionDisconnected(let msg): return "Session disconnected: \(msg)"
+        case .queryReplyError(let msg): return "Query reply error: \(msg)"
         }
     }
 }

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Service.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Service.swift
@@ -1,11 +1,21 @@
 // ZenohTransportSession+Service.swift
-// Service Server / Client stubs for the Zenoh transport.
+// Service Server / Client implementation for the Zenoh transport.
 //
-// The real implementation lands in phase 6. For phase 3 these methods
-// throw `TransportError.unsupportedFeature` so the build is green and
-// callers get a clear error if they reach for services on Zenoh today.
+// `rmw_zenoh_cpp` models a ROS 2 service as a Zenoh queryable on the request
+// key expression. The server declares a queryable; the client issues a `get`
+// against the same key expression with the request CDR as payload. The first
+// reply (success or error) resolves the call.
+//
+// The wire payload on each side is the raw user CDR (no `RMWRequestId`
+// prefix) — Zenoh handles request / reply correlation natively.
+//
+// Liveliness tokens (`SS` / `SC`) are not declared yet — declaring the
+// queryable itself makes the service discoverable via the Zenoh admin
+// space, which is sufficient for round-trip operation. Adding explicit
+// `SS` / `SC` liveliness tokens is future work.
 
 import Foundation
+import SwiftROS2Wire
 
 extension ZenohTransportSession {
     public func createServiceServer(
@@ -16,7 +26,46 @@ extension ZenohTransportSession {
         qos: TransportQoS,
         handler: @escaping @Sendable (Data) async throws -> Data
     ) throws -> any TransportService {
-        throw TransportError.unsupportedFeature("Zenoh service server (phase 6)")
+        guard !name.isEmpty else {
+            throw TransportError.invalidConfiguration("Service name cannot be empty")
+        }
+        guard !serviceTypeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Service type name cannot be empty")
+        }
+        guard isConnected else {
+            throw TransportError.notConnected
+        }
+        guard let cfg = config else {
+            throw TransportError.notConnected
+        }
+
+        let codec = ZenohWireCodec(distro: resolvedWireMode ?? .jazzy)
+        let keyExpr = codec.makeServiceKeyExpr(
+            domainId: cfg.domainId,
+            namespace: extractNamespace(from: name),
+            serviceName: extractTopicName(from: name),
+            serviceTypeName: serviceTypeName,
+            requestTypeHash: requestTypeHash
+        )
+
+        let server = ZenohTransportServiceServerImpl(
+            name: name,
+            keyExpr: keyExpr,
+            handler: handler
+        )
+
+        let queryable: any ZenohQueryableHandle
+        do {
+            queryable = try client.declareQueryable(keyExpr) { [weak server] query in
+                server?.handleQuery(query)
+            }
+        } catch let error as ZenohError {
+            throw TransportError.subscriberCreationFailed(error.localizedDescription ?? "declareQueryable failed")
+        }
+        server.attachQueryable(queryable)
+
+        appendServiceServer(server)
+        return server
     }
 
     public func createServiceClient(
@@ -26,6 +75,346 @@ extension ZenohTransportSession {
         responseTypeHash: String?,
         qos: TransportQoS
     ) throws -> any TransportClient {
-        throw TransportError.unsupportedFeature("Zenoh service client (phase 6)")
+        guard !name.isEmpty else {
+            throw TransportError.invalidConfiguration("Service name cannot be empty")
+        }
+        guard !serviceTypeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Service type name cannot be empty")
+        }
+        guard isConnected else {
+            throw TransportError.notConnected
+        }
+        guard let cfg = config else {
+            throw TransportError.notConnected
+        }
+
+        let codec = ZenohWireCodec(distro: resolvedWireMode ?? .jazzy)
+        let keyExpr = codec.makeServiceKeyExpr(
+            domainId: cfg.domainId,
+            namespace: extractNamespace(from: name),
+            serviceName: extractTopicName(from: name),
+            serviceTypeName: serviceTypeName,
+            requestTypeHash: requestTypeHash
+        )
+
+        let serviceClient = ZenohTransportServiceClientImpl(
+            client: client,
+            codec: codec,
+            gid: gidManager.getOrCreateGid(),
+            keyExpr: keyExpr,
+            name: name
+        )
+        appendServiceClient(serviceClient)
+        return serviceClient
+    }
+
+    // MARK: - Internal lock helpers
+
+    func appendServiceServer(_ server: ZenohTransportServiceServerImpl) {
+        publishersLock.lock()
+        serviceServers.append(server)
+        publishersLock.unlock()
+    }
+
+    func appendServiceClient(_ serviceClient: ZenohTransportServiceClientImpl) {
+        publishersLock.lock()
+        serviceClients.append(serviceClient)
+        publishersLock.unlock()
+    }
+
+    func takeAllServiceServers() -> [ZenohTransportServiceServerImpl] {
+        publishersLock.lock()
+        let out = serviceServers
+        serviceServers.removeAll()
+        publishersLock.unlock()
+        return out
+    }
+
+    func takeAllServiceClients() -> [ZenohTransportServiceClientImpl] {
+        publishersLock.lock()
+        let out = serviceClients
+        serviceClients.removeAll()
+        publishersLock.unlock()
+        return out
+    }
+}
+
+// MARK: - Zenoh Transport Service Server
+
+final class ZenohTransportServiceServerImpl: TransportService, @unchecked Sendable {
+    public let name: String
+    private let keyExpr: String
+    private let handler: @Sendable (Data) async throws -> Data
+    private var queryable: (any ZenohQueryableHandle)?
+    private let lock = NSLock()
+    private var closed = false
+
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed && queryable != nil
+    }
+
+    init(
+        name: String,
+        keyExpr: String,
+        handler: @escaping @Sendable (Data) async throws -> Data
+    ) {
+        self.name = name
+        self.keyExpr = keyExpr
+        self.handler = handler
+    }
+
+    func attachQueryable(_ q: any ZenohQueryableHandle) {
+        lock.lock()
+        queryable = q
+        lock.unlock()
+    }
+
+    /// Called from a zenoh-pico-owned thread. Spawn a Task so the user
+    /// handler runs in Swift concurrency, then `reply` / `replyError`.
+    func handleQuery(_ query: any ZenohQueryHandle) {
+        let userRequestCDR = query.payload
+        let captured = handler
+        Task {
+            do {
+                let userReplyCDR = try await captured(userRequestCDR)
+                try? query.reply(payload: userReplyCDR, attachment: nil)
+            } catch {
+                try? query.replyError(message: error.localizedDescription)
+            }
+        }
+    }
+
+    public func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let q = queryable
+        queryable = nil
+        lock.unlock()
+
+        try? q?.close()
+    }
+}
+
+// MARK: - Zenoh Transport Service Client
+
+final class ZenohTransportServiceClientImpl: TransportClient, @unchecked Sendable {
+    private let client: any ZenohClientProtocol
+    private let codec: ZenohWireCodec
+    private let gid: [UInt8]
+    private let keyExpr: String
+    public let name: String
+
+    private let seqLock = NSLock()
+    private var nextSeq: Int64 = 0
+
+    private let lock = NSLock()
+    private var closed = false
+
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+
+    init(
+        client: any ZenohClientProtocol,
+        codec: ZenohWireCodec,
+        gid: [UInt8],
+        keyExpr: String,
+        name: String
+    ) {
+        self.client = client
+        self.codec = codec
+        self.gid = gid
+        self.keyExpr = keyExpr
+        self.name = name
+    }
+
+    /// Zenoh queryable discovery is effectively immediate via the Zenoh
+    /// admin space; if a stricter wait is needed, callers can use
+    /// `Task.sleep` after construction. This matches what `rmw_zenoh_cpp`
+    /// does in practice.
+    public func waitForService(timeout: Duration) async throws {
+        lock.lock()
+        let isClosed = closed
+        lock.unlock()
+        if isClosed {
+            throw TransportError.sessionClosed
+        }
+    }
+
+    public func call(requestCDR: Data, timeout: Duration) async throws -> Data {
+        lock.lock()
+        if closed {
+            lock.unlock()
+            throw TransportError.sessionClosed
+        }
+        lock.unlock()
+
+        let seq: Int64 = {
+            seqLock.lock()
+            defer { seqLock.unlock() }
+            nextSeq += 1
+            return nextSeq
+        }()
+
+        let attachment = codec.buildAttachment(
+            seq: seq,
+            tsNsec: Int64(Date().timeIntervalSince1970 * 1_000_000_000),
+            gid: gid
+        )
+
+        let timeoutMs = Self.durationToMillis(timeout)
+        let state = CallState()
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Data, Error>) in
+                state.set(continuation: continuation, timeout: timeout)
+
+                do {
+                    try client.get(
+                        keyExpr: keyExpr,
+                        payload: requestCDR,
+                        attachment: attachment,
+                        timeoutMs: timeoutMs,
+                        handler: { result in
+                            switch result {
+                            case .success(let sample):
+                                state.deliverReply(payload: sample.payload, isError: false)
+                            case .failure(let err):
+                                let msg: String
+                                if case .queryReplyError(let m) = err {
+                                    msg = m
+                                } else {
+                                    msg = err.localizedDescription ?? "Zenoh get error"
+                                }
+                                state.deliverReply(payload: Data(msg.utf8), isError: true)
+                            }
+                        },
+                        onFinish: {
+                            state.finish()
+                        }
+                    )
+                } catch {
+                    state.fail(error)
+                }
+            }
+        } onCancel: {
+            state.cancel()
+        }
+    }
+
+    public func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        lock.unlock()
+    }
+
+    private static func durationToMillis(_ duration: Duration) -> UInt32 {
+        let comps = duration.components
+        let seconds = max(0, Int64(comps.seconds))
+        let attoseconds = Int64(comps.attoseconds)
+        // 1 ms == 10^15 attoseconds
+        let ms = seconds.multipliedReportingOverflow(by: 1_000)
+        if ms.overflow {
+            return UInt32.max
+        }
+        let total = ms.partialValue + attoseconds / 1_000_000_000_000_000
+        if total < 0 { return 0 }
+        if total > Int64(UInt32.max) { return UInt32.max }
+        return UInt32(total)
+    }
+}
+
+/// Internal state holder for a single in-flight `call`. Coordinates the
+/// reply / finish / cancel paths under a single lock so the continuation
+/// is only resumed once.
+private final class CallState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Data, Error>?
+    private var timeout: Duration = .seconds(0)
+    private var resolved = false
+    private var receivedReply: (payload: Data, isError: Bool)?
+
+    func set(continuation: CheckedContinuation<Data, Error>, timeout: Duration) {
+        lock.lock()
+        self.continuation = continuation
+        self.timeout = timeout
+        lock.unlock()
+    }
+
+    /// Called from the get handler. We store the first reply but defer the
+    /// actual continuation resume until `onFinish` fires — this matches the
+    /// shape `rmw_zenoh_cpp` uses (one reply per service get) and keeps the
+    /// resume-once invariant straightforward.
+    func deliverReply(payload: Data, isError: Bool) {
+        lock.lock()
+        if receivedReply == nil {
+            receivedReply = (payload, isError)
+        }
+        lock.unlock()
+    }
+
+    func finish() {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            return
+        }
+        resolved = true
+        let cont = continuation
+        continuation = nil
+        let reply = receivedReply
+        let dur = timeout
+        lock.unlock()
+
+        guard let cont = cont else { return }
+        if let reply = reply {
+            if reply.isError {
+                let msg = String(decoding: reply.payload, as: UTF8.self)
+                cont.resume(throwing: TransportError.serviceHandlerFailed(msg))
+            } else {
+                cont.resume(returning: reply.payload)
+            }
+        } else {
+            cont.resume(throwing: TransportError.requestTimeout(dur))
+        }
+    }
+
+    func fail(_ error: Error) {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            return
+        }
+        resolved = true
+        let cont = continuation
+        continuation = nil
+        lock.unlock()
+        cont?.resume(throwing: error)
+    }
+
+    func cancel() {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            return
+        }
+        resolved = true
+        let cont = continuation
+        continuation = nil
+        lock.unlock()
+        cont?.resume(throwing: TransportError.requestCancelled)
     }
 }

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Service.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Service.swift
@@ -236,16 +236,67 @@ final class ZenohTransportServiceClientImpl: TransportClient, @unchecked Sendabl
         self.name = name
     }
 
-    /// Zenoh queryable discovery is effectively immediate via the Zenoh
-    /// admin space; if a stricter wait is needed, callers can use
-    /// `Task.sleep` after construction. This matches what `rmw_zenoh_cpp`
-    /// does in practice.
+    /// Wait until at least one Zenoh queryable is reachable on the service
+    /// key expression. Polls via short-timeout `get`s and resolves on the
+    /// first reply (success or error reply both count — both prove the
+    /// queryable exists). Throws `connectionTimeout` if no reply arrives
+    /// before `timeout` elapses.
     public func waitForService(timeout: Duration) async throws {
         lock.lock()
         let isClosed = closed
         lock.unlock()
         if isClosed {
             throw TransportError.sessionClosed
+        }
+
+        let probeTimeoutMs: UInt32 = 200
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            let remainingMs = ZenohTransportServiceClientImpl.durationToMillis(
+                deadline - ContinuousClock.now
+            )
+            if remainingMs == 0 {
+                break
+            }
+            let attemptMs = min(probeTimeoutMs, remainingMs)
+            let reachable = await probeOnce(timeoutMs: attemptMs)
+            if reachable {
+                return
+            }
+        }
+        throw TransportError.connectionTimeout(
+            TimeInterval(
+                Double(timeout.components.seconds)
+                    + Double(timeout.components.attoseconds) / 1.0e18))
+    }
+
+    /// Issue a single discovery probe; resolve `true` on the first reply,
+    /// `false` if `onFinish` fires without one.
+    private func probeOnce(timeoutMs: UInt32) async -> Bool {
+        await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            let resumed = ConcurrencyOnceFlag()
+            do {
+                try client.get(
+                    keyExpr: keyExpr,
+                    payload: nil,
+                    attachment: nil,
+                    timeoutMs: timeoutMs,
+                    handler: { _ in
+                        if resumed.set() {
+                            cont.resume(returning: true)
+                        }
+                    },
+                    onFinish: {
+                        if resumed.set() {
+                            cont.resume(returning: false)
+                        }
+                    }
+                )
+            } catch {
+                if resumed.set() {
+                    cont.resume(returning: false)
+                }
+            }
         }
     }
 
@@ -334,6 +385,21 @@ final class ZenohTransportServiceClientImpl: TransportClient, @unchecked Sendabl
         if total < 0 { return 0 }
         if total > Int64(UInt32.max) { return UInt32.max }
         return UInt32(total)
+    }
+}
+
+/// One-shot flag — `set()` returns true exactly once, false on every later
+/// call. Used to guard CheckedContinuation.resume against being invoked
+/// twice when reply / finish / cancel race.
+private final class ConcurrencyOnceFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+    func set() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if fired { return false }
+        fired = true
+        return true
     }
 }
 

--- a/Sources/SwiftROS2Transport/ZenohTransportSession.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession.swift
@@ -17,6 +17,8 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
     let client: any ZenohClientProtocol
     var config: TransportConfig?
     var publishers: [String: ZenohTransportPublisher] = [:]
+    var serviceServers: [ZenohTransportServiceServerImpl] = []
+    var serviceClients: [ZenohTransportServiceClientImpl] = []
     let publishersLock = NSLock()
     let entityManager: EntityManager
     let gidManager: GIDManager
@@ -85,6 +87,16 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
         let pubs = takeAllPublishers()
         for pub in pubs {
             try? pub.close()
+        }
+
+        let servers = takeAllServiceServers()
+        for server in servers {
+            try? server.close()
+        }
+
+        let clients = takeAllServiceClients()
+        for serviceClient in clients {
+            try? serviceClient.close()
         }
 
         do {

--- a/Sources/SwiftROS2Zenoh/ZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/ZenohClient.swift
@@ -771,7 +771,7 @@ private func getReplyBridge(
 
     if isError {
         let message = String(data: payloadData, encoding: .utf8) ?? "<non-UTF8 error payload>"
-        getContext.handler(.failure(.internalError("query reply error: \(message)")))
+        getContext.handler(.failure(.queryReplyError(message)))
     } else {
         let sample = ZenohSample(keyExpr: keyExprString, payload: payloadData, attachment: attachmentData)
         getContext.handler(.success(sample))

--- a/Tests/SwiftROS2IntegrationTests/DDSServiceRoundTripTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/DDSServiceRoundTripTests.swift
@@ -1,0 +1,69 @@
+import SwiftROS2
+import SwiftROS2Messages
+import SwiftROS2Transport
+import XCTest
+
+/// Round-trip integration test for Service Server / Client over CycloneDDS.
+/// Requires:
+/// - `LINUX_IP` env var set to the Linux host running ROS 2 (skipped if absent).
+/// - The host runs `ros2 service call /test/trigger std_srvs/srv/Trigger {}`
+///   in parallel, with `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp` and
+///   `ROS_DOMAIN_ID=99`.
+///
+/// Skips gracefully when `LINUX_IP` is not set so CI stays deterministic.
+final class DDSServiceRoundTripTests: XCTestCase {
+    /// Same-process loopback round-trip — no LINUX_IP required. Verifies
+    /// that a Service Server and Client wired up against the same
+    /// DDSTransportSession round-trip a Trigger request without any
+    /// external host.
+    func testTriggerLoopbackOverDDS() async throws {
+        let domain = 43
+        let ctx = try await ROS2Context(
+            transport: .ddsMulticast(domainId: domain),
+            distro: .jazzy,
+            domainId: domain
+        )
+        let node = try await ctx.createNode(name: "dds_srv_loopback", namespace: "/loopback")
+
+        _ = try await node.createService(TriggerSrv.self, name: "trigger") { _ in
+            TriggerSrv.Response(success: true, message: "loopback-ok")
+        }
+        let cli = try await node.createClient(TriggerSrv.self, name: "trigger")
+
+        // SPDP/SEDP discovery is slower than Zenoh; give both endpoints
+        // time to match before issuing the call.
+        try await cli.waitForService(timeout: .seconds(5))
+
+        let response = try await cli.call(.init(), timeout: .seconds(5))
+        XCTAssertTrue(response.success)
+        XCTAssertEqual(response.message, "loopback-ok")
+
+        await ctx.shutdown()
+    }
+
+    /// Round-trip against a remote Linux host running `rmw_cyclonedds_cpp`.
+    /// Skipped unless `LINUX_IP` is set.
+    func testTriggerCallToLinuxHost() async throws {
+        guard let linuxIP = ProcessInfo.processInfo.environment["LINUX_IP"], !linuxIP.isEmpty else {
+            throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)")
+        }
+
+        let domain = 99
+        let ctx = try await ROS2Context(
+            transport: .ddsUnicast(
+                peers: [DDSPeer.peer(address: linuxIP, domainId: domain)],
+                domainId: domain
+            ),
+            distro: .jazzy,
+            domainId: domain
+        )
+        let node = try await ctx.createNode(name: "swift_ros2_it_dds_srv", namespace: "/test")
+        let cli = try await node.createClient(TriggerSrv.self, name: "trigger")
+
+        try await cli.waitForService(timeout: .seconds(10))
+        let response = try await cli.call(.init(), timeout: .seconds(10))
+        XCTAssertTrue(response.success || !response.message.isEmpty)
+
+        await ctx.shutdown()
+    }
+}

--- a/Tests/SwiftROS2IntegrationTests/ZenohServiceRoundTripTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/ZenohServiceRoundTripTests.swift
@@ -42,4 +42,35 @@ final class ZenohServiceRoundTripTests: XCTestCase {
 
         await ctx.shutdown()
     }
+
+    /// Hosts a Trigger service from this Swift process and waits for a
+    /// remote `ros2 service call` to invoke it. This exercises the
+    /// queryable / server side of the Zenoh service implementation that
+    /// the round-trip-from-here test (above) cannot reach.
+    func testTriggerHostOverZenoh() async throws {
+        guard let linuxIP = ProcessInfo.processInfo.environment["LINUX_IP"], !linuxIP.isEmpty else {
+            throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)")
+        }
+
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/\(linuxIP):7447", domainId: 0, wireMode: .jazzy),
+            distro: .jazzy
+        )
+        let node = try await ctx.createNode(name: "swift_ros2_it_zenoh_host", namespace: "/test")
+
+        let invoked = expectation(description: "remote ros2 service call invoked the Swift handler")
+        invoked.assertForOverFulfill = false
+        _ = try await node.createService(TriggerSrv.self, name: "swift_zenoh_trigger") { _ in
+            invoked.fulfill()
+            return TriggerSrv.Response(success: true, message: "hi from swift over zenoh")
+        }
+
+        // Run an external `ros2 service call /test/swift_zenoh_trigger
+        // std_srvs/srv/Trigger` against `rmw_zenoh_cpp` while this test is
+        // waiting. CI gates this entire test on LINUX_IP, so the runner
+        // never blocks on the wait when the env var is unset.
+        await fulfillment(of: [invoked], timeout: 60)
+
+        await ctx.shutdown()
+    }
 }

--- a/Tests/SwiftROS2IntegrationTests/ZenohServiceRoundTripTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/ZenohServiceRoundTripTests.swift
@@ -1,0 +1,45 @@
+import SwiftROS2
+import SwiftROS2Messages
+import SwiftROS2Transport
+import XCTest
+
+/// Round-trip integration test for Service Server / Client over Zenoh.
+/// Requires:
+/// - `LINUX_IP` env var set to the host running `rmw_zenohd` (skipped if absent).
+/// - On the host: `ros2 run rmw_zenoh_cpp rmw_zenohd` listening on
+///   `tcp/<LINUX_IP>:7447`.
+/// - On the host: `ros2 service call /test/trigger std_srvs/srv/Trigger {}`
+///   running with `RMW_IMPLEMENTATION=rmw_zenoh_cpp` (the swift-ros2 client
+///   side acts as the service server in this scenario).
+///
+/// Skips gracefully when `LINUX_IP` is not set so CI stays deterministic.
+final class ZenohServiceRoundTripTests: XCTestCase {
+    /// Calls a remote service hosted on the Linux host. The remote service
+    /// is expected to be a stock `std_srvs/srv/Trigger` server (e.g. the
+    /// `srv-server` example running on the host, or any rmw_zenoh_cpp
+    /// node serving `/test/trigger`).
+    func testTriggerCallOverZenoh() async throws {
+        guard let linuxIP = ProcessInfo.processInfo.environment["LINUX_IP"], !linuxIP.isEmpty else {
+            throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)")
+        }
+
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/\(linuxIP):7447", domainId: 0, wireMode: .jazzy),
+            distro: .jazzy
+        )
+        let node = try await ctx.createNode(name: "swift_ros2_it_zenoh_srv", namespace: "/test")
+        let cli = try await node.createClient(TriggerSrv.self, name: "trigger")
+
+        // Zenoh discovery is effectively instant via the admin space; a
+        // small explicit wait still matches what rmw_zenoh_cpp does.
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        let response = try await cli.call(.init(), timeout: .seconds(5))
+        // A live ROS 2 Trigger server typically replies success=true; the
+        // message field is implementation-dependent. Accept any non-empty
+        // reply as "round-trip succeeded".
+        XCTAssertTrue(response.success || !response.message.isEmpty)
+
+        await ctx.shutdown()
+    }
+}

--- a/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
+++ b/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
@@ -34,6 +34,21 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
     private var _subscribers: [MockTransportSubscriber] = []
     private var _closedCount = 0
 
+    // Service-related state. Default-disabled so tests that don't opt in
+    // keep getting the original "unsupportedFeature" throw.
+    private var _serviceMode: ServiceMode = .unsupported
+    private var _services: [MockTransportServiceServer] = []
+    private var _clients: [MockTransportServiceClient] = []
+
+    enum ServiceMode {
+        /// `createServiceServer` / `createServiceClient` throw `unsupportedFeature`.
+        case unsupported
+        /// In-process echo: client `call` invokes the matching server's handler.
+        case echo
+        /// Client `call` always sleeps for the requested timeout, then throws.
+        case neverResponds
+    }
+
     // MARK: - Public accessors (synchronized)
 
     var isConnected: Bool {
@@ -176,7 +191,17 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
         qos: TransportQoS,
         handler: @escaping @Sendable (Data) async throws -> Data
     ) throws -> any TransportService {
-        throw TransportError.unsupportedFeature("MockTransportSession service server (override per test)")
+        let mode: ServiceMode = synchronized { _serviceMode }
+        switch mode {
+        case .unsupported:
+            throw TransportError.unsupportedFeature(
+                "MockTransportSession service server (override per test)"
+            )
+        case .echo, .neverResponds:
+            let svc = MockTransportServiceServer(name: name, handler: handler)
+            synchronized { _services.append(svc) }
+            return svc
+        }
     }
 
     func createServiceClient(
@@ -186,7 +211,48 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
         responseTypeHash: String?,
         qos: TransportQoS
     ) throws -> any TransportClient {
-        throw TransportError.unsupportedFeature("MockTransportSession service client (override per test)")
+        let mode: ServiceMode = synchronized { _serviceMode }
+        switch mode {
+        case .unsupported:
+            throw TransportError.unsupportedFeature(
+                "MockTransportSession service client (override per test)"
+            )
+        case .echo:
+            let cli = MockTransportServiceClient(name: name, mode: .echo) { [weak self] req in
+                guard let self = self else { return Data() }
+                let target: MockTransportServiceServer? = self.synchronized {
+                    self._services.first(where: { $0.name == name })
+                }
+                if let svc = target {
+                    return try await svc.handler(req)
+                }
+                throw TransportError.notConnected
+            }
+            synchronized { _clients.append(cli) }
+            return cli
+        case .neverResponds:
+            let cli = MockTransportServiceClient(name: name, mode: .neverResponds) { _ in
+                Data()  // never reached
+            }
+            synchronized { _clients.append(cli) }
+            return cli
+        }
+    }
+
+    // MARK: - Service test helpers
+
+    /// Make subsequent `createServiceServer` / `createServiceClient` calls
+    /// produce in-process cooperating mocks: a client's `call` looks up the
+    /// matching server by name and invokes its handler directly.
+    func installEchoServiceTransport() {
+        synchronized { _serviceMode = .echo }
+    }
+
+    /// Make `createServiceClient` produce a client whose `call` sleeps for
+    /// the supplied timeout and then throws `requestTimeout`. Useful for
+    /// driving the umbrella's timeout mapping path.
+    func installNeverRespondingServiceTransport() {
+        synchronized { _serviceMode = .neverResponds }
     }
 }
 
@@ -224,6 +290,88 @@ final class MockTransportPublisher: TransportPublisher, @unchecked Sendable {
         let fanout = deliveryFanout
         lock.unlock()
         fanout?(data, timestamp)
+    }
+
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        closed = true
+    }
+}
+
+final class MockTransportServiceServer: TransportService, @unchecked Sendable {
+    let name: String
+    let handler: @Sendable (Data) async throws -> Data
+    private let lock = NSLock()
+    private var closed = false
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+
+    init(name: String, handler: @escaping @Sendable (Data) async throws -> Data) {
+        self.name = name
+        self.handler = handler
+    }
+
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        closed = true
+    }
+}
+
+final class MockTransportServiceClient: TransportClient, @unchecked Sendable {
+    enum Mode {
+        case echo
+        case neverResponds
+    }
+
+    let name: String
+    private let mode: Mode
+    private let dispatch: @Sendable (Data) async throws -> Data
+    private let lock = NSLock()
+    private var closed = false
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+
+    init(name: String, mode: Mode, dispatch: @escaping @Sendable (Data) async throws -> Data) {
+        self.name = name
+        self.mode = mode
+        self.dispatch = dispatch
+    }
+
+    func waitForService(timeout: Duration) async throws {
+        lock.lock()
+        let isClosed = closed
+        lock.unlock()
+        if isClosed {
+            throw TransportError.sessionClosed
+        }
+    }
+
+    func call(requestCDR: Data, timeout: Duration) async throws -> Data {
+        lock.lock()
+        if closed {
+            lock.unlock()
+            throw TransportError.sessionClosed
+        }
+        lock.unlock()
+
+        switch mode {
+        case .echo:
+            return try await dispatch(requestCDR)
+        case .neverResponds:
+            try? await Task.sleep(for: timeout)
+            try Task.checkCancellation()
+            throw TransportError.requestTimeout(timeout)
+        }
     }
 
     func close() throws {

--- a/Tests/SwiftROS2Tests/NodeLifecycleTests.swift
+++ b/Tests/SwiftROS2Tests/NodeLifecycleTests.swift
@@ -163,4 +163,39 @@ final class NodeLifecycleTests: XCTestCase {
             XCTAssertFalse(pub.isActive)
         }
     }
+
+    func testShutdownClosesAllServicesAndClients() async throws {
+        let session = MockTransportSession()
+        session.installEchoServiceTransport()
+        let ctx = try await ROS2Context(transport: .zenoh(locator: "tcp/m:7447"), session: session)
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+
+        let service = try await node.createService(TriggerSrv.self, name: "trig") { _ in
+            TriggerSrv.Response(success: true, message: "ok")
+        }
+        let cli = try await node.createClient(TriggerSrv.self, name: "trig")
+        XCTAssertTrue(service.isActive)
+
+        await node.destroy()
+
+        XCTAssertFalse(service.isActive, "service should be closed after node.destroy()")
+        XCTAssertFalse(cli.isActive, "client should be closed after node.destroy()")
+    }
+
+    func testContextShutdownClosesServicesViaNodeDestroy() async throws {
+        let session = MockTransportSession()
+        session.installEchoServiceTransport()
+        let ctx = try await ROS2Context(transport: .zenoh(locator: "tcp/m:7447"), session: session)
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+
+        let service = try await node.createService(TriggerSrv.self, name: "trig") { _ in
+            TriggerSrv.Response(success: true, message: "ok")
+        }
+        let cli = try await node.createClient(TriggerSrv.self, name: "trig")
+
+        await ctx.shutdown()
+
+        XCTAssertFalse(service.isActive, "service should be closed after ctx.shutdown()")
+        XCTAssertFalse(cli.isActive, "client should be closed after ctx.shutdown()")
+    }
 }

--- a/Tests/SwiftROS2Tests/NodeServiceTests.swift
+++ b/Tests/SwiftROS2Tests/NodeServiceTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SwiftROS2Messages
+import XCTest
+
+@testable import SwiftROS2
+
+final class NodeServiceTests: XCTestCase {
+    func testCreateServiceAndCallThroughMockTransport() async throws {
+        let mock = MockTransportSession()
+        mock.installEchoServiceTransport()
+
+        let ctx = try await ROS2Context(transport: .zenoh(locator: "tcp/127.0.0.1:7447"), session: mock)
+        let node = try await ctx.createNode(name: "n")
+
+        _ = try await node.createService(TriggerSrv.self, name: "/trigger") { _ in
+            TriggerSrv.Response(success: true, message: "ok")
+        }
+        let cli = try await node.createClient(TriggerSrv.self, name: "/trigger")
+        try await cli.waitForService(timeout: .milliseconds(100))
+        let resp = try await cli.call(.init(), timeout: .seconds(1))
+        XCTAssertTrue(resp.success)
+        XCTAssertEqual(resp.message, "ok")
+        await node.destroy()
+        await ctx.shutdown()
+    }
+
+    func testCallTimeoutSurfaces() async throws {
+        let mock = MockTransportSession()
+        mock.installNeverRespondingServiceTransport()
+
+        let ctx = try await ROS2Context(transport: .zenoh(locator: "tcp/127.0.0.1:7447"), session: mock)
+        let node = try await ctx.createNode(name: "n")
+        let cli = try await node.createClient(TriggerSrv.self, name: "/trigger")
+        do {
+            _ = try await cli.call(.init(), timeout: .milliseconds(50))
+            XCTFail("should time out")
+        } catch ServiceError.timeout {
+            // expected
+        }
+    }
+}

--- a/Tests/SwiftROS2TransportTests/Mocks/MockZenohClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockZenohClient.swift
@@ -17,6 +17,8 @@ final class MockZenohClient: ZenohClientProtocol, @unchecked Sendable {
     var putShouldThrow: ZenohError?
     var subscribeShouldThrow: ZenohError?
     var livelinessShouldThrow: ZenohError?
+    var declareQueryableShouldThrow: ZenohError?
+    var getShouldThrow: ZenohError?
     var healthOverride: Bool?
 
     // Recorded invocations
@@ -26,6 +28,17 @@ final class MockZenohClient: ZenohClientProtocol, @unchecked Sendable {
     private(set) var puts: [(key: String, payload: Data, attachment: Data?)] = []
     private(set) var subscriptions: [(key: String, handler: (ZenohSample) -> Void)] = []
     private(set) var livelinessDeclarations: [String] = []
+    private(set) var queryableDeclarations: [(key: String, handler: @Sendable (any ZenohQueryHandle) -> Void)] = []
+    private(set) var gets: [(key: String, payload: Data?, attachment: Data?, timeoutMs: UInt32)] = []
+
+    // Service test helpers
+    private(set) var lastQueryReplyPayload: Data?
+    private(set) var lastQueryReplyError: String?
+    private var queryReplied = false
+
+    /// Per-call scripts for `get`. Each `get` invocation pops the next entry.
+    /// `nil` payload means "fire only onFinish" (timeout).
+    private var getScripts: [(payload: Data?, isError: Bool)] = []
 
     func open(locator: String) throws {
         lock.lock()
@@ -93,6 +106,56 @@ final class MockZenohClient: ZenohClientProtocol, @unchecked Sendable {
         return MockLivelinessTokenHandle()
     }
 
+    func declareQueryable(
+        _ keyExpr: String,
+        handler: @escaping @Sendable (any ZenohQueryHandle) -> Void
+    ) throws -> any ZenohQueryableHandle {
+        lock.lock()
+        defer { lock.unlock() }
+        if let e = declareQueryableShouldThrow { throw e }
+        queryableDeclarations.append((key: keyExpr, handler: handler))
+        return MockQueryableHandle()
+    }
+
+    func get(
+        keyExpr: String,
+        payload: Data?,
+        attachment: Data?,
+        timeoutMs: UInt32,
+        handler: @escaping @Sendable (Result<ZenohSample, ZenohError>) -> Void,
+        onFinish: @escaping @Sendable () -> Void
+    ) throws {
+        lock.lock()
+        if let e = getShouldThrow {
+            lock.unlock()
+            throw e
+        }
+        gets.append((key: keyExpr, payload: payload, attachment: attachment, timeoutMs: timeoutMs))
+        let script: (payload: Data?, isError: Bool)? = getScripts.isEmpty ? nil : getScripts.removeFirst()
+        lock.unlock()
+
+        // Fire the scripted reply / finish on a background queue to mirror
+        // the C bridge's "callbacks run on a zenoh-pico-owned thread"
+        // contract, then immediately fire onFinish.
+        DispatchQueue.global(qos: .userInitiated).async {
+            if let script = script {
+                if let payload = script.payload {
+                    if script.isError {
+                        let msg = String(decoding: payload, as: UTF8.self)
+                        handler(.failure(.queryReplyError(msg)))
+                    } else {
+                        handler(
+                            .success(
+                                ZenohSample(keyExpr: keyExpr, payload: payload, attachment: nil)
+                            ))
+                    }
+                }
+                // payload == nil: timeout — only onFinish fires.
+            }
+            onFinish()
+        }
+    }
+
     /// Test helper: deliver a sample to all matching subscriber handlers.
     func deliver(sample: ZenohSample, toKeyExpr key: String) {
         let handlers: [(ZenohSample) -> Void] = {
@@ -103,6 +166,66 @@ final class MockZenohClient: ZenohClientProtocol, @unchecked Sendable {
         for handler in handlers {
             handler(sample)
         }
+    }
+
+    /// Test helper: deliver a synthetic query to the most-recently-declared
+    /// queryable whose key prefix matches `keyExpr`. The mock query handle
+    /// records `reply` / `replyError` calls into `lastQueryReplyPayload` /
+    /// `lastQueryReplyError`.
+    func deliverQueryToQueryable(keyExpr: String, payload: Data, attachment: Data?) {
+        let target: (key: String, handler: @Sendable (any ZenohQueryHandle) -> Void)? = {
+            lock.lock()
+            defer { lock.unlock() }
+            return queryableDeclarations.last(where: { keyExpr.hasPrefix($0.key) || $0.key.hasPrefix(keyExpr) })
+                ?? queryableDeclarations.last
+        }()
+        guard let target = target else { return }
+        let query = MockQueryHandle(
+            keyExpr: keyExpr,
+            payload: payload,
+            attachment: attachment
+        ) { [weak self] reply in
+            guard let self = self else { return }
+            self.lock.lock()
+            switch reply {
+            case .success(let p):
+                self.lastQueryReplyPayload = p
+            case .failure(let m):
+                self.lastQueryReplyError = m
+            }
+            self.queryReplied = true
+            self.lock.unlock()
+        }
+        target.handler(query)
+    }
+
+    /// Test helper: poll until a queryable reply has been recorded or the
+    /// timeout elapses.
+    func awaitQueryReply(timeout: Duration) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            lock.lock()
+            let done = queryReplied
+            lock.unlock()
+            if done { return }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        throw NSError(
+            domain: "MockZenohClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "awaitQueryReply timed out"])
+    }
+
+    /// Script the next `get` to return `payload` (success or error) before firing onFinish.
+    func scriptGetReply(payload: Data, isError: Bool) {
+        lock.lock()
+        getScripts.append((payload: payload, isError: isError))
+        lock.unlock()
+    }
+
+    /// Script the next `get` to fire only onFinish (no reply) — i.e. simulate timeout.
+    func scriptGetTimeout() {
+        lock.lock()
+        getScripts.append((payload: nil, isError: false))
+        lock.unlock()
     }
 }
 
@@ -128,5 +251,62 @@ final class MockLivelinessTokenHandle: ZenohLivelinessTokenHandle {
         lock.lock()
         defer { lock.unlock() }
         closeCount += 1
+    }
+}
+
+final class MockQueryableHandle: ZenohQueryableHandle {
+    private(set) var closeCount = 0
+    private let lock = NSLock()
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        closeCount += 1
+    }
+}
+
+/// Synthetic in-process `ZenohQueryHandle`. Reply / replyError are reported
+/// to the mock's recorder via the closure passed at init.
+final class MockQueryHandle: ZenohQueryHandle, @unchecked Sendable {
+    let keyExpr: String
+    let payload: Data
+    let attachment: Data?
+
+    enum Reply {
+        case success(Data)
+        case failure(String)
+    }
+
+    private let recorder: @Sendable (Reply) -> Void
+    private let lock = NSLock()
+    private var consumed = false
+
+    init(
+        keyExpr: String, payload: Data, attachment: Data?,
+        recorder: @escaping @Sendable (Reply) -> Void
+    ) {
+        self.keyExpr = keyExpr
+        self.payload = payload
+        self.attachment = attachment
+        self.recorder = recorder
+    }
+
+    func reply(payload: Data, attachment: Data?) throws {
+        try claim()
+        recorder(.success(payload))
+    }
+
+    func replyError(message: String) throws {
+        try claim()
+        recorder(.failure(message))
+    }
+
+    private func claim() throws {
+        lock.lock()
+        if consumed {
+            lock.unlock()
+            throw ZenohError.invalidParameter("query handle already consumed")
+        }
+        consumed = true
+        lock.unlock()
     }
 }

--- a/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
+++ b/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
@@ -31,7 +31,11 @@ final class DDSServiceTransportTests: XCTestCase {
 
         try await client.deliverToReader(topic: "rq/echoRequest", wire: wire, timestamp: 1_000)
 
-        let written = try await client.awaitWrite(topic: "rr/echoReply", timeout: .seconds(1))
+        // Generous timeout: the server spawns a `Task` to run the user
+        // handler asynchronously, then writes the reply. On heavily-loaded
+        // CI runners (notably Linux aarch64 under `swift test --parallel`)
+        // the cooperative scheduler can take seconds to dispatch that Task.
+        let written = try await client.awaitWrite(topic: "rr/echoReply", timeout: .seconds(10))
         let writtenBytes = try XCTUnwrap(written)
 
         XCTAssertEqual(received.value, userCDR)
@@ -58,9 +62,9 @@ final class DDSServiceTransportTests: XCTestCase {
         client.markPublicationsMatched(topic: "rq/echoRequest")
 
         let userRequest = Data([0x00, 0x01, 0x00, 0x00, 0xDE])
-        async let response: Data = svc.call(requestCDR: userRequest, timeout: .seconds(1))
+        async let response: Data = svc.call(requestCDR: userRequest, timeout: .seconds(10))
 
-        let writtenWire = try await client.awaitWrite(topic: "rq/echoRequest", timeout: .seconds(1))
+        let writtenWire = try await client.awaitWrite(topic: "rq/echoRequest", timeout: .seconds(10))
         let bytes = try XCTUnwrap(writtenWire)
         let (id, parsedReq) = try SampleIdentityPrefix.decode(wirePayload: bytes)
         XCTAssertEqual(parsedReq, userRequest)

--- a/Tests/SwiftROS2TransportTests/ZenohServiceTransportTests.swift
+++ b/Tests/SwiftROS2TransportTests/ZenohServiceTransportTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import XCTest
+
+@testable import SwiftROS2Transport
+
+final class ZenohServiceTransportTests: XCTestCase {
+    func testServerHandlerInvokedAndReplies() async throws {
+        let zenoh = MockZenohClient()
+        let session = ZenohTransportSession(client: zenoh)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447"))
+
+        let received = Box<Data?>(nil)
+        _ = try session.createServiceServer(
+            name: "/echo",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: nil,
+            responseTypeHash: nil,
+            qos: .sensorData,
+            handler: { req in
+                received.value = req
+                return Data([0x00, 0x01, 0x00, 0x00, 0xCC])
+            }
+        )
+
+        zenoh.deliverQueryToQueryable(
+            keyExpr: "0/echo/std_srvs::srv::dds_::Trigger_Request_",
+            payload: Data([0x00, 0x01, 0x00, 0x00, 0xDE]),
+            attachment: nil
+        )
+        try await zenoh.awaitQueryReply(timeout: .seconds(1))
+
+        XCTAssertEqual(received.value, Data([0x00, 0x01, 0x00, 0x00, 0xDE]))
+        XCTAssertEqual(zenoh.lastQueryReplyPayload, Data([0x00, 0x01, 0x00, 0x00, 0xCC]))
+    }
+
+    func testClientGetReturnsReply() async throws {
+        let zenoh = MockZenohClient()
+        let session = ZenohTransportSession(client: zenoh)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447"))
+
+        let cli = try session.createServiceClient(
+            name: "/echo",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: nil,
+            responseTypeHash: nil,
+            qos: .sensorData
+        )
+
+        zenoh.scriptGetReply(payload: Data([0x00, 0x01, 0x00, 0x00, 0xEE]), isError: false)
+        let result = try await cli.call(
+            requestCDR: Data([0x00, 0x01, 0x00, 0x00, 0xDE]),
+            timeout: .seconds(1)
+        )
+        XCTAssertEqual(result, Data([0x00, 0x01, 0x00, 0x00, 0xEE]))
+    }
+
+    func testClientGetTimeoutSurfacesAsRequestTimeout() async throws {
+        let zenoh = MockZenohClient()
+        let session = ZenohTransportSession(client: zenoh)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447"))
+        let cli = try session.createServiceClient(
+            name: "/echo",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: nil,
+            responseTypeHash: nil,
+            qos: .sensorData
+        )
+        zenoh.scriptGetTimeout()
+        do {
+            _ = try await cli.call(requestCDR: Data([0x00, 0x01, 0x00, 0x00]), timeout: .seconds(1))
+            XCTFail("should have thrown timeout")
+        } catch TransportError.requestTimeout {
+            // expected
+        }
+    }
+
+    func testClientGetErrorReplyMapsToHandlerFailed() async throws {
+        let zenoh = MockZenohClient()
+        let session = ZenohTransportSession(client: zenoh)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447"))
+        let cli = try session.createServiceClient(
+            name: "/echo",
+            serviceTypeName: "std_srvs/srv/Trigger",
+            requestTypeHash: nil,
+            responseTypeHash: nil,
+            qos: .sensorData
+        )
+        zenoh.scriptGetReply(payload: Data("boom".utf8), isError: true)
+        do {
+            _ = try await cli.call(requestCDR: Data([0x00, 0x01, 0x00, 0x00]), timeout: .seconds(1))
+            XCTFail("should have thrown handler failed")
+        } catch TransportError.serviceHandlerFailed(let msg) {
+            XCTAssertEqual(msg, "boom")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Final phase of the ROS 2 Services landing.

- `ZenohTransportSession.createServiceServer` / `createServiceClient` (queryable + get)
- `TransportError.serviceHandlerFailed` (transport-layer surface for remote-handler errors; the umbrella maps to `ServiceError.handlerFailed`)
- `ZenohError.queryReplyError(String)` so the get-reply-error path is distinguishable from local Zenoh failures
- Public umbrella API: `ROS2Service<S>`, `ROS2Client<S>`, `ServiceError` (`SwiftROS2`)
- `ROS2Node.createService` / `createClient` with full lifecycle (services + clients walked in `destroy()`)
- Examples: `swift run srv-server <transport>`, `swift run srv-client <transport>`
- LINUX_IP-gated integration tests for DDS + Zenoh round-trip
- README features bullet + Services usage snippet
- CHANGELOG 0.7.0 section extended with Services Added / Changed entries
- MIGRATION 0.6.x → 0.7.0 note (consolidates the Phase-1 `ROS2Service` → `ROS2ServiceType` rename)

Wire-compatible with `rmw_zenoh_cpp` + `rmw_cyclonedds_cpp` on Humble / Jazzy / Kilted / Rolling.

**Stack (PR #67 → #68 → #69 → this):**
- #67 (phase 3) — protocols + stubs
- #68 (phase 4) — DDS server/client
- #69 (phase 5) — Zenoh C-bridge queryable + get
- **this (phase 6) — umbrella API + Zenoh transport + examples + integration**

## Test plan

- [x] swift build (clean)
- [x] swift build --product srv-server --product srv-client (clean)
- [x] swift test --parallel (242 tests, 6 LINUX_IP-gated skips, 0 failures)
- [x] swift format lint --strict (clean)
- [x] ZenohServiceTransportTests: 4 tests (server reply, client get success, client timeout, client error reply)
- [x] NodeServiceTests: 2 tests via `MockTransportSession` (echo round-trip, timeout)
- [ ] LINUX_IP=… integration tests (DDS + Zenoh) — exercised manually after merge against the LAN ROS 2 host

## Notes / minor deviations from plan

- `ZenohTransportServiceClientImpl.waitForService` returns immediately (Zenoh queryable discovery is effectively instant via the admin space). Documented as "future work" if a stricter wait is needed.
- The `SS` liveliness token for Zenoh service servers is skipped — the queryable announce itself surfaces in the admin space; future-work comment added.
- Example target naming follows `talker` / `listener` precedent (kebab-case) so `swift run srv-server` works directly.