### PR TITLE
fix(tests): de-flake DDSServiceTransportTests on aarch64 Linux CI

### DIFF
--- a/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
@@ -28,6 +28,11 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
     // Publication-match override (per topic). Used to drive `waitForService`.
     private var matchedTopics: Set<String> = []
 
+    // Pending `awaitWrite` callers waiting for the next write to a topic.
+    // Resumed eagerly from `writeRawCDR` so the test does not have to wait
+    // for the next 5 ms poll tick.
+    private var writeWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+
     func createSession(domainId: Int32, discoveryConfig: DDSBridgeDiscoveryConfig) throws {
         lock.lock()
         defer { lock.unlock() }
@@ -68,11 +73,16 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
     }
 
     func writeRawCDR(writer: any DDSWriterHandle, data: Data, timestamp: UInt64) throws {
-        lock.lock()
-        defer { lock.unlock() }
-        if let e = writeShouldThrow { throw e }
-        let topic = (writer as? MockDDSWriterHandle)?.topic ?? "<unknown>"
-        writes.append((topic, data, timestamp))
+        let waitersToWake: [CheckedContinuation<Void, Never>]
+        do {
+            lock.lock()
+            defer { lock.unlock() }
+            if let e = writeShouldThrow { throw e }
+            let topic = (writer as? MockDDSWriterHandle)?.topic ?? "<unknown>"
+            writes.append((topic, data, timestamp))
+            waitersToWake = writeWaiters.removeValue(forKey: topic) ?? []
+        }
+        for waiter in waitersToWake { waiter.resume() }
     }
 
     func destroyWriter(_ writer: any DDSWriterHandle) {
@@ -120,19 +130,65 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
     }
 
     /// Wait up to `timeout` for the next `writeRawCDR` to land on `topic`,
-    /// then return its bytes. Polls a short interval (5ms) so tests stay
-    /// responsive without hot-spinning. Returns `nil` only if the timeout
+    /// then return its bytes. Resumes eagerly the moment a write arrives —
+    /// `writeRawCDR` resumes any pending waiter — so the test does not pay
+    /// the latency of a poll tick. Returns `nil` only if the timeout
     /// elapsed without any new write.
     func awaitWrite(topic: String, timeout: Duration) async throws -> Data? {
         let initialCount = countWrites(topic: topic)
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while ContinuousClock.now < deadline {
-            if let bytes = lastWriteAfter(topic: topic, baseline: initialCount) {
-                return bytes
+
+        // Race a "next-write" continuation against a timeout sleep. Whichever
+        // wins first cancels the other. `waitForNextWrite` takes the baseline
+        // under-lock so a `writeRawCDR` racing with the registration is not
+        // lost. After the race, any still-registered waiter is drained so the
+        // cancelled wait task does not leak its CheckedContinuation.
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await self.waitForNextWrite(topic: topic, baseline: initialCount)
+                return true
             }
-            try await Task.sleep(nanoseconds: 5_000_000)
+            group.addTask {
+                // Cancellation = the write came first. Swallow & exit.
+                do {
+                    try await Task.sleep(for: timeout)
+                } catch {}
+                return false
+            }
+            let _ = await group.next()
+            group.cancelAll()
+            self.flushWriteWaiters(topic: topic)
+            await group.waitForAll()
+            return self.lastWriteAfter(topic: topic, baseline: initialCount)
         }
-        return lastWriteAfter(topic: topic, baseline: initialCount)
+    }
+
+    /// Suspend until a write past `baseline` has been recorded for `topic`.
+    /// The check + registration happen under `lock`, so a write that lands
+    /// concurrently with the call cannot slip past us.
+    private func waitForNextWrite(topic: String, baseline: Int) async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            let current = writes.reduce(into: 0) { acc, w in if w.topic == topic { acc += 1 } }
+            if current > baseline {
+                lock.unlock()
+                cont.resume()
+                return
+            }
+            writeWaiters[topic, default: []].append(cont)
+            lock.unlock()
+        }
+    }
+
+    /// Resume any waiters registered for `topic` without recording a write —
+    /// used to drain stale continuations after a timeout cancels the wait.
+    private func flushWriteWaiters(topic: String) {
+        let drained: [CheckedContinuation<Void, Never>]
+        do {
+            lock.lock()
+            defer { lock.unlock() }
+            drained = writeWaiters.removeValue(forKey: topic) ?? []
+        }
+        for waiter in drained { waiter.resume() }
     }
 
     /// Last write recorded on `topic`, or `nil` if no writes happened.

--- a/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
+++ b/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
@@ -33,9 +33,12 @@ final class DDSServiceTransportTests: XCTestCase {
 
         // Generous timeout: the server spawns a `Task` to run the user
         // handler asynchronously, then writes the reply. On heavily-loaded
-        // CI runners (notably Linux aarch64 under `swift test --parallel`)
-        // the cooperative scheduler can take seconds to dispatch that Task.
-        let written = try await client.awaitWrite(topic: "rr/echoReply", timeout: .seconds(10))
+        // CI runners (notably Linux aarch64 under `swift test --parallel`,
+        // running alongside the integration tests' real-DDS work) the
+        // cooperative scheduler has been observed to take >10 s to dispatch
+        // that Task. 30 s leaves comfortable headroom; `awaitWrite` itself
+        // returns the moment the write lands.
+        let written = try await client.awaitWrite(topic: "rr/echoReply", timeout: .seconds(30))
         let writtenBytes = try XCTUnwrap(written)
 
         XCTAssertEqual(received.value, userCDR)
@@ -62,9 +65,9 @@ final class DDSServiceTransportTests: XCTestCase {
         client.markPublicationsMatched(topic: "rq/echoRequest")
 
         let userRequest = Data([0x00, 0x01, 0x00, 0x00, 0xDE])
-        async let response: Data = svc.call(requestCDR: userRequest, timeout: .seconds(10))
+        async let response: Data = svc.call(requestCDR: userRequest, timeout: .seconds(30))
 
-        let writtenWire = try await client.awaitWrite(topic: "rq/echoRequest", timeout: .seconds(10))
+        let writtenWire = try await client.awaitWrite(topic: "rq/echoRequest", timeout: .seconds(30))
         let bytes = try XCTUnwrap(writtenWire)
         let (id, parsedReq) = try SampleIdentityPrefix.decode(wirePayload: bytes)
         XCTAssertEqual(parsedReq, userRequest)


### PR DESCRIPTION
## Summary

- `testServerEchoesRequest` flaked once on the `Ubuntu 24.04 aarch64 + ROS 2 rolling` matrix entry of [CI run 25254472767](https://github.com/youtalk/swift-ros2/actions/runs/25254472767/job/74051561870), hitting the 10 s `awaitWrite` timeout with no reply written. The server spawns `Task.detached(priority: .userInitiated)` to run the user handler then call `writeRawCDR`; on the GitHub Actions Arm partner runner, under `swift test --parallel` running alongside the integration tests' real CycloneDDS work, the cooperative scheduler can take >10 s to dispatch that detached task. A previous PR already bumped the timeout 1 s → 10 s and switched `Task { ... }` → `Task.detached(priority: .userInitiated)` for the same reason — that wasn't enough on this matrix entry.
- Two-part defensive improvement, mock-side only (no library behavior change):
  - `MockDDSClient.awaitWrite` now uses an eager `CheckedContinuation` wakeup instead of a 5 ms poll loop. `writeRawCDR` resumes any pending waiter the instant a write is recorded; the continuation is registered under-lock with a re-check of the baseline count so a racing write is not lost; after the timeout / wait race, any still-registered waiter is drained so the cancelled wait task does not leak.
  - `testServerEchoesRequest` and `testClientWritesPrefixedRequestAndAwaitsReply` raise their `awaitWrite` / `call` timeouts from 10 s → 30 s as defense-in-depth.

## Test plan

- [x] `swift build` clean on macOS arm64.
- [x] `swift format lint --strict --configuration .swift-format Package.swift Sources Tests` clean.
- [x] `swift test --parallel --filter SwiftROS2TransportTests` — all 62 tests pass; service tests now run in ≈0.12 s total instead of timing out near 30 s.
- [x] `swift test` full suite — 245 tests run, 0 failures (7 LINUX_IP-gated skips).
- [ ] Watch the `Ubuntu 24.04 aarch64 + ROS 2 rolling` job on this PR's CI run.