### PR TITLE
fix(tests): eliminate awaitWrite baseline race in MockDDSClient

### DIFF
--- a/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
@@ -129,22 +129,22 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
         deliver(toTopic: topic, data: wire, timestamp: timestamp)
     }
 
-    /// Wait up to `timeout` for the next `writeRawCDR` to land on `topic`,
-    /// then return its bytes. Resumes eagerly the moment a write arrives —
-    /// `writeRawCDR` resumes any pending waiter — so the test does not pay
-    /// the latency of a poll tick. Returns `nil` only if the timeout
-    /// elapsed without any new write.
+    /// Wait up to `timeout` for a `writeRawCDR` on `topic`. If one has
+    /// already landed by the time this is called, it is returned immediately;
+    /// otherwise the call suspends until the next write arrives or the
+    /// timeout elapses. `writeRawCDR` resumes any pending waiter eagerly, so
+    /// there is no poll latency. Returns `nil` only if the timeout elapsed
+    /// without any write to `topic`.
+    ///
+    /// Tests call this at most once per topic, so "latest write or wait for
+    /// first" semantics match the intent. A baseline-vs-count scheme races
+    /// with eagerly-scheduled writer tasks (the writer can land on another
+    /// thread before the baseline is captured, leaving the waiter blocked
+    /// forever) — see PR fixing the x86_64 jazzy CI flake.
     func awaitWrite(topic: String, timeout: Duration) async throws -> Data? {
-        let initialCount = countWrites(topic: topic)
-
-        // Race a "next-write" continuation against a timeout sleep. Whichever
-        // wins first cancels the other. `waitForNextWrite` takes the baseline
-        // under-lock so a `writeRawCDR` racing with the registration is not
-        // lost. After the race, any still-registered waiter is drained so the
-        // cancelled wait task does not leak its CheckedContinuation.
         return await withTaskGroup(of: Bool.self) { group in
             group.addTask {
-                await self.waitForNextWrite(topic: topic, baseline: initialCount)
+                await self.waitUntilWriteExists(topic: topic)
                 return true
             }
             group.addTask {
@@ -158,18 +158,17 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
             group.cancelAll()
             self.flushWriteWaiters(topic: topic)
             await group.waitForAll()
-            return self.lastWriteAfter(topic: topic, baseline: initialCount)
+            return self.lastWritten(topic: topic)
         }
     }
 
-    /// Suspend until a write past `baseline` has been recorded for `topic`.
-    /// The check + registration happen under `lock`, so a write that lands
+    /// Suspend until at least one write to `topic` has been recorded. The
+    /// check + registration happen under `lock`, so a write that lands
     /// concurrently with the call cannot slip past us.
-    private func waitForNextWrite(topic: String, baseline: Int) async {
+    private func waitUntilWriteExists(topic: String) async {
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
             lock.lock()
-            let current = writes.reduce(into: 0) { acc, w in if w.topic == topic { acc += 1 } }
-            if current > baseline {
+            if writes.contains(where: { $0.topic == topic }) {
                 lock.unlock()
                 cont.resume()
                 return
@@ -211,22 +210,6 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
         defer { lock.unlock() }
         guard let mock = writer as? MockDDSWriterHandle else { return false }
         return matchedTopics.contains(mock.topic)
-    }
-
-    // MARK: - private helpers
-
-    private func countWrites(topic: String) -> Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return writes.reduce(into: 0) { acc, w in if w.topic == topic { acc += 1 } }
-    }
-
-    private func lastWriteAfter(topic: String, baseline: Int) -> Data? {
-        lock.lock()
-        defer { lock.unlock() }
-        let matching = writes.filter { $0.topic == topic }
-        guard matching.count > baseline else { return nil }
-        return matching.last?.data
     }
 }
 

--- a/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
@@ -142,7 +142,12 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
     /// thread before the baseline is captured, leaving the waiter blocked
     /// forever) — see PR fixing the x86_64 jazzy CI flake.
     func awaitWrite(topic: String, timeout: Duration) async throws -> Data? {
-        return await withTaskGroup(of: Bool.self) { group in
+        // Returns true iff the write-watcher arm won the race; only then is
+        // the recorded write within the timeout boundary and safe to return.
+        // If the sleep arm wins first, return nil even if a late write lands
+        // before `lastWritten` runs — otherwise tests would silently pass on
+        // post-deadline writes and the timeout assertion becomes a lie.
+        let writeWon = await withTaskGroup(of: Bool.self) { group in
             group.addTask {
                 await self.waitUntilWriteExists(topic: topic)
                 return true
@@ -154,12 +159,13 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
                 } catch {}
                 return false
             }
-            let _ = await group.next()
+            let winner = await group.next() ?? false
             group.cancelAll()
             self.flushWriteWaiters(topic: topic)
             await group.waitForAll()
-            return self.lastWritten(topic: topic)
+            return winner
         }
+        return writeWon ? lastWritten(topic: topic) : nil
     }
 
     /// Suspend until at least one write to `topic` has been recorded. The

--- a/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
+++ b/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
@@ -61,7 +61,11 @@ final class DDSServiceTransportTests: XCTestCase {
         client.markPublicationsMatched(topic: "rq/echoRequest")
 
         let userRequest = Data([0x00, 0x01, 0x00, 0x00, 0xDE])
-        async let response: Data = svc.call(requestCDR: userRequest, timeout: .seconds(5))
+        // svc.call's timeout covers both the outgoing-request write and the
+        // test-driven reply injection below. Keep it well above the
+        // awaitWrite budget so a slow request write cannot time the call out
+        // before this test gets to deliver the reply.
+        async let response: Data = svc.call(requestCDR: userRequest, timeout: .seconds(30))
 
         let writtenWire = try await client.awaitWrite(topic: "rq/echoRequest", timeout: .seconds(5))
         let bytes = try XCTUnwrap(writtenWire)

--- a/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
+++ b/Tests/SwiftROS2TransportTests/ServiceTransportTests.swift
@@ -31,14 +31,10 @@ final class DDSServiceTransportTests: XCTestCase {
 
         try await client.deliverToReader(topic: "rq/echoRequest", wire: wire, timestamp: 1_000)
 
-        // Generous timeout: the server spawns a `Task` to run the user
-        // handler asynchronously, then writes the reply. On heavily-loaded
-        // CI runners (notably Linux aarch64 under `swift test --parallel`,
-        // running alongside the integration tests' real-DDS work) the
-        // cooperative scheduler has been observed to take >10 s to dispatch
-        // that Task. 30 s leaves comfortable headroom; `awaitWrite` itself
-        // returns the moment the write lands.
-        let written = try await client.awaitWrite(topic: "rr/echoReply", timeout: .seconds(30))
+        // The server runs the handler on a `Task.detached` so the reply may
+        // already have landed by the time we ask for it; `awaitWrite` returns
+        // immediately if so, otherwise suspends until the write arrives.
+        let written = try await client.awaitWrite(topic: "rr/echoReply", timeout: .seconds(5))
         let writtenBytes = try XCTUnwrap(written)
 
         XCTAssertEqual(received.value, userCDR)
@@ -65,9 +61,9 @@ final class DDSServiceTransportTests: XCTestCase {
         client.markPublicationsMatched(topic: "rq/echoRequest")
 
         let userRequest = Data([0x00, 0x01, 0x00, 0x00, 0xDE])
-        async let response: Data = svc.call(requestCDR: userRequest, timeout: .seconds(30))
+        async let response: Data = svc.call(requestCDR: userRequest, timeout: .seconds(5))
 
-        let writtenWire = try await client.awaitWrite(topic: "rq/echoRequest", timeout: .seconds(30))
+        let writtenWire = try await client.awaitWrite(topic: "rq/echoRequest", timeout: .seconds(5))
         let bytes = try XCTUnwrap(writtenWire)
         let (id, parsedReq) = try SampleIdentityPrefix.decode(wirePayload: bytes)
         XCTAssertEqual(parsedReq, userRequest)


### PR DESCRIPTION
## Summary

`DDSServiceTransportTests.testServerEchoesRequest` timed out at 30s on
Ubuntu 24.04 x86_64 + jazzy CI ([failing run](https://github.com/youtalk/swift-ros2/actions/runs/25261960072/job/74070643853)).
Two prior fix attempts (#70 added `Task.detached(priority: .userInitiated)`,
#71 added eager continuation + 10s → 30s timeout bump) treated this as
cooperative-scheduler starvation; the symptom kept moving across
architectures because the actual defect is in the mock.

## Root cause

`MockDDSClient.awaitWrite` captured `initialCount = countWrites(topic:)`
*after* the server's `Task.detached` could already have landed its
`writeRawCDR` on another worker thread. Once `baseline = 1`,
`waitForNextWrite` waited for `count > 1` (which never comes), and on
timeout `lastWriteAfter(baseline: 1)` returned `nil` because
`matching.count == baseline`. `XCTUnwrap` then failed.

## Fix

Drop the baseline-vs-count scheme. `awaitWrite` now returns the latest
recorded write to the topic, or suspends on a continuation until one
arrives. Each test calls `awaitWrite` at most once per topic, so the new
semantics match intent and remove the race entirely. Inflated 30s
timeouts shrink back to 5s.

## Test plan

- [x] `swift test --filter SwiftROS2TransportTests` — 62/62 pass
- [x] `swift test --filter DDSServiceTransportTests/testServerEchoesRequest` — 10× consecutive pass at ~1ms each
- [x] `swift format lint --strict` clean
- [ ] CI matrix (Ubuntu 22.04/24.04 × x86_64/aarch64 × humble/jazzy/rolling) green