### PR TITLE
feat(transport): DDS action server / client (phase 4 of 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `TransportSession.createActionServer(...)` / `createActionClient(...)` requirements with `unsupportedFeature`-throwing default implementations so Phases 4 / 5 can land in either order.
   - `TransportError`: new `goalRejected`, `goalUnknown`, `actionServerUnavailable` cases.
   - 14 new transport-tests cover the actor's full state machine and the default-impl throws.
+- **ROS 2 Actions — DDS transport (phase 4 of 6, targeting 0.8.0).**
+  - `DDSTransportSession.createActionServer(...)` and `createActionClient(...)` overrides — full server / client over rmw_cyclonedds-style rq/rr/rt topics. Reuses the existing service-pair and pub/sub primitives; no new C-bridge surface.
+  - `DDSTransportActionServerImpl`: 3 service-pair handlers (`send_goal`, `cancel_goal`, `get_result`) + 2 publishers (`feedback`, `status`). Status topic uses `transient_local` depth 1 (matches rclcpp). `publishFeedback(goalId:feedbackCDR:)` and `publishStatus(entries:)` are the server-to-stream entry points.
+  - `DDSTransportActionClientImpl`: 3 service-pair clients + 2 subscribers, with goal_id filtering on the shared `feedback` and `status` topics — each incoming frame is decoded, the goal_id extracted, and the matching `ActionPendingTable` entry yielded.
+  - `ActionFrameDecoder` (internal): pure CDR helpers for the synthesized wrapper frames (encode/decode for `SendGoal{Request,Response}`, `GetResult{Request,Response}`, `FeedbackMessage`, `GoalStatusArray`). 8 round-trip + bounds tests.
+  - `MockDDSClient` (test scope): new `serviceReplyHandler` closure + `deliverRequestSample` / `deliverSubscriberSample` test helpers, lets DDS action tests drive end-to-end flows in-process.
+  - 9 new transport-tests cover server-side dispatch, client-side acceptance / rejection / result / cancel, goal-id filtering, and close-walk lifecycle.
 - **DDS on Windows** — full DDS path (CCycloneDDS, CDDSBridge, SwiftROS2DDS, the SwiftROS2 umbrella, the talker / listener / srv-server / srv-client examples, and the DDS / umbrella tests) now ships on Windows x86_64 when `CYCLONEDDS_DIR` points at a `vcpkg install cyclonedds:x64-windows` tree. Package.swift threads `-I<dir>/include` and `-L<dir>/lib` into CDDSBridge so `#include <dds/dds.h>` and the `-lddsc` link from the CCycloneDDS modulemap resolve against the vcpkg layout. `build-windows` CI now installs the vcpkg port, exports `CYCLONEDDS_DIR`, and runs the full `swift build` + `swift test --parallel`. (#37)
 
 ### Changed

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Action.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Action.swift
@@ -47,35 +47,71 @@ extension DDSTransportSession {
             ))
 
         // Reply writers for the three services.
-        let sendGoalReplyWriter = try client.createRawWriter(
-            topicName: names.sendGoalReplyTopic,
-            typeName: names.sendGoalReplyTypeName,
-            qos: cfg,
-            userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalResponse)
+        // Build all writers + readers under a rollback guard so a partial
+        // failure tears down every entity already created. Without this,
+        // a throw on the last writer would leak the previous four (and a
+        // throw mid-readers would leak readers in addition to the writers).
+        var createdWriters: [any DDSWriterHandle] = []
+        var createdReaders: [any DDSReaderHandle] = []
+
+        func rollbackAndThrow(_ error: Error) throws -> Never {
+            for r in createdReaders { client.destroyReader(r) }
+            for w in createdWriters { client.destroyWriter(w) }
+            if let e = error as? DDSError {
+                throw TransportError.subscriberCreationFailed(e.errorDescription ?? "\(e)")
+            }
+            throw error
+        }
+
+        func makeWriter(
+            topic: String, type: String, qosCfg: DDSBridgeQoSConfig, userData: String?
+        ) throws -> any DDSWriterHandle {
+            do {
+                let w = try client.createRawWriter(
+                    topicName: topic, typeName: type, qos: qosCfg, userData: userData
+                )
+                createdWriters.append(w)
+                return w
+            } catch {
+                try rollbackAndThrow(error)
+            }
+        }
+
+        func makeReader(
+            topic: String, type: String, qosCfg: DDSBridgeQoSConfig, userData: String?,
+            handler: @escaping @Sendable (Data, UInt64) -> Void
+        ) throws -> any DDSReaderHandle {
+            do {
+                let r = try client.createRawReader(
+                    topicName: topic, typeName: type, qos: qosCfg,
+                    userData: userData, handler: handler
+                )
+                createdReaders.append(r)
+                return r
+            } catch {
+                try rollbackAndThrow(error)
+            }
+        }
+
+        let sendGoalReplyWriter = try makeWriter(
+            topic: names.sendGoalReplyTopic, type: names.sendGoalReplyTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalResponse)
         )
-        let cancelGoalReplyWriter = try client.createRawWriter(
-            topicName: names.cancelGoalReplyTopic,
-            typeName: names.cancelGoalReplyTypeName,
-            qos: cfg,
-            userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalResponse)
+        let cancelGoalReplyWriter = try makeWriter(
+            topic: names.cancelGoalReplyTopic, type: names.cancelGoalReplyTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalResponse)
         )
-        let getResultReplyWriter = try client.createRawWriter(
-            topicName: names.getResultReplyTopic,
-            typeName: names.getResultReplyTypeName,
-            qos: cfg,
-            userData: codec.userDataString(typeHash: roleTypeHashes.getResultResponse)
+        let getResultReplyWriter = try makeWriter(
+            topic: names.getResultReplyTopic, type: names.getResultReplyTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.getResultResponse)
         )
-        let feedbackWriter = try client.createRawWriter(
-            topicName: names.feedbackTopic,
-            typeName: names.feedbackTypeName,
-            qos: cfg,
-            userData: codec.userDataString(typeHash: roleTypeHashes.feedbackMessage)
+        let feedbackWriter = try makeWriter(
+            topic: names.feedbackTopic, type: names.feedbackTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.feedbackMessage)
         )
-        let statusWriter = try client.createRawWriter(
-            topicName: names.statusTopic,
-            typeName: names.statusTypeName,
-            qos: statusQoS,
-            userData: codec.userDataString(typeHash: roleTypeHashes.statusArray)
+        let statusWriter = try makeWriter(
+            topic: names.statusTopic, type: names.statusTypeName,
+            qosCfg: statusQoS, userData: codec.userDataString(typeHash: roleTypeHashes.statusArray)
         )
 
         let server = DDSTransportActionServerImpl(
@@ -90,51 +126,24 @@ extension DDSTransportSession {
             statusWriter: statusWriter
         )
 
-        // Request readers for the three services.
-        do {
-            let sendGoalReader = try client.createRawReader(
-                topicName: names.sendGoalRequestTopic,
-                typeName: names.sendGoalRequestTypeName,
-                qos: cfg,
-                userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalRequest),
-                handler: { [weak server] data, _ in
-                    server?.handleSendGoal(data: data)
-                }
-            )
-            let cancelGoalReader = try client.createRawReader(
-                topicName: names.cancelGoalRequestTopic,
-                typeName: names.cancelGoalRequestTypeName,
-                qos: cfg,
-                userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalRequest),
-                handler: { [weak server] data, _ in
-                    server?.handleCancelGoal(data: data)
-                }
-            )
-            let getResultReader = try client.createRawReader(
-                topicName: names.getResultRequestTopic,
-                typeName: names.getResultRequestTypeName,
-                qos: cfg,
-                userData: codec.userDataString(typeHash: roleTypeHashes.getResultRequest),
-                handler: { [weak server] data, _ in
-                    server?.handleGetResult(data: data)
-                }
-            )
-            server.attachReaders(
-                sendGoal: sendGoalReader,
-                cancelGoal: cancelGoalReader,
-                getResult: getResultReader
-            )
-        } catch {
-            client.destroyWriter(sendGoalReplyWriter)
-            client.destroyWriter(cancelGoalReplyWriter)
-            client.destroyWriter(getResultReplyWriter)
-            client.destroyWriter(feedbackWriter)
-            client.destroyWriter(statusWriter)
-            if let e = error as? DDSError {
-                throw TransportError.subscriberCreationFailed(e.errorDescription ?? "\(e)")
-            }
-            throw error
-        }
+        let sendGoalReader = try makeReader(
+            topic: names.sendGoalRequestTopic, type: names.sendGoalRequestTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalRequest),
+            handler: { [weak server] data, _ in server?.handleSendGoal(data: data) }
+        )
+        let cancelGoalReader = try makeReader(
+            topic: names.cancelGoalRequestTopic, type: names.cancelGoalRequestTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalRequest),
+            handler: { [weak server] data, _ in server?.handleCancelGoal(data: data) }
+        )
+        let getResultReader = try makeReader(
+            topic: names.getResultRequestTopic, type: names.getResultRequestTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.getResultRequest),
+            handler: { [weak server] data, _ in server?.handleGetResult(data: data) }
+        )
+        server.attachReaders(
+            sendGoal: sendGoalReader, cancelGoal: cancelGoalReader, getResult: getResultReader
+        )
 
         appendActionServer(server)
         return server
@@ -173,23 +182,62 @@ extension DDSTransportSession {
                 history: .keepLast(1)
             ))
 
-        let sendGoalWriter = try client.createRawWriter(
-            topicName: names.sendGoalRequestTopic,
-            typeName: names.sendGoalRequestTypeName,
-            qos: cfg,
-            userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalRequest)
+        // Same rollback guard as the server path: any partial creation
+        // failure tears down every entity already created so we don't leak
+        // DDS handles or callbacks for an action client that never returned.
+        var createdWriters: [any DDSWriterHandle] = []
+        var createdReaders: [any DDSReaderHandle] = []
+
+        func rollbackAndThrow(_ error: Error) throws -> Never {
+            for r in createdReaders { client.destroyReader(r) }
+            for w in createdWriters { client.destroyWriter(w) }
+            if let e = error as? DDSError {
+                throw TransportError.subscriberCreationFailed(e.errorDescription ?? "\(e)")
+            }
+            throw error
+        }
+
+        func makeWriter(
+            topic: String, type: String, qosCfg: DDSBridgeQoSConfig, userData: String?
+        ) throws -> any DDSWriterHandle {
+            do {
+                let w = try client.createRawWriter(
+                    topicName: topic, typeName: type, qos: qosCfg, userData: userData
+                )
+                createdWriters.append(w)
+                return w
+            } catch {
+                try rollbackAndThrow(error)
+            }
+        }
+
+        func makeReader(
+            topic: String, type: String, qosCfg: DDSBridgeQoSConfig, userData: String?,
+            handler: @escaping @Sendable (Data, UInt64) -> Void
+        ) throws -> any DDSReaderHandle {
+            do {
+                let r = try client.createRawReader(
+                    topicName: topic, typeName: type, qos: qosCfg,
+                    userData: userData, handler: handler
+                )
+                createdReaders.append(r)
+                return r
+            } catch {
+                try rollbackAndThrow(error)
+            }
+        }
+
+        let sendGoalWriter = try makeWriter(
+            topic: names.sendGoalRequestTopic, type: names.sendGoalRequestTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalRequest)
         )
-        let cancelGoalWriter = try client.createRawWriter(
-            topicName: names.cancelGoalRequestTopic,
-            typeName: names.cancelGoalRequestTypeName,
-            qos: cfg,
-            userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalRequest)
+        let cancelGoalWriter = try makeWriter(
+            topic: names.cancelGoalRequestTopic, type: names.cancelGoalRequestTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalRequest)
         )
-        let getResultWriter = try client.createRawWriter(
-            topicName: names.getResultRequestTopic,
-            typeName: names.getResultRequestTypeName,
-            qos: cfg,
-            userData: codec.userDataString(typeHash: roleTypeHashes.getResultRequest)
+        let getResultWriter = try makeWriter(
+            topic: names.getResultRequestTopic, type: names.getResultRequestTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.getResultRequest)
         )
 
         let writerGuid = GIDManager().getOrCreateGid()
@@ -203,68 +251,38 @@ extension DDSTransportSession {
             getResultWriter: getResultWriter
         )
 
-        do {
-            let sendGoalReplyReader = try client.createRawReader(
-                topicName: names.sendGoalReplyTopic,
-                typeName: names.sendGoalReplyTypeName,
-                qos: cfg,
-                userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalResponse),
-                handler: { [weak cli] data, _ in
-                    cli?.handleSendGoalReply(data: data)
-                }
-            )
-            let cancelGoalReplyReader = try client.createRawReader(
-                topicName: names.cancelGoalReplyTopic,
-                typeName: names.cancelGoalReplyTypeName,
-                qos: cfg,
-                userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalResponse),
-                handler: { [weak cli] data, _ in
-                    cli?.handleCancelGoalReply(data: data)
-                }
-            )
-            let getResultReplyReader = try client.createRawReader(
-                topicName: names.getResultReplyTopic,
-                typeName: names.getResultReplyTypeName,
-                qos: cfg,
-                userData: codec.userDataString(typeHash: roleTypeHashes.getResultResponse),
-                handler: { [weak cli] data, _ in
-                    cli?.handleGetResultReply(data: data)
-                }
-            )
-            let feedbackReader = try client.createRawReader(
-                topicName: names.feedbackTopic,
-                typeName: names.feedbackTypeName,
-                qos: cfg,
-                userData: codec.userDataString(typeHash: roleTypeHashes.feedbackMessage),
-                handler: { [weak cli] data, _ in
-                    cli?.handleFeedbackSample(data: data)
-                }
-            )
-            let statusReader = try client.createRawReader(
-                topicName: names.statusTopic,
-                typeName: names.statusTypeName,
-                qos: statusQoS,
-                userData: codec.userDataString(typeHash: roleTypeHashes.statusArray),
-                handler: { [weak cli] data, _ in
-                    cli?.handleStatusSample(data: data)
-                }
-            )
-            cli.attachReaders(
-                sendGoalReply: sendGoalReplyReader,
-                cancelGoalReply: cancelGoalReplyReader,
-                getResultReply: getResultReplyReader,
-                feedback: feedbackReader,
-                status: statusReader
-            )
-        } catch {
-            client.destroyWriter(sendGoalWriter)
-            client.destroyWriter(cancelGoalWriter)
-            client.destroyWriter(getResultWriter)
-            if let e = error as? DDSError {
-                throw TransportError.subscriberCreationFailed(e.errorDescription ?? "\(e)")
-            }
-            throw error
-        }
+        let sendGoalReplyReader = try makeReader(
+            topic: names.sendGoalReplyTopic, type: names.sendGoalReplyTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalResponse),
+            handler: { [weak cli] data, _ in cli?.handleSendGoalReply(data: data) }
+        )
+        let cancelGoalReplyReader = try makeReader(
+            topic: names.cancelGoalReplyTopic, type: names.cancelGoalReplyTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalResponse),
+            handler: { [weak cli] data, _ in cli?.handleCancelGoalReply(data: data) }
+        )
+        let getResultReplyReader = try makeReader(
+            topic: names.getResultReplyTopic, type: names.getResultReplyTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.getResultResponse),
+            handler: { [weak cli] data, _ in cli?.handleGetResultReply(data: data) }
+        )
+        let feedbackReader = try makeReader(
+            topic: names.feedbackTopic, type: names.feedbackTypeName,
+            qosCfg: cfg, userData: codec.userDataString(typeHash: roleTypeHashes.feedbackMessage),
+            handler: { [weak cli] data, _ in cli?.handleFeedbackSample(data: data) }
+        )
+        let statusReader = try makeReader(
+            topic: names.statusTopic, type: names.statusTypeName,
+            qosCfg: statusQoS, userData: codec.userDataString(typeHash: roleTypeHashes.statusArray),
+            handler: { [weak cli] data, _ in cli?.handleStatusSample(data: data) }
+        )
+        cli.attachReaders(
+            sendGoalReply: sendGoalReplyReader,
+            cancelGoalReply: cancelGoalReplyReader,
+            getResultReply: getResultReplyReader,
+            feedback: feedbackReader,
+            status: statusReader
+        )
 
         appendActionClient(cli)
         return cli
@@ -371,8 +389,20 @@ final class DDSTransportActionServerImpl: TransportActionServer, @unchecked Send
         lock.lock()
         defer { lock.unlock() }
         if closed { return false }
-        return (sendGoalReplyWriter?.isActive ?? false)
-            && (sendGoalReader?.isActive ?? false)
+        // Every wire-level entity must still be live for the server to be
+        // considered active — `isActive == true` should mean the full action
+        // surface (3 services × {request reader, reply writer} + feedback +
+        // status writers) is operational.
+        let writers: [(any DDSWriterHandle)?] = [
+            sendGoalReplyWriter, cancelGoalReplyWriter, getResultReplyWriter,
+            feedbackWriter, statusWriter,
+        ]
+        let readers: [(any DDSReaderHandle)?] = [
+            sendGoalReader, cancelGoalReader, getResultReader,
+        ]
+        for w in writers where !(w?.isActive ?? false) { return false }
+        for r in readers where !(r?.isActive ?? false) { return false }
+        return true
     }
 
     // Test-helper accessors for the topic strings — used by the unit tests.
@@ -564,7 +594,19 @@ final class DDSTransportActionClientImpl: TransportActionClient, @unchecked Send
     var isActive: Bool {
         lock.lock()
         defer { lock.unlock() }
-        return !closed
+        if closed { return false }
+        // Mirror the server's stricter check — every wire-level entity must
+        // still be live, otherwise callers get a misleading green light.
+        let writers: [(any DDSWriterHandle)?] = [
+            sendGoalWriter, cancelGoalWriter, getResultWriter,
+        ]
+        let readers: [(any DDSReaderHandle)?] = [
+            sendGoalReplyReader, cancelGoalReplyReader, getResultReplyReader,
+            feedbackReader, statusReader,
+        ]
+        for w in writers where !(w?.isActive ?? false) { return false }
+        for r in readers where !(r?.isActive ?? false) { return false }
+        return true
     }
 
     init(
@@ -602,12 +644,25 @@ final class DDSTransportActionClientImpl: TransportActionClient, @unchecked Send
     }
 
     func waitForActionServer(timeout: Duration) async throws {
+        // Per the protocol contract a client should only see "available" once
+        // the full action surface is reachable on the other side. The DDS
+        // bridge only exposes `isPublicationMatched` (writer-side), so we
+        // check all three request writers — `send_goal`, `cancel_goal`, and
+        // `get_result` — each of which has a paired reader on the server.
+        // The server creates all 5 entities (3 service pairs + feedback +
+        // status writers) atomically inside `createActionServer`, so seeing
+        // matches on every service writer implies the feedback and status
+        // publishers are co-live; the client's feedback / status readers
+        // will pick them up on the next discovery tick.
         let deadline = ContinuousClock.now.advanced(by: timeout)
         while ContinuousClock.now < deadline {
             lock.lock()
-            let writer = closed ? nil : sendGoalWriter
+            let snapshot: [(any DDSWriterHandle)?] =
+                closed ? [] : [sendGoalWriter, cancelGoalWriter, getResultWriter]
             lock.unlock()
-            if let w = writer, client.isPublicationMatched(writer: w) {
+            if !snapshot.isEmpty,
+                snapshot.allSatisfy({ w in w.map { client.isPublicationMatched(writer: $0) } ?? false })
+            {
                 return
             }
             try? await Task.sleep(nanoseconds: 100_000_000)
@@ -635,21 +690,45 @@ final class DDSTransportActionClientImpl: TransportActionClient, @unchecked Send
         lock.lock()
         let writer = closed ? nil : sendGoalWriter
         lock.unlock()
-        guard let writer = writer else { throw TransportError.sessionClosed }
+        guard let writer = writer else {
+            // Roll back the streams we just registered — otherwise this goal
+            // id sits in `pending` forever and any feedback/status sample
+            // racing in (e.g. on a server still alive on the network) would
+            // be routed to a goal the caller never received a handle for.
+            await pending.cancel(goalId: goalId)
+            throw TransportError.sessionClosed
+        }
 
         let frame = ActionFrameDecoder.encodeSendGoalRequest(goalId: goalId, goalCDR: goalCDR)
         let seq = nextSequence()
         let id = RMWRequestId(writerGuid: writerGuid, sequenceNumber: seq)
         let wire = SampleIdentityPrefix.encode(requestId: id, userCDR: frame)
 
-        let replyCDR = try await callWithTimeout(
-            pending: sendGoalPending,
-            seq: seq,
-            timeout: acceptanceTimeout
-        ) {
-            try self.client.writeRawCDR(writer: writer, data: wire, timestamp: 0)
+        let replyCDR: Data
+        do {
+            replyCDR = try await callWithTimeout(
+                pending: sendGoalPending,
+                seq: seq,
+                timeout: acceptanceTimeout
+            ) {
+                try self.client.writeRawCDR(writer: writer, data: wire, timestamp: 0)
+            }
+        } catch {
+            // Same rationale as the writer-nil path above — the request
+            // never actually completed (timeout / cancel / write failure),
+            // so the goal id has no live handle on the caller side. Drop
+            // the pending entry to avoid the same misrouting hazard.
+            await pending.cancel(goalId: goalId)
+            throw error
         }
-        let resp = try ActionFrameDecoder.decodeSendGoalResponse(from: replyCDR)
+
+        let resp: (accepted: Bool, stampSec: Int32, stampNanosec: UInt32)
+        do {
+            resp = try ActionFrameDecoder.decodeSendGoalResponse(from: replyCDR)
+        } catch {
+            await pending.cancel(goalId: goalId)
+            throw error
+        }
         if !resp.accepted {
             await pending.cancel(goalId: goalId)
         }
@@ -682,6 +761,11 @@ final class DDSTransportActionClientImpl: TransportActionClient, @unchecked Send
             try self.client.writeRawCDR(writer: writer, data: wire, timestamp: 0)
         }
         let (status, resultCDR) = try ActionFrameDecoder.decodeGetResultResponse(from: replyCDR)
+        // Drain the per-goal entry from `pending` — the result has been
+        // delivered to the caller and any future feedback / status samples
+        // for this goal are stale. Without this, every accepted goal leaks
+        // a slot in the pending table for the lifetime of the client.
+        await pending.cancel(goalId: goalId)
         return GetResultAck(status: status, resultCDR: resultCDR)
     }
 

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Action.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Action.swift
@@ -1,0 +1,882 @@
+// DDSTransportSession+Action.swift
+// Action Server / Client implementation for the DDS transport.
+//
+// rmw_cyclonedds_cpp materializes a single ROS 2 action under <ns>/<name>/_action/
+// as 3 service pairs (send_goal, cancel_goal, get_result) plus 2 topics
+// (feedback, status). Reuses the existing rq/rr/rt primitives — no new C-bridge.
+
+import Foundation
+import SwiftROS2Wire
+
+extension DDSTransportSession {
+    public func createActionServer(
+        name: String,
+        actionTypeName: String,
+        roleTypeHashes: ActionRoleTypeHashes,
+        qos: TransportQoS,
+        handlers: TransportActionServerHandlers
+    ) throws -> any TransportActionServer {
+        guard !name.isEmpty else {
+            throw TransportError.invalidConfiguration("Action name cannot be empty")
+        }
+        guard !actionTypeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Action type name cannot be empty")
+        }
+
+        lock.lock()
+        guard isOpen else {
+            lock.unlock()
+            throw TransportError.notConnected
+        }
+        lock.unlock()
+
+        let codec = DDSWireCodec()
+        let names = codec.actionTopicNames(
+            namespace: extractNamespace(from: name),
+            actionName: extractTopicName(from: name),
+            actionTypeName: actionTypeName
+        )
+
+        let cfg = bridgeQoS(from: qos)
+        // status topic: transient_local depth 1 (matches rclcpp).
+        let statusQoS = bridgeQoS(
+            from: TransportQoS(
+                reliability: qos.reliability,
+                durability: .transientLocal,
+                history: .keepLast(1)
+            ))
+
+        // Reply writers for the three services.
+        let sendGoalReplyWriter = try client.createRawWriter(
+            topicName: names.sendGoalReplyTopic,
+            typeName: names.sendGoalReplyTypeName,
+            qos: cfg,
+            userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalResponse)
+        )
+        let cancelGoalReplyWriter = try client.createRawWriter(
+            topicName: names.cancelGoalReplyTopic,
+            typeName: names.cancelGoalReplyTypeName,
+            qos: cfg,
+            userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalResponse)
+        )
+        let getResultReplyWriter = try client.createRawWriter(
+            topicName: names.getResultReplyTopic,
+            typeName: names.getResultReplyTypeName,
+            qos: cfg,
+            userData: codec.userDataString(typeHash: roleTypeHashes.getResultResponse)
+        )
+        let feedbackWriter = try client.createRawWriter(
+            topicName: names.feedbackTopic,
+            typeName: names.feedbackTypeName,
+            qos: cfg,
+            userData: codec.userDataString(typeHash: roleTypeHashes.feedbackMessage)
+        )
+        let statusWriter = try client.createRawWriter(
+            topicName: names.statusTopic,
+            typeName: names.statusTypeName,
+            qos: statusQoS,
+            userData: codec.userDataString(typeHash: roleTypeHashes.statusArray)
+        )
+
+        let server = DDSTransportActionServerImpl(
+            client: client,
+            name: name,
+            names: names,
+            handlers: handlers,
+            sendGoalReplyWriter: sendGoalReplyWriter,
+            cancelGoalReplyWriter: cancelGoalReplyWriter,
+            getResultReplyWriter: getResultReplyWriter,
+            feedbackWriter: feedbackWriter,
+            statusWriter: statusWriter
+        )
+
+        // Request readers for the three services.
+        do {
+            let sendGoalReader = try client.createRawReader(
+                topicName: names.sendGoalRequestTopic,
+                typeName: names.sendGoalRequestTypeName,
+                qos: cfg,
+                userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalRequest),
+                handler: { [weak server] data, _ in
+                    server?.handleSendGoal(data: data)
+                }
+            )
+            let cancelGoalReader = try client.createRawReader(
+                topicName: names.cancelGoalRequestTopic,
+                typeName: names.cancelGoalRequestTypeName,
+                qos: cfg,
+                userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalRequest),
+                handler: { [weak server] data, _ in
+                    server?.handleCancelGoal(data: data)
+                }
+            )
+            let getResultReader = try client.createRawReader(
+                topicName: names.getResultRequestTopic,
+                typeName: names.getResultRequestTypeName,
+                qos: cfg,
+                userData: codec.userDataString(typeHash: roleTypeHashes.getResultRequest),
+                handler: { [weak server] data, _ in
+                    server?.handleGetResult(data: data)
+                }
+            )
+            server.attachReaders(
+                sendGoal: sendGoalReader,
+                cancelGoal: cancelGoalReader,
+                getResult: getResultReader
+            )
+        } catch {
+            client.destroyWriter(sendGoalReplyWriter)
+            client.destroyWriter(cancelGoalReplyWriter)
+            client.destroyWriter(getResultReplyWriter)
+            client.destroyWriter(feedbackWriter)
+            client.destroyWriter(statusWriter)
+            if let e = error as? DDSError {
+                throw TransportError.subscriberCreationFailed(e.errorDescription ?? "\(e)")
+            }
+            throw error
+        }
+
+        appendActionServer(server)
+        return server
+    }
+
+    public func createActionClient(
+        name: String,
+        actionTypeName: String,
+        roleTypeHashes: ActionRoleTypeHashes,
+        qos: TransportQoS
+    ) throws -> any TransportActionClient {
+        guard !name.isEmpty else {
+            throw TransportError.invalidConfiguration("Action name cannot be empty")
+        }
+        guard !actionTypeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Action type name cannot be empty")
+        }
+        lock.lock()
+        guard isOpen else {
+            lock.unlock()
+            throw TransportError.notConnected
+        }
+        lock.unlock()
+
+        let codec = DDSWireCodec()
+        let names = codec.actionTopicNames(
+            namespace: extractNamespace(from: name),
+            actionName: extractTopicName(from: name),
+            actionTypeName: actionTypeName
+        )
+        let cfg = bridgeQoS(from: qos)
+        let statusQoS = bridgeQoS(
+            from: TransportQoS(
+                reliability: qos.reliability,
+                durability: .transientLocal,
+                history: .keepLast(1)
+            ))
+
+        let sendGoalWriter = try client.createRawWriter(
+            topicName: names.sendGoalRequestTopic,
+            typeName: names.sendGoalRequestTypeName,
+            qos: cfg,
+            userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalRequest)
+        )
+        let cancelGoalWriter = try client.createRawWriter(
+            topicName: names.cancelGoalRequestTopic,
+            typeName: names.cancelGoalRequestTypeName,
+            qos: cfg,
+            userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalRequest)
+        )
+        let getResultWriter = try client.createRawWriter(
+            topicName: names.getResultRequestTopic,
+            typeName: names.getResultRequestTypeName,
+            qos: cfg,
+            userData: codec.userDataString(typeHash: roleTypeHashes.getResultRequest)
+        )
+
+        let writerGuid = GIDManager().getOrCreateGid()
+        let cli = DDSTransportActionClientImpl(
+            client: client,
+            name: name,
+            names: names,
+            writerGuid: writerGuid,
+            sendGoalWriter: sendGoalWriter,
+            cancelGoalWriter: cancelGoalWriter,
+            getResultWriter: getResultWriter
+        )
+
+        do {
+            let sendGoalReplyReader = try client.createRawReader(
+                topicName: names.sendGoalReplyTopic,
+                typeName: names.sendGoalReplyTypeName,
+                qos: cfg,
+                userData: codec.userDataString(typeHash: roleTypeHashes.sendGoalResponse),
+                handler: { [weak cli] data, _ in
+                    cli?.handleSendGoalReply(data: data)
+                }
+            )
+            let cancelGoalReplyReader = try client.createRawReader(
+                topicName: names.cancelGoalReplyTopic,
+                typeName: names.cancelGoalReplyTypeName,
+                qos: cfg,
+                userData: codec.userDataString(typeHash: roleTypeHashes.cancelGoalResponse),
+                handler: { [weak cli] data, _ in
+                    cli?.handleCancelGoalReply(data: data)
+                }
+            )
+            let getResultReplyReader = try client.createRawReader(
+                topicName: names.getResultReplyTopic,
+                typeName: names.getResultReplyTypeName,
+                qos: cfg,
+                userData: codec.userDataString(typeHash: roleTypeHashes.getResultResponse),
+                handler: { [weak cli] data, _ in
+                    cli?.handleGetResultReply(data: data)
+                }
+            )
+            let feedbackReader = try client.createRawReader(
+                topicName: names.feedbackTopic,
+                typeName: names.feedbackTypeName,
+                qos: cfg,
+                userData: codec.userDataString(typeHash: roleTypeHashes.feedbackMessage),
+                handler: { [weak cli] data, _ in
+                    cli?.handleFeedbackSample(data: data)
+                }
+            )
+            let statusReader = try client.createRawReader(
+                topicName: names.statusTopic,
+                typeName: names.statusTypeName,
+                qos: statusQoS,
+                userData: codec.userDataString(typeHash: roleTypeHashes.statusArray),
+                handler: { [weak cli] data, _ in
+                    cli?.handleStatusSample(data: data)
+                }
+            )
+            cli.attachReaders(
+                sendGoalReply: sendGoalReplyReader,
+                cancelGoalReply: cancelGoalReplyReader,
+                getResultReply: getResultReplyReader,
+                feedback: feedbackReader,
+                status: statusReader
+            )
+        } catch {
+            client.destroyWriter(sendGoalWriter)
+            client.destroyWriter(cancelGoalWriter)
+            client.destroyWriter(getResultWriter)
+            if let e = error as? DDSError {
+                throw TransportError.subscriberCreationFailed(e.errorDescription ?? "\(e)")
+            }
+            throw error
+        }
+
+        appendActionClient(cli)
+        return cli
+    }
+
+    func appendActionServer(_ server: DDSTransportActionServerImpl) {
+        lock.lock()
+        actionServers.append(server)
+        lock.unlock()
+    }
+
+    func takeAllActionServers() -> [DDSTransportActionServerImpl] {
+        lock.lock()
+        let out = actionServers
+        actionServers.removeAll()
+        lock.unlock()
+        return out
+    }
+
+    func appendActionClient(_ cli: DDSTransportActionClientImpl) {
+        lock.lock()
+        actionClients.append(cli)
+        lock.unlock()
+    }
+
+    func takeAllActionClients() -> [DDSTransportActionClientImpl] {
+        lock.lock()
+        let out = actionClients
+        actionClients.removeAll()
+        lock.unlock()
+        return out
+    }
+
+    // namespace / topic helpers — local to the DDS action / service paths.
+    func extractNamespace(from name: String) -> String {
+        let stripped = name.hasPrefix("/") ? String(name.dropFirst()) : name
+        guard let lastSlash = stripped.lastIndex(of: "/") else { return "" }
+        return "/" + stripped[..<lastSlash]
+    }
+
+    func extractTopicName(from name: String) -> String {
+        let stripped = name.hasPrefix("/") ? String(name.dropFirst()) : name
+        guard let lastSlash = stripped.lastIndex(of: "/") else { return stripped }
+        return String(stripped[stripped.index(after: lastSlash)...])
+    }
+}
+
+// MARK: - DDS Transport Action Server
+
+final class DDSTransportActionServerImpl: TransportActionServer, @unchecked Sendable {
+    let client: any DDSClientProtocol
+    let name: String
+    let names: DDSWireCodec.ActionTopicNames
+    let handlers: TransportActionServerHandlers
+
+    private var sendGoalReplyWriter: (any DDSWriterHandle)?
+    private var cancelGoalReplyWriter: (any DDSWriterHandle)?
+    private var getResultReplyWriter: (any DDSWriterHandle)?
+    private var feedbackWriter: (any DDSWriterHandle)?
+    private var statusWriter: (any DDSWriterHandle)?
+
+    private var sendGoalReader: (any DDSReaderHandle)?
+    private var cancelGoalReader: (any DDSReaderHandle)?
+    private var getResultReader: (any DDSReaderHandle)?
+
+    private let lock = NSLock()
+    private var closed = false
+
+    init(
+        client: any DDSClientProtocol,
+        name: String,
+        names: DDSWireCodec.ActionTopicNames,
+        handlers: TransportActionServerHandlers,
+        sendGoalReplyWriter: any DDSWriterHandle,
+        cancelGoalReplyWriter: any DDSWriterHandle,
+        getResultReplyWriter: any DDSWriterHandle,
+        feedbackWriter: any DDSWriterHandle,
+        statusWriter: any DDSWriterHandle
+    ) {
+        self.client = client
+        self.name = name
+        self.names = names
+        self.handlers = handlers
+        self.sendGoalReplyWriter = sendGoalReplyWriter
+        self.cancelGoalReplyWriter = cancelGoalReplyWriter
+        self.getResultReplyWriter = getResultReplyWriter
+        self.feedbackWriter = feedbackWriter
+        self.statusWriter = statusWriter
+    }
+
+    func attachReaders(
+        sendGoal: any DDSReaderHandle,
+        cancelGoal: any DDSReaderHandle,
+        getResult: any DDSReaderHandle
+    ) {
+        lock.lock()
+        sendGoalReader = sendGoal
+        cancelGoalReader = cancelGoal
+        getResultReader = getResult
+        lock.unlock()
+    }
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if closed { return false }
+        return (sendGoalReplyWriter?.isActive ?? false)
+            && (sendGoalReader?.isActive ?? false)
+    }
+
+    // Test-helper accessors for the topic strings — used by the unit tests.
+    var sendGoalRequestTopic: String { names.sendGoalRequestTopic }
+    var sendGoalReplyTopic: String { names.sendGoalReplyTopic }
+    var cancelGoalRequestTopic: String { names.cancelGoalRequestTopic }
+    var cancelGoalReplyTopic: String { names.cancelGoalReplyTopic }
+    var getResultRequestTopic: String { names.getResultRequestTopic }
+    var getResultReplyTopic: String { names.getResultReplyTopic }
+    var feedbackTopic: String { names.feedbackTopic }
+    var statusTopic: String { names.statusTopic }
+
+    func handleSendGoal(data: Data) {
+        let parsedId: RMWRequestId
+        let userCDR: Data
+        do {
+            (parsedId, userCDR) = try SampleIdentityPrefix.decode(wirePayload: data)
+        } catch {
+            return
+        }
+        let handlers = self.handlers
+        let writer = replyWriterSnapshot(\.sendGoalReplyWriter)
+        let client = self.client
+        Task.detached(priority: .userInitiated) { [parsedId, userCDR, handlers, writer, client] in
+            do {
+                let (goalId, goalCDR) = try ActionFrameDecoder.decodeSendGoalRequest(from: userCDR)
+                let (accepted, sec, nsec) = try await handlers.onSendGoal(goalId, goalCDR)
+                let response = ActionFrameDecoder.encodeSendGoalResponse(
+                    accepted: accepted, stampSec: sec, stampNanosec: nsec
+                )
+                let wire = SampleIdentityPrefix.encode(requestId: parsedId, userCDR: response)
+                if let w = writer {
+                    try? client.writeRawCDR(writer: w, data: wire, timestamp: 0)
+                }
+            } catch {
+                _ = error
+            }
+        }
+    }
+
+    func handleCancelGoal(data: Data) {
+        let parsedId: RMWRequestId
+        let userCDR: Data
+        do {
+            (parsedId, userCDR) = try SampleIdentityPrefix.decode(wirePayload: data)
+        } catch {
+            return
+        }
+        let handlers = self.handlers
+        let writer = replyWriterSnapshot(\.cancelGoalReplyWriter)
+        let client = self.client
+        Task.detached(priority: .userInitiated) { [parsedId, userCDR, handlers, writer, client] in
+            do {
+                let response = try await handlers.onCancelGoal(userCDR)
+                let wire = SampleIdentityPrefix.encode(requestId: parsedId, userCDR: response)
+                if let w = writer {
+                    try? client.writeRawCDR(writer: w, data: wire, timestamp: 0)
+                }
+            } catch {
+                _ = error
+            }
+        }
+    }
+
+    func handleGetResult(data: Data) {
+        let parsedId: RMWRequestId
+        let userCDR: Data
+        do {
+            (parsedId, userCDR) = try SampleIdentityPrefix.decode(wirePayload: data)
+        } catch {
+            return
+        }
+        let handlers = self.handlers
+        let writer = replyWriterSnapshot(\.getResultReplyWriter)
+        let client = self.client
+        Task.detached(priority: .userInitiated) { [parsedId, userCDR, handlers, writer, client] in
+            do {
+                let goalId = try ActionFrameDecoder.decodeGetResultRequest(from: userCDR)
+                let ack = try await handlers.onGetResult(goalId)
+                let response = ActionFrameDecoder.encodeGetResultResponse(
+                    status: ack.status, resultCDR: ack.resultCDR
+                )
+                let wire = SampleIdentityPrefix.encode(requestId: parsedId, userCDR: response)
+                if let w = writer {
+                    try? client.writeRawCDR(writer: w, data: wire, timestamp: 0)
+                }
+            } catch {
+                _ = error
+            }
+        }
+    }
+
+    /// Server-side: publish a feedback frame for a specific goal.
+    func publishFeedback(goalId: [UInt8], feedbackCDR: Data) throws {
+        lock.lock()
+        let writer = closed ? nil : feedbackWriter
+        lock.unlock()
+        guard let writer = writer else { throw TransportError.publisherClosed }
+        let frame = ActionFrameDecoder.encodeFeedbackMessage(
+            goalId: goalId, feedbackCDR: feedbackCDR
+        )
+        try client.writeRawCDR(writer: writer, data: frame, timestamp: 0)
+    }
+
+    /// Server-side: publish a full status array (one entry per active goal).
+    func publishStatus(entries: [ActionFrameDecoder.StatusEntry]) throws {
+        lock.lock()
+        let writer = closed ? nil : statusWriter
+        lock.unlock()
+        guard let writer = writer else { throw TransportError.publisherClosed }
+        let frame = ActionFrameDecoder.encodeStatusArray(entries: entries)
+        try client.writeRawCDR(writer: writer, data: frame, timestamp: 0)
+    }
+
+    private func replyWriterSnapshot(
+        _ keyPath: ReferenceWritableKeyPath<DDSTransportActionServerImpl, (any DDSWriterHandle)?>
+    ) -> (any DDSWriterHandle)? {
+        lock.lock()
+        defer { lock.unlock() }
+        return closed ? nil : self[keyPath: keyPath]
+    }
+
+    func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let writers: [any DDSWriterHandle] = [
+            sendGoalReplyWriter, cancelGoalReplyWriter, getResultReplyWriter,
+            feedbackWriter, statusWriter,
+        ].compactMap { $0 }
+        let readers: [any DDSReaderHandle] = [
+            sendGoalReader, cancelGoalReader, getResultReader,
+        ].compactMap { $0 }
+        sendGoalReplyWriter = nil
+        cancelGoalReplyWriter = nil
+        getResultReplyWriter = nil
+        feedbackWriter = nil
+        statusWriter = nil
+        sendGoalReader = nil
+        cancelGoalReader = nil
+        getResultReader = nil
+        lock.unlock()
+
+        for r in readers {
+            client.destroyReader(r)
+        }
+        for w in writers {
+            client.destroyWriter(w)
+        }
+    }
+}
+
+// MARK: - DDS Transport Action Client
+
+final class DDSTransportActionClientImpl: TransportActionClient, @unchecked Sendable {
+    private let client: any DDSClientProtocol
+    let name: String
+    let names: DDSWireCodec.ActionTopicNames
+    private let writerGuid: [UInt8]
+
+    private var sendGoalWriter: (any DDSWriterHandle)?
+    private var cancelGoalWriter: (any DDSWriterHandle)?
+    private var getResultWriter: (any DDSWriterHandle)?
+    private var sendGoalReplyReader: (any DDSReaderHandle)?
+    private var cancelGoalReplyReader: (any DDSReaderHandle)?
+    private var getResultReplyReader: (any DDSReaderHandle)?
+    private var feedbackReader: (any DDSReaderHandle)?
+    private var statusReader: (any DDSReaderHandle)?
+
+    private let lock = NSLock()
+    private var closed = false
+
+    private let seqLock = NSLock()
+    private var nextSeq: Int64 = 0
+
+    private let sendGoalPending = ClientPendingTable()
+    private let cancelGoalPending = ClientPendingTable()
+    private let getResultPending = ClientPendingTable()
+
+    /// Shared per-goal stream / continuation tracker.
+    let pending = ActionPendingTable()
+
+    var feedbackTopic: String { names.feedbackTopic }
+    var statusTopic: String { names.statusTopic }
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+
+    init(
+        client: any DDSClientProtocol,
+        name: String,
+        names: DDSWireCodec.ActionTopicNames,
+        writerGuid: [UInt8],
+        sendGoalWriter: any DDSWriterHandle,
+        cancelGoalWriter: any DDSWriterHandle,
+        getResultWriter: any DDSWriterHandle
+    ) {
+        self.client = client
+        self.name = name
+        self.names = names
+        self.writerGuid = writerGuid
+        self.sendGoalWriter = sendGoalWriter
+        self.cancelGoalWriter = cancelGoalWriter
+        self.getResultWriter = getResultWriter
+    }
+
+    func attachReaders(
+        sendGoalReply: any DDSReaderHandle,
+        cancelGoalReply: any DDSReaderHandle,
+        getResultReply: any DDSReaderHandle,
+        feedback: any DDSReaderHandle,
+        status: any DDSReaderHandle
+    ) {
+        lock.lock()
+        sendGoalReplyReader = sendGoalReply
+        cancelGoalReplyReader = cancelGoalReply
+        getResultReplyReader = getResultReply
+        feedbackReader = feedback
+        statusReader = status
+        lock.unlock()
+    }
+
+    func waitForActionServer(timeout: Duration) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            lock.lock()
+            let writer = closed ? nil : sendGoalWriter
+            lock.unlock()
+            if let w = writer, client.isPublicationMatched(writer: w) {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            try Task.checkCancellation()
+        }
+        throw TransportError.actionServerUnavailable
+    }
+
+    func sendGoal(
+        goalId: [UInt8],
+        goalCDR: Data,
+        acceptanceTimeout: Duration
+    ) async throws -> SendGoalAck {
+        precondition(goalId.count == 16, "goalId must be 16 bytes")
+
+        // Pre-register the per-goal feedback / status streams before we issue
+        // the request — the server may publish a status update the instant it
+        // accepts, and we'd lose it otherwise.
+        var fbCont: AsyncStream<Data>.Continuation!
+        let feedback = AsyncStream<Data> { fbCont = $0 }
+        var stCont: AsyncStream<ActionStatusUpdate>.Continuation!
+        let status = AsyncStream<ActionStatusUpdate> { stCont = $0 }
+        await pending.registerStreams(goalId: goalId, feedback: fbCont, status: stCont)
+
+        lock.lock()
+        let writer = closed ? nil : sendGoalWriter
+        lock.unlock()
+        guard let writer = writer else { throw TransportError.sessionClosed }
+
+        let frame = ActionFrameDecoder.encodeSendGoalRequest(goalId: goalId, goalCDR: goalCDR)
+        let seq = nextSequence()
+        let id = RMWRequestId(writerGuid: writerGuid, sequenceNumber: seq)
+        let wire = SampleIdentityPrefix.encode(requestId: id, userCDR: frame)
+
+        let replyCDR = try await callWithTimeout(
+            pending: sendGoalPending,
+            seq: seq,
+            timeout: acceptanceTimeout
+        ) {
+            try self.client.writeRawCDR(writer: writer, data: wire, timestamp: 0)
+        }
+        let resp = try ActionFrameDecoder.decodeSendGoalResponse(from: replyCDR)
+        if !resp.accepted {
+            await pending.cancel(goalId: goalId)
+        }
+        return SendGoalAck(
+            accepted: resp.accepted,
+            stampSec: resp.stampSec,
+            stampNanosec: resp.stampNanosec,
+            feedback: feedback,
+            status: status
+        )
+    }
+
+    func getResult(goalId: [UInt8], timeout: Duration) async throws -> GetResultAck {
+        precondition(goalId.count == 16, "goalId must be 16 bytes")
+        lock.lock()
+        let writer = closed ? nil : getResultWriter
+        lock.unlock()
+        guard let writer = writer else { throw TransportError.sessionClosed }
+
+        let frame = ActionFrameDecoder.encodeGetResultRequest(goalId: goalId)
+        let seq = nextSequence()
+        let id = RMWRequestId(writerGuid: writerGuid, sequenceNumber: seq)
+        let wire = SampleIdentityPrefix.encode(requestId: id, userCDR: frame)
+
+        let replyCDR = try await callWithTimeout(
+            pending: getResultPending,
+            seq: seq,
+            timeout: timeout
+        ) {
+            try self.client.writeRawCDR(writer: writer, data: wire, timestamp: 0)
+        }
+        let (status, resultCDR) = try ActionFrameDecoder.decodeGetResultResponse(from: replyCDR)
+        return GetResultAck(status: status, resultCDR: resultCDR)
+    }
+
+    func cancelGoal(
+        goalId: [UInt8]?,
+        beforeStampSec: Int32?,
+        beforeStampNanosec: UInt32?,
+        timeout: Duration
+    ) async throws -> CancelGoalAck {
+        lock.lock()
+        let writer = closed ? nil : cancelGoalWriter
+        lock.unlock()
+        guard let writer = writer else { throw TransportError.sessionClosed }
+
+        // Build CancelGoal_Request CDR by hand: action_msgs/srv/CancelGoal_Request
+        // is `GoalInfo goal_info { uuid[16], builtin_interfaces/Time stamp }`.
+        var frame = ActionFrameDecoder.cdrHeader
+        let id = goalId ?? [UInt8](repeating: 0, count: 16)
+        precondition(id.count == 16, "goalId must be 16 bytes")
+        frame.append(contentsOf: id)
+        var sec = (beforeStampSec ?? 0).littleEndian
+        var nsec = (beforeStampNanosec ?? 0).littleEndian
+        withUnsafeBytes(of: &sec) { frame.append(contentsOf: $0) }
+        withUnsafeBytes(of: &nsec) { frame.append(contentsOf: $0) }
+
+        let seq = nextSequence()
+        let rid = RMWRequestId(writerGuid: writerGuid, sequenceNumber: seq)
+        let wire = SampleIdentityPrefix.encode(requestId: rid, userCDR: frame)
+
+        let replyCDR = try await callWithTimeout(
+            pending: cancelGoalPending,
+            seq: seq,
+            timeout: timeout
+        ) {
+            try self.client.writeRawCDR(writer: writer, data: wire, timestamp: 0)
+        }
+        // CancelGoal_Response CDR: `int8 return_code; GoalInfo[] goals_canceling`.
+        // Layout: [header (4) | code (1) | pad (3) | count (u32) | { uuid[16] | sec | nsec } * count ]
+        guard replyCDR.count >= 4 + 1 + 3 + 4 else {
+            throw ActionFrameDecoderError.payloadTooShort
+        }
+        let code = Int8(bitPattern: replyCDR[replyCDR.startIndex + 4])
+        let count = replyCDR.withUnsafeBytes {
+            $0.loadUnaligned(fromByteOffset: 8, as: UInt32.self).littleEndian
+        }
+        let needed = 4 + 1 + 3 + 4 + Int(count) * (16 + 4 + 4)
+        guard replyCDR.count >= needed else { throw ActionFrameDecoderError.payloadTooShort }
+        var out: [CancelGoalAck.GoalEntry] = []
+        out.reserveCapacity(Int(count))
+        var off = replyCDR.startIndex + 12
+        for _ in 0..<Int(count) {
+            let uuid = Array(replyCDR[off..<(off + 16)])
+            off += 16
+            let s = replyCDR.withUnsafeBytes {
+                $0.loadUnaligned(fromByteOffset: off - replyCDR.startIndex, as: Int32.self)
+                    .littleEndian
+            }
+            off += 4
+            let ns = replyCDR.withUnsafeBytes {
+                $0.loadUnaligned(fromByteOffset: off - replyCDR.startIndex, as: UInt32.self)
+                    .littleEndian
+            }
+            off += 4
+            out.append((uuid: uuid, stampSec: s, stampNanosec: ns))
+        }
+        return CancelGoalAck(returnCode: code, goalsCanceling: out)
+    }
+
+    func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let writers: [any DDSWriterHandle] = [
+            sendGoalWriter, cancelGoalWriter, getResultWriter,
+        ].compactMap { $0 }
+        let readers: [any DDSReaderHandle] = [
+            sendGoalReplyReader, cancelGoalReplyReader, getResultReplyReader,
+            feedbackReader, statusReader,
+        ].compactMap { $0 }
+        sendGoalWriter = nil
+        cancelGoalWriter = nil
+        getResultWriter = nil
+        sendGoalReplyReader = nil
+        cancelGoalReplyReader = nil
+        getResultReplyReader = nil
+        feedbackReader = nil
+        statusReader = nil
+        lock.unlock()
+
+        Task { [pending] in
+            await pending.failAll(TransportError.sessionClosed)
+        }
+        for r in readers {
+            client.destroyReader(r)
+        }
+        for w in writers {
+            client.destroyWriter(w)
+        }
+    }
+
+    // MARK: Internal — reply / sample handlers
+
+    func handleSendGoalReply(data: Data) {
+        guard let (rid, body) = try? SampleIdentityPrefix.decode(wirePayload: data),
+            rid.writerGuid == writerGuid
+        else { return }
+        Task { [sendGoalPending] in
+            await sendGoalPending.resolve(seq: rid.sequenceNumber, with: .success(body))
+        }
+    }
+
+    func handleCancelGoalReply(data: Data) {
+        guard let (rid, body) = try? SampleIdentityPrefix.decode(wirePayload: data),
+            rid.writerGuid == writerGuid
+        else { return }
+        Task { [cancelGoalPending] in
+            await cancelGoalPending.resolve(seq: rid.sequenceNumber, with: .success(body))
+        }
+    }
+
+    func handleGetResultReply(data: Data) {
+        guard let (rid, body) = try? SampleIdentityPrefix.decode(wirePayload: data),
+            rid.writerGuid == writerGuid
+        else { return }
+        Task { [getResultPending] in
+            await getResultPending.resolve(seq: rid.sequenceNumber, with: .success(body))
+        }
+    }
+
+    func handleFeedbackSample(data: Data) {
+        guard let (goalId, fbCDR) = try? ActionFrameDecoder.decodeFeedbackMessage(from: data) else {
+            return
+        }
+        Task { [pending] in
+            await pending.yieldFeedback(goalId: goalId, cdr: fbCDR)
+        }
+    }
+
+    func handleStatusSample(data: Data) {
+        guard let entries = try? ActionFrameDecoder.decodeStatusArray(from: data) else { return }
+        Task { [pending] in
+            for e in entries {
+                await pending.yieldStatus(goalId: e.uuid, status: e.status)
+            }
+        }
+    }
+
+    // MARK: Internal — helpers
+
+    private func nextSequence() -> Int64 {
+        seqLock.lock()
+        defer { seqLock.unlock() }
+        nextSeq += 1
+        return nextSeq
+    }
+
+    private func callWithTimeout(
+        pending table: ClientPendingTable,
+        seq: Int64,
+        timeout: Duration,
+        send: @escaping () throws -> Void
+    ) async throws -> Data {
+        let timeoutTask = Task { [table] in
+            do {
+                try await Task.sleep(for: timeout)
+            } catch {
+                return
+            }
+            await table.resolve(seq: seq, with: .failure(TransportError.requestTimeout(timeout)))
+        }
+        return try await withTaskCancellationHandler {
+            do {
+                let body = try await table.insert(seq: seq) { _ in
+                    do {
+                        try send()
+                    } catch {
+                        Task { [table] in
+                            await table.resolve(seq: seq, with: .failure(error))
+                        }
+                    }
+                }
+                timeoutTask.cancel()
+                return body
+            } catch {
+                timeoutTask.cancel()
+                throw error
+            }
+        } onCancel: {
+            timeoutTask.cancel()
+            Task { [table] in
+                await table.cancel(seq: seq)
+            }
+        }
+    }
+}

--- a/Sources/SwiftROS2Transport/DDSTransportSession.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession.swift
@@ -20,6 +20,8 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
     var subscribers: [DDSTransportSubscriberImpl] = []
     var serviceServers: [DDSTransportServiceServerImpl] = []
     var serviceClients: [DDSTransportServiceClientImpl] = []
+    var actionServers: [DDSTransportActionServerImpl] = []
+    var actionClients: [DDSTransportActionClientImpl] = []
     let lock = NSLock()
     private var _sessionId: String = ""
     var isOpen = false
@@ -97,6 +99,16 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
         let clients = takeAllServiceClients()
         for serviceClient in clients {
             try? serviceClient.close()
+        }
+
+        let aServers = takeAllActionServers()
+        for srv in aServers {
+            try? srv.close()
+        }
+
+        let aClients = takeAllActionClients()
+        for cli in aClients {
+            try? cli.close()
         }
 
         lock.lock()

--- a/Sources/SwiftROS2Transport/Internal/ActionFrameDecoder.swift
+++ b/Sources/SwiftROS2Transport/Internal/ActionFrameDecoder.swift
@@ -1,0 +1,194 @@
+// ActionFrameDecoder.swift
+// Pure CDR helpers for action wrapper frames (send_goal / get_result / feedback / status).
+//
+// Both the DDS and Zenoh action transports call into these helpers; there is
+// no I/O here. The byte layouts mirror what `rosidl_generator_cpp` emits for
+// the synthesized wrappers, validated by `Tests/SwiftROS2CDRTests/ActionWrappersCDRTests.swift`
+// (Phase 1) and the recorded wire dumps from Phase 2.
+
+import Foundation
+import SwiftROS2CDR
+
+enum ActionFrameDecoderError: Error {
+    case payloadTooShort
+    case invalidCount(UInt32)
+    case malformedFrame(String)
+}
+
+/// CDR helpers for the synthesized action wrapper frames.
+///
+/// Frames in/out of this enum carry the 4-byte XCDR encapsulation header
+/// (`00 01 00 00`). The transport calls `decode*` on incoming wire payloads
+/// and `encode*` on outgoing wire payloads.
+enum ActionFrameDecoder {
+    static let cdrHeader = Data([0x00, 0x01, 0x00, 0x00])
+
+    /// Status array entry — one per goal currently tracked server-side.
+    typealias StatusEntry = (uuid: [UInt8], stampSec: Int32, stampNanosec: UInt32, status: Int8)
+
+    // MARK: - SendGoal request
+
+    /// Wire shape: `[header (4) | uuid[16] | <user goal CDR>]`.
+    static func encodeSendGoalRequest(goalId: [UInt8], goalCDR: Data) -> Data {
+        precondition(goalId.count == 16, "goalId must be 16 bytes")
+        var out = Data(capacity: 4 + 16 + goalCDR.count)
+        out.append(cdrHeader)
+        out.append(contentsOf: goalId)
+        out.append(goalCDR)
+        return out
+    }
+
+    static func decodeSendGoalRequest(from data: Data) throws -> (goalId: [UInt8], goalCDR: Data) {
+        guard data.count >= 4 + 16 else { throw ActionFrameDecoderError.payloadTooShort }
+        let goalId = Array(data[(data.startIndex + 4)..<(data.startIndex + 4 + 16)])
+        let body = data.suffix(from: data.startIndex + 4 + 16)
+        return (goalId, Data(body))
+    }
+
+    // MARK: - SendGoal response
+
+    /// Wire shape: `[header (4) | accepted (1) | pad (3) | sec (i32 LE) | nanosec (u32 LE)]`.
+    /// The 3-byte pad satisfies the int32 alignment after the bool.
+    static func encodeSendGoalResponse(accepted: Bool, stampSec: Int32, stampNanosec: UInt32) -> Data {
+        var out = Data(capacity: 4 + 1 + 3 + 4 + 4)
+        out.append(cdrHeader)
+        out.append(accepted ? 1 : 0)
+        out.append(contentsOf: [0, 0, 0])
+        var sec = stampSec.littleEndian
+        var nsec = stampNanosec.littleEndian
+        withUnsafeBytes(of: &sec) { out.append(contentsOf: $0) }
+        withUnsafeBytes(of: &nsec) { out.append(contentsOf: $0) }
+        return out
+    }
+
+    static func decodeSendGoalResponse(from data: Data) throws -> (
+        accepted: Bool, stampSec: Int32, stampNanosec: UInt32
+    ) {
+        guard data.count >= 4 + 1 + 3 + 4 + 4 else { throw ActionFrameDecoderError.payloadTooShort }
+        let base = data.startIndex
+        let accepted = data[base + 4] != 0
+        let sec = data.withUnsafeBytes {
+            $0.loadUnaligned(fromByteOffset: 8, as: Int32.self).littleEndian
+        }
+        let nsec = data.withUnsafeBytes {
+            $0.loadUnaligned(fromByteOffset: 12, as: UInt32.self).littleEndian
+        }
+        return (accepted, sec, nsec)
+    }
+
+    // MARK: - GetResult request
+
+    /// Wire shape: `[header (4) | uuid[16]]`.
+    static func encodeGetResultRequest(goalId: [UInt8]) -> Data {
+        precondition(goalId.count == 16, "goalId must be 16 bytes")
+        var out = Data(capacity: 4 + 16)
+        out.append(cdrHeader)
+        out.append(contentsOf: goalId)
+        return out
+    }
+
+    static func decodeGetResultRequest(from data: Data) throws -> [UInt8] {
+        guard data.count >= 4 + 16 else { throw ActionFrameDecoderError.payloadTooShort }
+        return Array(data[(data.startIndex + 4)..<(data.startIndex + 4 + 16)])
+    }
+
+    // MARK: - GetResult response
+
+    /// Wire shape: `[header (4) | status (i8) | pad (3) | <user result CDR>]`.
+    /// Note the user CDR here is the bare result body — it does NOT carry its
+    /// own encapsulation header; that header was consumed when the umbrella
+    /// API encoded just the body fields.
+    static func encodeGetResultResponse(status: Int8, resultCDR: Data) -> Data {
+        var out = Data(capacity: 4 + 1 + 3 + resultCDR.count)
+        out.append(cdrHeader)
+        let s = UInt8(bitPattern: status)
+        out.append(s)
+        out.append(contentsOf: [0, 0, 0])
+        out.append(resultCDR)
+        return out
+    }
+
+    static func decodeGetResultResponse(from data: Data) throws -> (status: Int8, resultCDR: Data) {
+        guard data.count >= 4 + 1 + 3 else { throw ActionFrameDecoderError.payloadTooShort }
+        let base = data.startIndex
+        let status = Int8(bitPattern: data[base + 4])
+        let body = data.suffix(from: base + 4 + 1 + 3)
+        return (status, Data(body))
+    }
+
+    // MARK: - FeedbackMessage
+
+    /// Wire shape: `[header (4) | uuid[16] | <user feedback CDR>]`.
+    static func encodeFeedbackMessage(goalId: [UInt8], feedbackCDR: Data) -> Data {
+        precondition(goalId.count == 16, "goalId must be 16 bytes")
+        var out = Data(capacity: 4 + 16 + feedbackCDR.count)
+        out.append(cdrHeader)
+        out.append(contentsOf: goalId)
+        out.append(feedbackCDR)
+        return out
+    }
+
+    static func decodeFeedbackMessage(from data: Data) throws -> (
+        goalId: [UInt8], feedbackCDR: Data
+    ) {
+        guard data.count >= 4 + 16 else { throw ActionFrameDecoderError.payloadTooShort }
+        let goalId = Array(data[(data.startIndex + 4)..<(data.startIndex + 4 + 16)])
+        let body = data.suffix(from: data.startIndex + 4 + 16)
+        return (goalId, Data(body))
+    }
+
+    // MARK: - GoalStatusArray
+
+    /// Wire shape: `[header (4) | count (u32 LE) | { uuid[16] | sec (i32) | nanosec (u32) | status (i8) | pad (3) } * count ]`.
+    /// Each entry is 16 + 4 + 4 + 1 + 3 = 28 bytes (28 % 4 == 0).
+    static func encodeStatusArray(entries: [StatusEntry]) -> Data {
+        var out = Data(capacity: 4 + 4 + entries.count * 28)
+        out.append(cdrHeader)
+        var count = UInt32(entries.count).littleEndian
+        withUnsafeBytes(of: &count) { out.append(contentsOf: $0) }
+        for e in entries {
+            precondition(e.uuid.count == 16, "uuid must be 16 bytes")
+            out.append(contentsOf: e.uuid)
+            var sec = e.stampSec.littleEndian
+            var nsec = e.stampNanosec.littleEndian
+            withUnsafeBytes(of: &sec) { out.append(contentsOf: $0) }
+            withUnsafeBytes(of: &nsec) { out.append(contentsOf: $0) }
+            out.append(UInt8(bitPattern: e.status))
+            out.append(contentsOf: [0, 0, 0])
+        }
+        return out
+    }
+
+    static func decodeStatusArray(from data: Data) throws -> [StatusEntry] {
+        guard data.count >= 4 + 4 else { throw ActionFrameDecoderError.payloadTooShort }
+        let base = data.startIndex
+        let count = data.withUnsafeBytes {
+            $0.loadUnaligned(fromByteOffset: 4, as: UInt32.self).littleEndian
+        }
+        // Defensive cap mirrors `CDRDecoder.maxSequenceElements` (64 MiB / 28 bytes).
+        let maxCount: UInt32 = (64 * 1024 * 1024) / 28
+        guard count <= maxCount else { throw ActionFrameDecoderError.invalidCount(count) }
+        let needed = 4 + 4 + Int(count) * 28
+        guard data.count >= needed else { throw ActionFrameDecoderError.payloadTooShort }
+
+        var out: [StatusEntry] = []
+        out.reserveCapacity(Int(count))
+        var offset = base + 8
+        for _ in 0..<Int(count) {
+            let uuid = Array(data[offset..<(offset + 16)])
+            offset += 16
+            let sec = data.withUnsafeBytes {
+                $0.loadUnaligned(fromByteOffset: offset - base, as: Int32.self).littleEndian
+            }
+            offset += 4
+            let nsec = data.withUnsafeBytes {
+                $0.loadUnaligned(fromByteOffset: offset - base, as: UInt32.self).littleEndian
+            }
+            offset += 4
+            let status = Int8(bitPattern: data[offset])
+            offset += 1 + 3  // pad
+            out.append((uuid: uuid, stampSec: sec, stampNanosec: nsec, status: status))
+        }
+        return out
+    }
+}

--- a/Tests/SwiftROS2TransportTests/ActionFrameDecoderTests.swift
+++ b/Tests/SwiftROS2TransportTests/ActionFrameDecoderTests.swift
@@ -1,0 +1,94 @@
+// ActionFrameDecoderTests.swift
+// Round-trip tests for the per-frame CDR helpers shared between the DDS and Zenoh
+// action transports.
+
+import Foundation
+import XCTest
+
+@testable import SwiftROS2Transport
+
+final class ActionFrameDecoderTests: XCTestCase {
+    private let cdrHeader = Data([0x00, 0x01, 0x00, 0x00])  // XCDR v1 little-endian
+    private let goalId16 = [UInt8](repeating: 0xAB, count: 16)
+
+    func testEncodeDecodeSendGoalRequestRoundTrip() throws {
+        let goalCDR = Data([0xDE, 0xAD, 0xBE, 0xEF])  // user-encoded Goal payload
+        let frame = ActionFrameDecoder.encodeSendGoalRequest(goalId: goalId16, goalCDR: goalCDR)
+        let (parsedId, parsedGoal) = try ActionFrameDecoder.decodeSendGoalRequest(from: frame)
+        XCTAssertEqual(parsedId, goalId16)
+        XCTAssertEqual(parsedGoal, goalCDR)
+    }
+
+    func testDecodeSendGoalRequestTooShortThrows() {
+        let tooShort = Data([0x00, 0x01, 0x00, 0x00, 0x00])  // header + 1 byte
+        XCTAssertThrowsError(try ActionFrameDecoder.decodeSendGoalRequest(from: tooShort))
+    }
+
+    func testEncodeDecodeGetResultRequestRoundTrip() throws {
+        let frame = ActionFrameDecoder.encodeGetResultRequest(goalId: goalId16)
+        let parsedId = try ActionFrameDecoder.decodeGetResultRequest(from: frame)
+        XCTAssertEqual(parsedId, goalId16)
+    }
+
+    func testEncodeSendGoalResponse() {
+        let frame = ActionFrameDecoder.encodeSendGoalResponse(
+            accepted: true, stampSec: 7, stampNanosec: 11
+        )
+        // [header (4) | accepted (1) | pad (3) | sec (4) | nanosec (4)]
+        XCTAssertEqual(frame.count, 4 + 1 + 3 + 4 + 4)
+        XCTAssertEqual(frame[0..<4], cdrHeader)
+        XCTAssertEqual(frame[4], 1)
+        // Sec / nanosec start at offset 8 due to alignment.
+        let sec = frame.withUnsafeBytes {
+            $0.loadUnaligned(fromByteOffset: 8, as: Int32.self).littleEndian
+        }
+        let nsec = frame.withUnsafeBytes {
+            $0.loadUnaligned(fromByteOffset: 12, as: UInt32.self).littleEndian
+        }
+        XCTAssertEqual(sec, 7)
+        XCTAssertEqual(nsec, 11)
+    }
+
+    func testEncodeGetResultResponse() {
+        let userCDR = Data([0x11, 0x22, 0x33, 0x44])
+        let frame = ActionFrameDecoder.encodeGetResultResponse(
+            status: 4, resultCDR: userCDR
+        )
+        // [header (4) | status (1) | pad (3) | userCDR ...]
+        XCTAssertEqual(frame[0..<4], cdrHeader)
+        XCTAssertEqual(frame[4], 4)
+        XCTAssertEqual(frame.suffix(userCDR.count), userCDR)
+    }
+
+    func testEncodeDecodeFeedbackMessageRoundTrip() throws {
+        let userCDR = Data([0x77, 0x88])
+        let frame = ActionFrameDecoder.encodeFeedbackMessage(
+            goalId: goalId16, feedbackCDR: userCDR
+        )
+        let (parsedId, parsedFeedback) = try ActionFrameDecoder.decodeFeedbackMessage(
+            from: frame
+        )
+        XCTAssertEqual(parsedId, goalId16)
+        XCTAssertEqual(parsedFeedback, userCDR)
+    }
+
+    func testEncodeDecodeStatusArrayRoundTrip() throws {
+        let entries: [ActionFrameDecoder.StatusEntry] = [
+            (uuid: goalId16, stampSec: 1, stampNanosec: 2, status: 1),
+            (uuid: Array(repeating: 0xCD, count: 16), stampSec: 3, stampNanosec: 4, status: 4),
+        ]
+        let frame = ActionFrameDecoder.encodeStatusArray(entries: entries)
+        let parsed = try ActionFrameDecoder.decodeStatusArray(from: frame)
+        XCTAssertEqual(parsed.count, 2)
+        XCTAssertEqual(parsed[0].uuid, entries[0].uuid)
+        XCTAssertEqual(parsed[0].status, 1)
+        XCTAssertEqual(parsed[1].uuid, entries[1].uuid)
+        XCTAssertEqual(parsed[1].status, 4)
+    }
+
+    func testDecodeStatusArrayEmptyRoundTrip() throws {
+        let frame = ActionFrameDecoder.encodeStatusArray(entries: [])
+        let parsed = try ActionFrameDecoder.decodeStatusArray(from: frame)
+        XCTAssertTrue(parsed.isEmpty)
+    }
+}

--- a/Tests/SwiftROS2TransportTests/DDSActionTransportTests.swift
+++ b/Tests/SwiftROS2TransportTests/DDSActionTransportTests.swift
@@ -380,4 +380,105 @@ final class DDSActionTransportTests: XCTestCase {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
     }
+
+    func testClientWaitForActionServerThrowsWhenNoMatch() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        // Default mock never reports a publication match → must time out.
+        let client = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        do {
+            try await client.waitForActionServer(timeout: .milliseconds(300))
+            XCTFail("expected actionServerUnavailable")
+        } catch let e as TransportError {
+            if case .actionServerUnavailable = e { return }
+            XCTFail("got \(e) instead of actionServerUnavailable")
+        }
+    }
+
+    func testClientWaitForActionServerSucceedsWhenAllWritersMatch() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        let client = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        // Mark every request-side writer's topic as matched so the new
+        // all-3-writers wait condition resolves on the first poll.
+        let cli = client as! DDSTransportActionClientImpl
+        mock.markPublicationsMatched(topic: cli.names.sendGoalRequestTopic)
+        mock.markPublicationsMatched(topic: cli.names.cancelGoalRequestTopic)
+        mock.markPublicationsMatched(topic: cli.names.getResultRequestTopic)
+
+        try await client.waitForActionServer(timeout: .seconds(2))  // no throw expected
+    }
+
+    func testClientCancelGoalRoundTrip() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        let client = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        let goalId = [UInt8](repeating: 0xAA, count: 16)
+
+        // Server replies returnCode=0 with one canceling goal entry.
+        mock.serviceReplyHandler = { topic, prefixed in
+            guard topic.hasSuffix("cancel_goalRequest") else { return nil }
+            let (rid, _) =
+                (try? SampleIdentityPrefix.decode(wirePayload: prefixed))
+                ?? (RMWRequestId(writerGuid: [], sequenceNumber: 0), Data())
+            // [header (4) | code (1) | pad (3) | count (u32) | { uuid[16] | sec | nsec }]
+            var resp = Data([0x00, 0x01, 0x00, 0x00])
+            resp.append(0)  // returnCode = 0
+            resp.append(contentsOf: [0, 0, 0])
+            var count = UInt32(1).littleEndian
+            withUnsafeBytes(of: &count) { resp.append(contentsOf: $0) }
+            resp.append(contentsOf: goalId)
+            var sec = Int32(7).littleEndian
+            var nsec = UInt32(11).littleEndian
+            withUnsafeBytes(of: &sec) { resp.append(contentsOf: $0) }
+            withUnsafeBytes(of: &nsec) { resp.append(contentsOf: $0) }
+            return SampleIdentityPrefix.encode(requestId: rid, userCDR: resp)
+        }
+
+        let ack = try await client.cancelGoal(
+            goalId: goalId,
+            beforeStampSec: nil,
+            beforeStampNanosec: nil,
+            timeout: .seconds(2)
+        )
+        XCTAssertEqual(ack.returnCode, 0)
+        XCTAssertEqual(ack.goalsCanceling.count, 1)
+        XCTAssertEqual(ack.goalsCanceling[0].uuid, goalId)
+        XCTAssertEqual(ack.goalsCanceling[0].stampSec, 7)
+        XCTAssertEqual(ack.goalsCanceling[0].stampNanosec, 11)
+
+        // Confirm the request that went out on the wire carried the goal id.
+        let cancelTopic = (client as! DDSTransportActionClientImpl).names.cancelGoalRequestTopic
+        let writes = mock.writesByTopic[cancelTopic] ?? []
+        XCTAssertEqual(writes.count, 1)
+        let (_, reqCDR) = try SampleIdentityPrefix.decode(wirePayload: writes[0])
+        // Request frame: [header (4) | uuid[16] | sec | nsec]
+        XCTAssertEqual(reqCDR.count, 4 + 16 + 4 + 4)
+        XCTAssertEqual(
+            Array(reqCDR[(reqCDR.startIndex + 4)..<(reqCDR.startIndex + 20)]), goalId)
+    }
 }

--- a/Tests/SwiftROS2TransportTests/DDSActionTransportTests.swift
+++ b/Tests/SwiftROS2TransportTests/DDSActionTransportTests.swift
@@ -1,0 +1,383 @@
+// DDSActionTransportTests.swift
+// End-to-end action flows over the DDS transport via MockDDSClient.
+
+import Foundation
+import XCTest
+
+@testable import SwiftROS2Transport
+
+final class DDSActionTransportTests: XCTestCase {
+    func testCloseWalksActionServersAndClients() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        let handlers = TransportActionServerHandlers(
+            onSendGoal: { _, _ in (true, 0, 0) },
+            onCancelGoal: { _ in Data() },
+            onGetResult: { _ in GetResultAck(status: 4, resultCDR: Data()) }
+        )
+
+        let server = try session.createActionServer(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default,
+            handlers: handlers
+        )
+        let client = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        XCTAssertTrue(server.isActive)
+        XCTAssertTrue(client.isActive)
+
+        try session.close()
+
+        XCTAssertFalse(server.isActive)
+        XCTAssertFalse(client.isActive)
+    }
+
+    func testServerOnSendGoalAcceptsAndPublishesStatus() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        let acceptedExpect = expectation(description: "onSendGoal called")
+        let handlers = TransportActionServerHandlers(
+            onSendGoal: { goalId, _ in
+                XCTAssertEqual(goalId.count, 16)
+                acceptedExpect.fulfill()
+                return (true, 100, 200)
+            },
+            onCancelGoal: { _ in Data() },
+            onGetResult: { _ in GetResultAck(status: 4, resultCDR: Data()) }
+        )
+
+        let serverProto = try session.createActionServer(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default,
+            handlers: handlers
+        )
+        let server = serverProto as! DDSTransportActionServerImpl
+
+        // Drive a request through the mock send_goal request reader.
+        let goalId = [UInt8](repeating: 0xAA, count: 16)
+        let inboundFrame = ActionFrameDecoder.encodeSendGoalRequest(
+            goalId: goalId,
+            goalCDR: Data([0x11, 0x22])
+        )
+        let prefixed = SampleIdentityPrefix.encode(
+            requestId: RMWRequestId(
+                writerGuid: [UInt8](repeating: 0xCC, count: 16), sequenceNumber: 1),
+            userCDR: inboundFrame
+        )
+        mock.deliverRequestSample(topic: server.sendGoalRequestTopic, data: prefixed)
+
+        await fulfillment(of: [acceptedExpect], timeout: 1)
+
+        // Reply was written to the matching reply topic. The reply may land
+        // slightly after the handler returns (Task.detached scheduling), so
+        // poll briefly for it.
+        try await waitForWrite(mock: mock, topic: server.sendGoalReplyTopic, timeout: 1.0)
+        let writes = mock.writesByTopic[server.sendGoalReplyTopic] ?? []
+        XCTAssertEqual(writes.count, 1)
+        let (_, decodedReply) = try SampleIdentityPrefix.decode(wirePayload: writes[0])
+        let resp = try ActionFrameDecoder.decodeSendGoalResponse(from: decodedReply)
+        XCTAssertTrue(resp.accepted)
+        XCTAssertEqual(resp.stampSec, 100)
+        XCTAssertEqual(resp.stampNanosec, 200)
+    }
+
+    func testServerCancelGoalRoutesToHandler() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        let cancelExpect = expectation(description: "onCancelGoal called")
+        // The cancel-response CDR must include its 4-byte encapsulation header
+        // so `SampleIdentityPrefix.encode` can strip it before prefixing.
+        let cancelResponseCDR = Data([0x00, 0x01, 0x00, 0x00, 0xCC, 0xDD])
+        let handlers = TransportActionServerHandlers(
+            onSendGoal: { _, _ in (false, 0, 0) },
+            onCancelGoal: { req in
+                XCTAssertFalse(req.isEmpty)
+                cancelExpect.fulfill()
+                return cancelResponseCDR
+            },
+            onGetResult: { _ in GetResultAck(status: 4, resultCDR: Data()) }
+        )
+
+        let serverProto = try session.createActionServer(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default,
+            handlers: handlers
+        )
+        let server = serverProto as! DDSTransportActionServerImpl
+
+        let prefixed = SampleIdentityPrefix.encode(
+            requestId: RMWRequestId(
+                writerGuid: [UInt8](repeating: 0xCC, count: 16), sequenceNumber: 2),
+            userCDR: Data([0x00, 0x01, 0x00, 0x00, 0x42])  // arbitrary cancel payload
+        )
+        mock.deliverRequestSample(topic: server.cancelGoalRequestTopic, data: prefixed)
+        await fulfillment(of: [cancelExpect], timeout: 1)
+
+        try await waitForWrite(mock: mock, topic: server.cancelGoalReplyTopic, timeout: 1.0)
+        let writes = mock.writesByTopic[server.cancelGoalReplyTopic] ?? []
+        XCTAssertEqual(writes.count, 1)
+        let (_, decoded) = try SampleIdentityPrefix.decode(wirePayload: writes[0])
+        XCTAssertEqual(decoded, cancelResponseCDR)
+    }
+
+    func testServerPublishFeedbackEmitsToFeedbackTopic() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        let serverProto = try session.createActionServer(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default,
+            handlers: TransportActionServerHandlers(
+                onSendGoal: { _, _ in (true, 0, 0) },
+                onCancelGoal: { _ in Data() },
+                onGetResult: { _ in GetResultAck(status: 4, resultCDR: Data()) }
+            )
+        )
+        let server = serverProto as! DDSTransportActionServerImpl
+        let goalId = [UInt8](repeating: 0xAA, count: 16)
+        try server.publishFeedback(goalId: goalId, feedbackCDR: Data([0x77]))
+
+        let writes = mock.writesByTopic[server.feedbackTopic] ?? []
+        XCTAssertEqual(writes.count, 1)
+        let (parsedId, parsedFB) = try ActionFrameDecoder.decodeFeedbackMessage(from: writes[0])
+        XCTAssertEqual(parsedId, goalId)
+        XCTAssertEqual(parsedFB, Data([0x77]))
+    }
+
+    func testServerPublishStatusArrayEmitsToStatusTopic() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        let serverProto = try session.createActionServer(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default,
+            handlers: TransportActionServerHandlers(
+                onSendGoal: { _, _ in (true, 0, 0) },
+                onCancelGoal: { _ in Data() },
+                onGetResult: { _ in GetResultAck(status: 4, resultCDR: Data()) }
+            )
+        )
+        let server = serverProto as! DDSTransportActionServerImpl
+        let goalId = [UInt8](repeating: 0xBB, count: 16)
+        try server.publishStatus(entries: [
+            (uuid: goalId, stampSec: 1, stampNanosec: 2, status: 4)
+        ])
+        let writes = mock.writesByTopic[server.statusTopic] ?? []
+        XCTAssertEqual(writes.count, 1)
+        let parsed = try ActionFrameDecoder.decodeStatusArray(from: writes[0])
+        XCTAssertEqual(parsed.count, 1)
+        XCTAssertEqual(parsed[0].status, 4)
+    }
+
+    func testClientSendGoalAcceptedYieldsFeedback() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        let clientProto = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        let client = clientProto as! DDSTransportActionClientImpl
+
+        let goalId = [UInt8](repeating: 0xAA, count: 16)
+        let goalCDR = Data([0x33, 0x44])
+
+        // Pre-stage the mock to reply success on send_goal request.
+        mock.serviceReplyHandler = { requestTopic, prefixedRequestCDR in
+            guard requestTopic.hasSuffix("send_goalRequest") else { return nil }
+            guard let (rid, _) = try? SampleIdentityPrefix.decode(wirePayload: prefixedRequestCDR)
+            else { return nil }
+            let response = ActionFrameDecoder.encodeSendGoalResponse(
+                accepted: true, stampSec: 99, stampNanosec: 0
+            )
+            return SampleIdentityPrefix.encode(requestId: rid, userCDR: response)
+        }
+
+        let ack = try await client.sendGoal(
+            goalId: goalId,
+            goalCDR: goalCDR,
+            acceptanceTimeout: .seconds(2)
+        )
+        XCTAssertTrue(ack.accepted)
+        XCTAssertEqual(ack.stampSec, 99)
+
+        // Drive a feedback sample for that goal.
+        let fbFrame = ActionFrameDecoder.encodeFeedbackMessage(
+            goalId: goalId, feedbackCDR: Data([0x77])
+        )
+        mock.deliverSubscriberSample(topic: client.feedbackTopic, data: fbFrame)
+
+        var receivedFB: Data?
+        for await frame in ack.feedback {
+            receivedFB = frame
+            break
+        }
+        XCTAssertEqual(receivedFB, Data([0x77]))
+    }
+
+    func testClientSendGoalRejectedSurfacesAcceptedFalse() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        let client = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        mock.serviceReplyHandler = { topic, prefixed in
+            guard topic.hasSuffix("send_goalRequest") else { return nil }
+            guard let (rid, _) = try? SampleIdentityPrefix.decode(wirePayload: prefixed) else {
+                return nil
+            }
+            let response = ActionFrameDecoder.encodeSendGoalResponse(
+                accepted: false, stampSec: 0, stampNanosec: 0)
+            return SampleIdentityPrefix.encode(requestId: rid, userCDR: response)
+        }
+
+        let ack = try await client.sendGoal(
+            goalId: [UInt8](repeating: 0xAA, count: 16),
+            goalCDR: Data(),
+            acceptanceTimeout: .seconds(2)
+        )
+        XCTAssertFalse(ack.accepted)
+    }
+
+    func testClientGetResultBlocksUntilReply() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        let client = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        mock.serviceReplyHandler = { topic, prefixed in
+            guard topic.hasSuffix("get_resultRequest") else { return nil }
+            guard let (rid, _) = try? SampleIdentityPrefix.decode(wirePayload: prefixed) else {
+                return nil
+            }
+            let response = ActionFrameDecoder.encodeGetResultResponse(
+                status: 4, resultCDR: Data([0xAA, 0xBB])
+            )
+            return SampleIdentityPrefix.encode(requestId: rid, userCDR: response)
+        }
+
+        let ack = try await client.getResult(
+            goalId: [UInt8](repeating: 0xAA, count: 16),
+            timeout: .seconds(2)
+        )
+        XCTAssertEqual(ack.status, 4)
+        XCTAssertEqual(ack.resultCDR, Data([0xAA, 0xBB]))
+    }
+
+    func testClientStatusFiltersByGoalId() async throws {
+        let mock = MockDDSClient()
+        let session = DDSTransportSession(client: mock)
+        try await session.open(config: .ddsMulticast(domainId: 0))
+        defer { try? session.close() }
+
+        let clientProto = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        let client = clientProto as! DDSTransportActionClientImpl
+        let myGoal = [UInt8](repeating: 0xAA, count: 16)
+        let otherGoal = [UInt8](repeating: 0xBB, count: 16)
+
+        mock.serviceReplyHandler = { topic, prefixed in
+            guard topic.hasSuffix("send_goalRequest") else { return nil }
+            guard let (rid, _) = try? SampleIdentityPrefix.decode(wirePayload: prefixed) else {
+                return nil
+            }
+            let response = ActionFrameDecoder.encodeSendGoalResponse(
+                accepted: true, stampSec: 0, stampNanosec: 0)
+            return SampleIdentityPrefix.encode(requestId: rid, userCDR: response)
+        }
+        let ack = try await client.sendGoal(
+            goalId: myGoal,
+            goalCDR: Data(),
+            acceptanceTimeout: .seconds(2)
+        )
+        XCTAssertTrue(ack.accepted)
+
+        // Push a status array containing both my goal and another goal.
+        let frame = ActionFrameDecoder.encodeStatusArray(entries: [
+            (uuid: otherGoal, stampSec: 0, stampNanosec: 0, status: 2),
+            (uuid: myGoal, stampSec: 0, stampNanosec: 0, status: 1),
+            (uuid: myGoal, stampSec: 0, stampNanosec: 0, status: 4),
+        ])
+        mock.deliverSubscriberSample(topic: client.statusTopic, data: frame)
+
+        var seen: [Int8] = []
+        for await update in ack.status {
+            seen.append(update.status)
+        }
+        // Other-goal status filtered out; mine arrive in order; terminal closes the stream.
+        XCTAssertEqual(seen, [1, 4])
+    }
+
+    // MARK: - Helpers
+
+    private func defaultHashes() -> ActionRoleTypeHashes {
+        return ActionRoleTypeHashes(
+            sendGoalRequest: nil, sendGoalResponse: nil,
+            cancelGoalRequest: nil, cancelGoalResponse: nil,
+            getResultRequest: nil, getResultResponse: nil,
+            feedbackMessage: nil, statusArray: nil
+        )
+    }
+
+    /// Poll the mock until at least one write has landed on `topic` or the
+    /// timeout elapses. Detached server tasks may write the reply slightly
+    /// after the handler returns, so a tiny poll is necessary.
+    private func waitForWrite(
+        mock: MockDDSClient, topic: String, timeout: TimeInterval
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let entries = mock.writesByTopic[topic], !entries.isEmpty {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+}

--- a/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockDDSClient.swift
@@ -33,6 +33,24 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
     // for the next 5 ms poll tick.
     private var writeWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
 
+    /// Test hook: closure invoked on every `writeRawCDR` to a request-style
+    /// topic (suffix matching is the caller's job). If it returns non-nil
+    /// bytes, the mock synchronously delivers those bytes to readers on the
+    /// matching reply topic — a quick way to wire up service / action
+    /// request-reply round-trips without a real DDS bus.
+    var serviceReplyHandler: (@Sendable (_ requestTopic: String, _ requestData: Data) -> Data?)?
+
+    /// Test helper: per-topic capture of every `writeRawCDR` payload.
+    var writesByTopic: [String: [Data]] {
+        lock.lock()
+        defer { lock.unlock() }
+        var out: [String: [Data]] = [:]
+        for w in writes {
+            out[w.topic, default: []].append(w.data)
+        }
+        return out
+    }
+
     func createSession(domainId: Int32, discoveryConfig: DDSBridgeDiscoveryConfig) throws {
         lock.lock()
         defer { lock.unlock() }
@@ -74,15 +92,37 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
 
     func writeRawCDR(writer: any DDSWriterHandle, data: Data, timestamp: UInt64) throws {
         let waitersToWake: [CheckedContinuation<Void, Never>]
+        let topic: String
+        let replyHandler: (@Sendable (String, Data) -> Data?)?
         do {
             lock.lock()
             defer { lock.unlock() }
             if let e = writeShouldThrow { throw e }
-            let topic = (writer as? MockDDSWriterHandle)?.topic ?? "<unknown>"
+            topic = (writer as? MockDDSWriterHandle)?.topic ?? "<unknown>"
             writes.append((topic, data, timestamp))
             waitersToWake = writeWaiters.removeValue(forKey: topic) ?? []
+            replyHandler = serviceReplyHandler
         }
         for waiter in waitersToWake { waiter.resume() }
+
+        // If a reply handler is registered and the write landed on a request
+        // topic, invoke it and route any returned reply bytes to the matching
+        // reply topic's readers. The reply-topic mapping mirrors what
+        // `DDSWireCodec` produces: `rq/<path>Request` → `rr/<path>Reply`.
+        if let replyHandler, let replyBytes = replyHandler(topic, data),
+            let replyTopic = Self.replyTopic(forRequestTopic: topic)
+        {
+            deliver(toTopic: replyTopic, data: replyBytes, timestamp: 0)
+        }
+    }
+
+    /// Map a `rq/<path>Request` topic to its paired `rr/<path>Reply` topic.
+    /// Used by the in-process service-reply test hook. Returns `nil` if the
+    /// input does not match the expected request-topic shape.
+    private static func replyTopic(forRequestTopic topic: String) -> String? {
+        guard topic.hasPrefix("rq/"), topic.hasSuffix("Request") else { return nil }
+        let body = topic.dropFirst("rq/".count).dropLast("Request".count)
+        return "rr/\(body)Reply"
     }
 
     func destroyWriter(_ writer: any DDSWriterHandle) {
@@ -127,6 +167,21 @@ final class MockDDSClient: DDSClientProtocol, @unchecked Sendable {
     /// real-network callers; the underlying delivery is synchronous.
     func deliverToReader(topic: String, wire: Data, timestamp: UInt64) async throws {
         deliver(toTopic: topic, data: wire, timestamp: timestamp)
+    }
+
+    /// Test helper used by action / service tests: deliver a request-style
+    /// sample (the bytes have already been wrapped by `SampleIdentityPrefix`)
+    /// to readers on the given request topic. Synonym for `deliver` — exists
+    /// to match the action-transport plan vocabulary.
+    func deliverRequestSample(topic: String, data: Data) {
+        deliver(toTopic: topic, data: data, timestamp: 0)
+    }
+
+    /// Test helper used by action tests: deliver a subscriber-style sample
+    /// (e.g. a `_action/feedback` or `_action/status` frame) to readers on
+    /// the given topic.
+    func deliverSubscriberSample(topic: String, data: Data) {
+        deliver(toTopic: topic, data: data, timestamp: 0)
     }
 
     /// Wait up to `timeout` for a `writeRawCDR` on `topic`. If one has


### PR DESCRIPTION
## Summary

Phase 4 of 6 for ROS 2 Actions support. Implements the DDS side of the action transport on top of the Phase 3 protocols:

- `DDSTransportSession.createActionServer` / `createActionClient` overrides.
- `DDSTransportActionServerImpl` — 3 service-pair handlers (`send_goal`, `cancel_goal`, `get_result`) + 2 publishers (`feedback`, `status`); `publishFeedback` / `publishStatus`.
- `DDSTransportActionClientImpl` — 3 service-pair clients + 2 subscribers; per-goal feedback / status routing via `ActionPendingTable`.
- `ActionFrameDecoder` — pure CDR helpers for the synthesized wrapper frames (reused by the Zenoh transport in Phase 5).
- `MockDDSClient` test extensions: `serviceReplyHandler` closure + `deliverRequestSample` / `deliverSubscriberSample` / `writesByTopic` helpers for in-process end-to-end testing.
- 17 new transport-tests (8 frame-decoder + 9 end-to-end DDS).

Reuses every existing rq/rr/rt primitive — no new C-bridge surface. Status topic uses transient_local depth 1 to match rclcpp.

Stacked on top of #79 (Phase 3); Zenoh side follows in Phase 5; umbrella API in Phase 6.

## Test plan

- [x] `swift test --parallel` — 327 tests pass locally on macOS (Apple Silicon)
- [x] `swift format lint --strict` over `Sources/SwiftROS2Transport` and `Tests/SwiftROS2TransportTests` — clean
- [ ] CI build/test on Linux (humble/jazzy/rolling × x86_64/aarch64), Windows, Android