### PR TITLE
chore(msgs): drop unused import Foundation from built-in message files

### DIFF
--- a/Sources/SwiftROS2Messages/BuiltinMessages/GeometryMsgs/GeometryMsgs.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/GeometryMsgs/GeometryMsgs.swift
@@ -1,7 +1,6 @@
 // GeometryMsgs.swift
 // geometry_msgs stamped types
 
-import Foundation
 import SwiftROS2CDR
 
 /// geometry_msgs/msg/TwistStamped

--- a/Sources/SwiftROS2Messages/BuiltinMessages/GeometryMsgs/TFMessage.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/GeometryMsgs/TFMessage.swift
@@ -1,7 +1,6 @@
 // TFMessage.swift
 // tf2_msgs/msg/TFMessage
 
-import Foundation
 import SwiftROS2CDR
 
 /// tf2_msgs/msg/TFMessage

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/BatteryState.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/BatteryState.swift
@@ -1,7 +1,6 @@
 // BatteryState.swift
 // sensor_msgs/msg/BatteryState
 
-import Foundation
 import SwiftROS2CDR
 
 /// sensor_msgs/msg/BatteryState

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/CameraInfo.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/CameraInfo.swift
@@ -1,7 +1,6 @@
 // CameraInfo.swift
 // sensor_msgs/msg/CameraInfo
 
-import Foundation
 import SwiftROS2CDR
 
 /// sensor_msgs/msg/CameraInfo

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/FluidPressure.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/FluidPressure.swift
@@ -1,7 +1,6 @@
 // FluidPressure.swift
 // sensor_msgs/msg/FluidPressure
 
-import Foundation
 import SwiftROS2CDR
 
 /// sensor_msgs/msg/FluidPressure

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/Illuminance.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/Illuminance.swift
@@ -1,7 +1,6 @@
 // Illuminance.swift
 // sensor_msgs/msg/Illuminance
 
-import Foundation
 import SwiftROS2CDR
 
 /// sensor_msgs/msg/Illuminance

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/Imu.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/Imu.swift
@@ -1,7 +1,6 @@
 // Imu.swift
 // sensor_msgs/msg/Imu
 
-import Foundation
 import SwiftROS2CDR
 
 /// sensor_msgs/msg/Imu

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/Joy.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/Joy.swift
@@ -1,7 +1,6 @@
 // Joy.swift
 // sensor_msgs/msg/Joy
 
-import Foundation
 import SwiftROS2CDR
 
 /// sensor_msgs/msg/Joy

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/MagneticField.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/MagneticField.swift
@@ -1,7 +1,6 @@
 // MagneticField.swift
 // sensor_msgs/msg/MagneticField
 
-import Foundation
 import SwiftROS2CDR
 
 /// sensor_msgs/msg/MagneticField

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/NavSatFix.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/NavSatFix.swift
@@ -1,7 +1,6 @@
 // NavSatFix.swift
 // sensor_msgs/msg/NavSatFix
 
-import Foundation
 import SwiftROS2CDR
 
 /// sensor_msgs/msg/NavSatStatus

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/PointField.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/PointField.swift
@@ -1,7 +1,6 @@
 // PointField.swift
 // sensor_msgs/msg/PointField
 
-import Foundation
 import SwiftROS2CDR
 
 /// PointField data types

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/Range.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/Range.swift
@@ -1,7 +1,6 @@
 // Range.swift
 // sensor_msgs/msg/Range
 
-import Foundation
 import SwiftROS2CDR
 
 /// sensor_msgs/msg/Range

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/RegionOfInterest.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/RegionOfInterest.swift
@@ -1,7 +1,6 @@
 // RegionOfInterest.swift
 // sensor_msgs/RegionOfInterest
 
-import Foundation
 import SwiftROS2CDR
 
 /// sensor_msgs/RegionOfInterest

--- a/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/Temperature.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/SensorMsgs/Temperature.swift
@@ -1,7 +1,6 @@
 // Temperature.swift
 // sensor_msgs/msg/Temperature
 
-import Foundation
 import SwiftROS2CDR
 
 /// sensor_msgs/msg/Temperature

--- a/Sources/SwiftROS2Messages/BuiltinMessages/StdMsgs/StdMsgs.swift
+++ b/Sources/SwiftROS2Messages/BuiltinMessages/StdMsgs/StdMsgs.swift
@@ -1,7 +1,6 @@
 // StdMsgs.swift
 // std_msgs basic types
 
-import Foundation
 import SwiftROS2CDR
 
 /// std_msgs/msg/String


### PR DESCRIPTION
Mechanical sweep across Sources/SwiftROS2Messages/BuiltinMessages/** to
remove import Foundation from files that don't reference any Foundation
type, restoring symmetry with the BuiltinServices/ files cleaned up in
PR #52.

Files retaining import Foundation actually use Foundation types:
- CommonTypes.swift (Date)
- MessageProtocol.swift (LocalizedError)
- AudioData.swift, CompressedImage.swift, Image.swift, PointCloud2.swift (Data)

Closes #54.

https://claude.ai/code/session_01NpZj5r1BtsNYso5P8SRZ28