### PR TITLE
feat(windows): ship CycloneDDS via vcpkg + CYCLONEDDS_DIR (#37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,19 +221,22 @@ jobs:
         shell: bash
         run: |
           "$VCPKG_INSTALLATION_ROOT/vcpkg.exe" install cyclonedds:x64-windows
-          CYCLONEDDS_PREFIX="$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
+          # Forward-slash the path so the value Package.swift reads is
+          # uniform regardless of how Windows runners hand off env vars
+          # to bash. Backslashes survive `>> $GITHUB_ENV`, mixed
+          # separators trip up some tools.
+          CYCLONEDDS_PREFIX="${VCPKG_INSTALLATION_ROOT//\\//}/installed/x64-windows"
           echo "CYCLONEDDS_DIR=$CYCLONEDDS_PREFIX" >> "$GITHUB_ENV"
-          # Forward-slash path so $GITHUB_PATH appends cleanly on the
-          # bash runner; Windows accepts either separator at lookup time.
           echo "$CYCLONEDDS_PREFIX/bin" >> "$GITHUB_PATH"
       - name: Verify CycloneDDS install
         shell: bash
         run: |
+          echo "CYCLONEDDS_DIR=$CYCLONEDDS_DIR"
           ls "$CYCLONEDDS_DIR/include/dds/dds.h"
           ls "$CYCLONEDDS_DIR/lib/ddsc.lib"
           ls "$CYCLONEDDS_DIR/bin/ddsc.dll"
       - name: Build
-        run: swift build
+        run: swift build -v
       - name: Test
         run: swift test --parallel
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,26 +235,8 @@ jobs:
           ls "$CYCLONEDDS_DIR/include/dds/dds.h"
           ls "$CYCLONEDDS_DIR/lib/ddsc.lib"
           ls "$CYCLONEDDS_DIR/bin/ddsc.dll"
-      # Diagnostic — `swift package describe` runs the manifest once
-      # and prints the resolved target list. On Windows the DDS arm
-      # depends on `CYCLONEDDS_DIR`; this step verifies the env var
-      # actually reaches the manifest evaluator (and that CDDSBridge
-      # / SwiftROS2DDS land in the graph) before the build step.
-      - name: Describe package
-        shell: bash
-        run: swift package describe --type text 2>&1 | tee describe.txt
       - name: Build
-        shell: bash
-        run: swift build -v 2>&1 | tee build-log.txt
-      - name: Upload build log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-build-log
-          path: |
-            build-log.txt
-            describe.txt
-          if-no-files-found: ignore
+        run: swift build
       - name: Test
         run: swift test --parallel
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
           swift test --parallel
 
   build-windows:
-    name: Build & Test (Windows x86_64, Zenoh only)
+    name: Build & Test (Windows x86_64, Zenoh + DDS)
     needs: [swift-format]
     runs-on: windows-latest
     # Pin Swift 6.3.1 here (not 6.0.2 like macOS + Linux) because 6.0.2's
@@ -210,6 +210,28 @@ jobs:
           tag: 6.3.1-RELEASE
       - name: Swift version
         run: swift --version
+      # CycloneDDS via vcpkg (parallel to the Linux pkg-config + apt path).
+      # `windows-latest` ships vcpkg pre-installed at $VCPKG_INSTALLATION_ROOT.
+      # `cyclonedds:x64-windows` is dynamic (DLL + import lib) — `bin/`
+      # lands on PATH so ddsc.dll resolves at test runtime, and Package.swift
+      # reads CYCLONEDDS_DIR to wire `-I<dir>/include` + `-L<dir>/lib`
+      # into CDDSBridge. Without this step the manifest falls back to the
+      # 0.5.0–0.7.0 Zenoh-only Windows shape.
+      - name: Install CycloneDDS via vcpkg
+        shell: bash
+        run: |
+          "$VCPKG_INSTALLATION_ROOT/vcpkg.exe" install cyclonedds:x64-windows
+          CYCLONEDDS_PREFIX="$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
+          echo "CYCLONEDDS_DIR=$CYCLONEDDS_PREFIX" >> "$GITHUB_ENV"
+          # Forward-slash path so $GITHUB_PATH appends cleanly on the
+          # bash runner; Windows accepts either separator at lookup time.
+          echo "$CYCLONEDDS_PREFIX/bin" >> "$GITHUB_PATH"
+      - name: Verify CycloneDDS install
+        shell: bash
+        run: |
+          ls "$CYCLONEDDS_DIR/include/dds/dds.h"
+          ls "$CYCLONEDDS_DIR/lib/ddsc.lib"
+          ls "$CYCLONEDDS_DIR/bin/ddsc.dll"
       - name: Build
         run: swift build
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,8 +235,26 @@ jobs:
           ls "$CYCLONEDDS_DIR/include/dds/dds.h"
           ls "$CYCLONEDDS_DIR/lib/ddsc.lib"
           ls "$CYCLONEDDS_DIR/bin/ddsc.dll"
+      # Diagnostic — `swift package describe` runs the manifest once
+      # and prints the resolved target list. On Windows the DDS arm
+      # depends on `CYCLONEDDS_DIR`; this step verifies the env var
+      # actually reaches the manifest evaluator (and that CDDSBridge
+      # / SwiftROS2DDS land in the graph) before the build step.
+      - name: Describe package
+        shell: bash
+        run: swift package describe --type text 2>&1 | tee describe.txt
       - name: Build
-        run: swift build -v
+        shell: bash
+        run: swift build -v 2>&1 | tee build-log.txt
+      - name: Upload build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-build-log
+          path: |
+            build-log.txt
+            describe.txt
+          if-no-files-found: ignore
       - name: Test
         run: swift test --parallel
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **DDS on Windows** — full DDS path (CCycloneDDS, CDDSBridge, SwiftROS2DDS, the SwiftROS2 umbrella, the talker / listener / srv-server / srv-client examples, and the DDS / umbrella tests) now ships on Windows x86_64 when `CYCLONEDDS_DIR` points at a `vcpkg install cyclonedds:x64-windows` tree. Package.swift threads `-I<dir>/include` and `-L<dir>/lib` into CDDSBridge so `#include <dds/dds.h>` and the `-lddsc` link from the CCycloneDDS modulemap resolve against the vcpkg layout. `build-windows` CI now installs the vcpkg port, exports `CYCLONEDDS_DIR`, and runs the full `swift build` + `swift test --parallel`. (#37)
+
+### Changed
+- `Package.swift` Windows arm: `if !isWindowsBuild && !isAndroidBuild` gate replaced with a `canBuildDDS` flag that honors `CYCLONEDDS_DIR`. Without `CYCLONEDDS_DIR` the Windows arm keeps the 0.5.0–0.7.0 Zenoh-only shape; with it set, the umbrella + DDS targets join the build graph alongside the existing Zenoh path.
+
 ## [0.7.0] - 2026-05-01
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -10,11 +10,16 @@ import PackageDescription
 // build helper.
 //
 // CycloneDDS on Linux resolves through pkg-config; on Apple it ships
-// as a prebuilt xcframework. Windows and Android do not ship DDS —
-// the entire DDS path (cCycloneDDS, CDDSBridge, SwiftROS2DDS, the
-// SwiftROS2 umbrella, and the DDS/umbrella tests) is compiled out on
-// both platforms via the runtime `if !isWindowsBuild && !isAndroidBuild`
-// gate around the targets/products additions further down.
+// as a prebuilt xcframework. On Windows the DDS path opts in through a
+// `CYCLONEDDS_DIR` env var pointing at a vcpkg-installed CycloneDDS
+// tree (`vcpkg install cyclonedds:x64-windows`); the manifest then adds
+// `-I<dir>/include` and `-L<dir>/lib` to CDDSBridge so `#include
+// <dds/dds.h>` and `-lddsc` resolve. Without `CYCLONEDDS_DIR` the
+// Windows build keeps the existing Zenoh-only carve-out. Android does
+// not ship DDS at all — the entire DDS path (cCycloneDDS, CDDSBridge,
+// SwiftROS2DDS, the SwiftROS2 umbrella, and the DDS/umbrella tests) is
+// compiled out via the runtime `if canBuildDDS` gate around the
+// targets/products additions further down.
 //
 // Cross-compilation target detection. Plain `#if os(...)` at manifest
 // scope reflects the HOST, which breaks when cross-compiling from
@@ -53,6 +58,26 @@ let targetOS: String = {
 let isLinuxBuild = targetOS == "linux"
 let isWindowsBuild = targetOS == "windows"
 let isAndroidBuild = targetOS == "android"
+
+// Windows DDS opt-in. When `CYCLONEDDS_DIR` is set on a Windows build,
+// the manifest pulls in the full DDS path (CCycloneDDS / CDDSBridge /
+// SwiftROS2DDS / SwiftROS2 umbrella / examples / DDS tests) and wires
+// `-I<dir>/include` + `-L<dir>/lib` into CDDSBridge so `#include
+// <dds/dds.h>` and the `-lddsc` link emitted by the CCycloneDDS
+// modulemap both resolve against the vcpkg-installed CycloneDDS tree.
+// When unset, the Windows arm stays Zenoh-only — same shape as 0.5.0
+// through 0.7.0.
+let windowsCycloneDDSDir: String? = {
+    guard isWindowsBuild else { return nil }
+    guard let raw = Context.environment["CYCLONEDDS_DIR"] else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+}()
+
+// Whether the current target can build the CycloneDDS-based DDS path.
+// Apple (binary xcframework) and Linux (pkg-config) always can; Windows
+// can only when `CYCLONEDDS_DIR` is set; Android never can.
+let canBuildDDS = !isAndroidBuild && (!isWindowsBuild || windowsCycloneDDSDir != nil)
 
 let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.7.0"
 
@@ -223,18 +248,28 @@ var targets: [Target] = [
 ]
 
 // DDS path + the SwiftROS2 umbrella + examples + umbrella-level tests.
-// These are only included on platforms where CycloneDDS is consumable.
-// Windows and Android do not build CycloneDDS from source (SPM cannot
-// orchestrate the ddsrt CMake configure-time header generation), so
-// both platforms import SwiftROS2Zenoh directly instead of the
-// SwiftROS2 umbrella. DDS on Windows / Android is a future track.
-if !isWindowsBuild && !isAndroidBuild {
+// These are only included on platforms where CycloneDDS is consumable
+// (see `canBuildDDS` above): Apple via binary xcframework, Linux via
+// pkg-config, Windows via vcpkg + `CYCLONEDDS_DIR`. Android does not
+// ship DDS — `import SwiftROS2Zenoh` is the supported entry point
+// there. Windows builds without `CYCLONEDDS_DIR` set keep the same
+// Zenoh-only shape as 0.5.0 through 0.7.0.
+if canBuildDDS {
     let cCycloneDDS: Target = {
         if isLinuxBuild {
             return .systemLibrary(
                 name: "CCycloneDDS",
                 path: "Sources/CCycloneDDS",
                 pkgConfig: "CycloneDDS"
+            )
+        } else if isWindowsBuild {
+            // Windows uses the same modulemap + shim.h as Linux, but
+            // header / library search paths come from `CYCLONEDDS_DIR`
+            // (vcpkg) injected onto CDDSBridge below — there is no
+            // pkg-config in the picture.
+            return .systemLibrary(
+                name: "CCycloneDDS",
+                path: "Sources/CCycloneDDS"
             )
         } else {
             return .binaryTarget(
@@ -244,6 +279,22 @@ if !isWindowsBuild && !isAndroidBuild {
             )
         }
     }()
+
+    // CDDSBridge consumes `<dds/...>` headers via `#include` and links
+    // `ddsc` (the link directive lives in CCycloneDDS's modulemap). On
+    // Linux those flags come from pkg-config; on Apple they come from
+    // the xcframework. On Windows there is no automatic injection, so
+    // the manifest threads `-I<vcpkg>/include` and `-L<vcpkg>/lib`
+    // through `cSettings` / `linkerSettings` keyed off `CYCLONEDDS_DIR`.
+    // The unsafeFlags are gated on `isWindowsBuild` at manifest scope
+    // so non-Windows targets see no unsafe flags — that keeps the
+    // package consumable as an external SPM dependency on Apple/Linux.
+    var ddsBridgeCSettings: [CSetting] = [.define("DDS_AVAILABLE", to: "1")]
+    var ddsBridgeLinkerSettings: [LinkerSetting] = []
+    if isWindowsBuild, let dir = windowsCycloneDDSDir {
+        ddsBridgeCSettings.append(.unsafeFlags(["-I", "\(dir)/include"]))
+        ddsBridgeLinkerSettings.append(.unsafeFlags(["-L\(dir)/lib"]))
+    }
 
     products.append(contentsOf: [
         .library(name: "SwiftROS2", targets: ["SwiftROS2"]),
@@ -259,9 +310,8 @@ if !isWindowsBuild && !isAndroidBuild {
             path: "Sources/CDDSBridge",
             sources: ["dds_bridge.c", "raw_cdr_sertype.c", "raw_cdr_regression_bridge.c"],
             publicHeadersPath: "include",
-            cSettings: [
-                .define("DDS_AVAILABLE", to: "1")
-            ]
+            cSettings: ddsBridgeCSettings,
+            linkerSettings: ddsBridgeLinkerSettings
         ),
 
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -299,6 +299,14 @@ if canBuildDDS {
         // separators regardless of how `CYCLONEDDS_DIR` was exported.
         let normalizedDir = dir.replacingOccurrences(of: "\\", with: "/")
         ddsBridgeCSettings.append(.unsafeFlags(["-I\(normalizedDir)/include"]))
+        // CycloneDDS's `dds/ddsrt/misc.h` defines `DDSRT_WARNING_MSVC_OFF(x)`
+        // as `__pragma(warning(disable: ## x))`. The `##` token-paste
+        // glues `:` and the warning number into `:4146`, which MSVC
+        // accepts but clang rejects with `error: pasting formed ':4146',
+        // an invalid preprocessing token [-Winvalid-token-paste]`.
+        // Swift on Windows ships clang.exe, so the headers refuse to
+        // parse without this suppression.
+        ddsBridgeCSettings.append(.unsafeFlags(["-Wno-invalid-token-paste"]))
         ddsBridgeLinkerSettings.append(.unsafeFlags(["-L\(normalizedDir)/lib"]))
         ddsBridgeLinkerSettings.append(.linkedLibrary("ddsc"))
     }

--- a/Package.swift
+++ b/Package.swift
@@ -281,19 +281,26 @@ if canBuildDDS {
     }()
 
     // CDDSBridge consumes `<dds/...>` headers via `#include` and links
-    // `ddsc` (the link directive lives in CCycloneDDS's modulemap). On
-    // Linux those flags come from pkg-config; on Apple they come from
-    // the xcframework. On Windows there is no automatic injection, so
-    // the manifest threads `-I<vcpkg>/include` and `-L<vcpkg>/lib`
-    // through `cSettings` / `linkerSettings` keyed off `CYCLONEDDS_DIR`.
-    // The unsafeFlags are gated on `isWindowsBuild` at manifest scope
-    // so non-Windows targets see no unsafe flags — that keeps the
-    // package consumable as an external SPM dependency on Apple/Linux.
+    // `ddsc`. On Linux those flags come from pkg-config; on Apple they
+    // come from the xcframework. On Windows the manifest threads
+    // `-I<vcpkg>/include` + `-L<vcpkg>/lib` through `cSettings` /
+    // `linkerSettings` keyed off `CYCLONEDDS_DIR`, plus an explicit
+    // `.linkedLibrary("ddsc")` (the modulemap's `link "ddsc"` directive
+    // only fires when something does `import CCycloneDDS` from Swift,
+    // and nobody in this package does — CDDSBridge reaches CycloneDDS
+    // through plain `#include`). The unsafeFlags are gated on
+    // `isWindowsBuild` at manifest scope so non-Windows targets see no
+    // unsafe flags — that keeps the package consumable as an external
+    // SPM dependency on Apple/Linux.
     var ddsBridgeCSettings: [CSetting] = [.define("DDS_AVAILABLE", to: "1")]
     var ddsBridgeLinkerSettings: [LinkerSetting] = []
     if isWindowsBuild, let dir = windowsCycloneDDSDir {
-        ddsBridgeCSettings.append(.unsafeFlags(["-I", "\(dir)/include"]))
-        ddsBridgeLinkerSettings.append(.unsafeFlags(["-L\(dir)/lib"]))
+        // Forward-slash the path so clang on Windows sees uniform
+        // separators regardless of how `CYCLONEDDS_DIR` was exported.
+        let normalizedDir = dir.replacingOccurrences(of: "\\", with: "/")
+        ddsBridgeCSettings.append(.unsafeFlags(["-I\(normalizedDir)/include"]))
+        ddsBridgeLinkerSettings.append(.unsafeFlags(["-L\(normalizedDir)/lib"]))
+        ddsBridgeLinkerSettings.append(.linkedLibrary("ddsc"))
     }
 
     products.append(contentsOf: [

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Bringing ROS 2 to a phone, headset, or laptop usually means cross-compiling `rcl
 ## Features
 
 - **Dual transport.** `SwiftROS2Zenoh` talks to `rmw_zenoh_cpp`; `SwiftROS2DDS` talks to `rmw_cyclonedds_cpp`. Switch transports with a single `TransportConfig` change.
-- **No `rcl` dependency.** Wire-level publish / subscribe means no `rcl`, no `rclcpp`, no Python / colcon, no `rmw_*` shim layer — and no transitive build of FastDDS or CycloneDDS from source on the consumer side (Apple targets get xcframeworks; Linux gets a `pkg-config` lookup; Windows / Android stay Zenoh-only for now).
+- **No `rcl` dependency.** Wire-level publish / subscribe means no `rcl`, no `rclcpp`, no Python / colcon, no `rmw_*` shim layer — and no transitive build of FastDDS or CycloneDDS from source on the consumer side (Apple targets get xcframeworks; Linux gets a `pkg-config` lookup; Windows resolves CycloneDDS through `vcpkg`; Android stays Zenoh-only for now).
 - **Swift-native API.** `async`/`await` everywhere, `AsyncStream` subscriptions, `Sendable` conformance, structured concurrency, no opaque pointer juggling above the FFI seam.
 - **Pre-built Apple binaries.** `CZenohPico.xcframework` + `CCycloneDDS.xcframework` are attached to every GitHub Release. `swift build` downloads them in seconds — no CMake, no local bootstrap, no Apple-side codesigning dance.
-- **Source build everywhere else.** Linux, Windows, and Android compile `zenoh-pico` from `vendor/` via SwiftPM directly, each picking the matching backend (`unix` / `windows`). CycloneDDS comes from `pkg-config` on Linux. No vendored prebuilts needed.
+- **Source build everywhere else.** Linux, Windows, and Android compile `zenoh-pico` from `vendor/` via SwiftPM directly, each picking the matching backend (`unix` / `windows`). CycloneDDS comes from `pkg-config` on Linux and `vcpkg` on Windows. No vendored prebuilts needed.
 - **Multi-distro wire format.** Humble, Jazzy, Kilted, Rolling. Select via `ROS2Distro` on `ROS2Context`; Zenoh defaults to Jazzy when unspecified. Schema differences (e.g. `sensor_msgs/Range` gaining `variance` after Humble) are gated automatically through `isLegacySchema`.
 - **23 built-in message types** spanning `sensor_msgs`, `geometry_msgs`, `std_msgs`, `audio_common_msgs`, and `tf2_msgs`. Pure-Swift XCDR v1 encoder + decoder cover both the publish and subscribe paths.
 - **Services** (Server / Client) — `rclcpp` / `rclpy`-shaped API with full Humble / Jazzy / Kilted / Rolling reach over Zenoh and DDS.
@@ -41,7 +41,7 @@ Bringing ROS 2 to a phone, headset, or laptop usually means cross-compiling `rcl
 | Mac Catalyst          | 16.0                                           | `binaryTarget` xcframework                          | Zenoh + DDS    | (covered by `build-macos` Swift compile) | `maccatalyst`                        |
 | visionOS              | 1.0                                            | `binaryTarget` xcframework                          | Zenoh + DDS    | (covered by `build-macos` Swift compile) | `xros` + `xrsimulator`               |
 | Linux                 | Ubuntu 22.04 / 24.04 (x86_64, aarch64)         | `zenoh-pico` source build + `pkg-config` for DDS    | Zenoh + DDS    | `build-linux` (×6: 3 distros × 2 arches)  | n/a (source build)                   |
-| Windows               | Windows 10 / 11 (x86_64)                       | `zenoh-pico` source build (Winsock + Iphlpapi)      | Zenoh only     | `build-windows`                       | n/a (source build)                   |
+| Windows               | Windows 10 / 11 (x86_64)                       | `zenoh-pico` source build (Winsock + Iphlpapi) + `vcpkg` for DDS | Zenoh + DDS    | `build-windows`                       | n/a (source build)                   |
 | Android               | API 28+ (arm64-v8a, x86_64)                    | `zenoh-pico` source build (Bionic, unix backend)    | Zenoh only     | `build-android` (×2 ABIs)             | n/a (source build)                   |
 
 The `build-macos` job runs `swift build` / `swift test` on `macos-15`, which compiles the Swift sources for the macOS host only — that proves the Swift code compiles against the Apple toolchain, but it does *not* drive `xcodebuild` against `iphoneos` / `iphonesimulator` / `maccatalyst` / `xros` / `xrsimulator` destinations. Those non-host Apple slices are built end-to-end only by the [`release-xcframework.yml`](.github/workflows/release-xcframework.yml) workflow at tag time, which produces the `CZenohPico.xcframework` + `CCycloneDDS.xcframework` zips attached to each GitHub release. Per-push runtime validation on iOS / visionOS / Mac Catalyst comes from [Conduit](https://apps.apple.com/app/id6757171237) — the 10K+ developer production user — rather than CI.
@@ -100,23 +100,33 @@ swift test                                    # 69 pass, 2 LINUX_IP-gated skips
 
 ### Windows
 
-Windows ships Zenoh only; the DDS path is currently excluded from the Windows build graph (SwiftPM cannot orchestrate CycloneDDS's `ddsrt` CMake configure-time header generation, and no usable prebuilt path exists yet — see [Roadmap](#roadmap)).
+Windows supports both transports. Zenoh builds `vendor/zenoh-pico` from source (no extra setup); DDS resolves CycloneDDS through [vcpkg](https://vcpkg.io) — install the port once and point `CYCLONEDDS_DIR` at the install tree before `swift build`. Without `CYCLONEDDS_DIR`, the manifest stays Zenoh-only (same shape as 0.5.0–0.7.0).
+
+```powershell
+# One-time CycloneDDS install via vcpkg.
+vcpkg install cyclonedds:x64-windows
+
+# Each shell that runs `swift build` needs CYCLONEDDS_DIR pointed at the
+# vcpkg install tree, plus bin/ on PATH so ddsc.dll resolves at runtime.
+$env:CYCLONEDDS_DIR = "$env:VCPKG_ROOT\installed\x64-windows"
+$env:Path = "$env:CYCLONEDDS_DIR\bin;$env:Path"
+```
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.6.0"),
+    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.8.0"),
 ],
 targets: [
     .target(
         name: "YourApp",
         dependencies: [
-            .product(name: "SwiftROS2Zenoh", package: "swift-ros2"),    // umbrella isn't built on Windows
+            .product(name: "SwiftROS2", package: "swift-ros2"),
         ]
     ),
 ]
 ```
 
-Requires Swift 6.3.1. No `setup.bash` or `PKG_CONFIG_PATH` step — `swift build` handles the `zenoh-pico` source build automatically.
+Requires Swift 6.3.1. No `setup.bash` or `PKG_CONFIG_PATH` step — `swift build` reads `CYCLONEDDS_DIR` and threads `-I<dir>/include` + `-L<dir>/lib` into CDDSBridge directly.
 
 ### Android (cross-compile from macOS or Linux)
 
@@ -149,7 +159,7 @@ import SwiftROS2Zenoh    // the SwiftROS2 umbrella isn't built on Android — sa
 
 ## Quick Start
 
-> **Windows / Android note:** the examples below use the `SwiftROS2` umbrella, which is excluded from those platforms. Use `SwiftROS2Zenoh.ZenohClient` directly for the Zenoh path; the high-level `ROS2Context` / `ROS2Node` wrappers land on Windows and Android when DDS does (see [Roadmap](#roadmap)).
+> **Android note:** the examples below use the `SwiftROS2` umbrella, which is excluded on Android (Windows now ships the umbrella when `CYCLONEDDS_DIR` is set, see above). Use `SwiftROS2Zenoh.ZenohClient` directly on Android; the high-level `ROS2Context` / `ROS2Node` wrappers land there when DDS does (see [Roadmap](#roadmap)).
 
 ### Publish an IMU message over Zenoh
 
@@ -302,7 +312,7 @@ Past releases shipped roughly one breaking platform / transport / API change per
 
 ### Medium-term
 
-- **DDS on Windows / Android** — currently blocked on SwiftPM not orchestrating CycloneDDS's `ddsrt` CMake-configure-time header generation. Likely path: prebuilt `.artifactbundle` distribution for both targets, similar to the Apple xcframeworks but in the SPM artifact-bundle format.
+- **DDS on Android** — currently blocked on SwiftPM not orchestrating CycloneDDS's `ddsrt` CMake-configure-time header generation under the Android NDK toolchain. Likely path: prebuilt `.artifactbundle` distribution for Android, similar to the Apple xcframeworks but in the SPM artifact-bundle format. (DDS on Windows landed in 0.8.0 via the `vcpkg` + `CYCLONEDDS_DIR` approach.)
 - **XCDR2 wire format** — only XCDR v1 is implemented today. XCDR v2 is required for some Rolling-era message types. Additive (new init flag on `CDRDecoder`).
 - **Richer QoS profiles** — `.servicesDefault`, `.parameters`, `.systemDefault` to match `rcl`. Today any non-default QoS knob has to be set by hand on the underlying `TransportConfig`.
 

--- a/Sources/SwiftROS2/Documentation.docc/SwiftROS2.md
+++ b/Sources/SwiftROS2/Documentation.docc/SwiftROS2.md
@@ -10,7 +10,7 @@ aarch64), Windows (x86_64), and Android (arm64-v8a, x86_64). It speaks two
 transports natively:
 
 - **Zenoh** — interoperates with `rmw_zenoh_cpp`. Ships on every supported platform.
-- **DDS** — interoperates with `rmw_cyclonedds_cpp`. Apple platforms + Linux only.
+- **DDS** — interoperates with `rmw_cyclonedds_cpp`. Apple platforms, Linux, and Windows (Android still pending).
 
 ## Topics
 


### PR DESCRIPTION
Drop the !isWindowsBuild gate on the DDS path: when CYCLONEDDS_DIR
points at a `vcpkg install cyclonedds:x64-windows` tree, Package.swift
now pulls CCycloneDDS / CDDSBridge / SwiftROS2DDS / the SwiftROS2
umbrella / talker / listener / srv-server / srv-client / DDS+umbrella
tests into the Windows build graph and threads `-I<dir>/include` plus
`-L<dir>/lib` into CDDSBridge so `#include <dds/dds.h>` and the
`-lddsc` link emitted by the CCycloneDDS modulemap resolve against
the vcpkg layout.

Without CYCLONEDDS_DIR the Windows arm keeps the 0.5.0–0.7.0
Zenoh-only shape, so existing consumers do not regress. The
unsafeFlags wiring is gated on `isWindowsBuild` at manifest scope,
which keeps Apple/Linux external-package consumption clean (no
unsafe flags surface on those manifests).

build-windows CI installs the vcpkg port, exports CYCLONEDDS_DIR,
and adds the CycloneDDS bin/ directory to PATH so ddsc.dll resolves
at swift test runtime, then runs the full `swift build` +
`swift test --parallel` (no longer a Zenoh-only carve-out).

README, DocC catalog, and CHANGELOG updated to drop the
"DDS pending on Windows" caveat.

https://claude.ai/code/session_01QWo8NCdi1YUu8tG7yQaK7S