### PR TITLE
feat(transport): Zenoh action server / client (phase 5 of 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ActionFrameDecoder` (internal): pure CDR helpers for the synthesized wrapper frames (encode/decode for `SendGoal{Request,Response}`, `GetResult{Request,Response}`, `FeedbackMessage`, `GoalStatusArray`). 8 round-trip + bounds tests.
   - `MockDDSClient` (test scope): new `serviceReplyHandler` closure + `deliverRequestSample` / `deliverSubscriberSample` test helpers, lets DDS action tests drive end-to-end flows in-process.
   - 9 new transport-tests cover server-side dispatch, client-side acceptance / rejection / result / cancel, goal-id filtering, and close-walk lifecycle.
+- **ROS 2 Actions — Zenoh transport (phase 5 of 6, targeting 0.8.0).**
+  - `ZenohTransportSession.createActionServer(...)` and `createActionClient(...)` overrides — full server / client over Zenoh queryables (3 services), publishers (`feedback`, `status`), and `SA` / `CA` liveliness tokens. Reuses `ActionFrameDecoder` from Phase 4; no new C-bridge surface.
+  - `ZenohTransportActionServerImpl`: 3 queryables for `send_goal` / `cancel_goal` / `get_result`, plus 2 publishers and a single `SA` liveliness anchor on the `send_goal` request type.
+  - `ZenohTransportActionClientImpl`: 3 `get(...)` callers, 2 subscribers with goal-id filtering routed through `ActionPendingTable`, a `CA` liveliness token announcement, and `waitForActionServer` that polls the `send_goal` queryable with a 200ms `get` until any reply lands or `timeout` elapses (throws `TransportError.actionServerUnavailable` on miss).
+  - `MockZenohClient` (test scope): new `getReplyHandler`, `putsByKey`, `declaredLivelinessTokens`, `deliverQuery`, and `deliverSubscriberSample` test helpers.
+  - 8 new transport-tests cover server queryable dispatch, feedback / status publication + liveliness, client send_goal / get_result / status filtering, and `waitForActionServer` timeout.
 - **DDS on Windows** — full DDS path (CCycloneDDS, CDDSBridge, SwiftROS2DDS, the SwiftROS2 umbrella, the talker / listener / srv-server / srv-client examples, and the DDS / umbrella tests) now ships on Windows x86_64 when `CYCLONEDDS_DIR` points at a `vcpkg install cyclonedds:x64-windows` tree. Package.swift threads `-I<dir>/include` and `-L<dir>/lib` into CDDSBridge so `#include <dds/dds.h>` and the `-lddsc` link from the CCycloneDDS modulemap resolve against the vcpkg layout. `build-windows` CI now installs the vcpkg port, exports `CYCLONEDDS_DIR`, and runs the full `swift build` + `swift test --parallel`. (#37)
 
 ### Changed

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Action.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Action.swift
@@ -1,0 +1,698 @@
+// ZenohTransportSession+Action.swift
+// Action Server / Client implementation for the Zenoh transport.
+//
+// Mirrors the DDS action transport (Phase 4) but layered on Zenoh's native
+// queryable / get / put / subscribe primitives. Reuses `ActionFrameDecoder`
+// from Phase 4 for frame layouts — Zenoh and DDS share the synthesized
+// wrapper CDR shapes (DDS additionally prefixes a 24-byte `RMWRequestId`
+// for the request/reply paths; Zenoh skips that since the queryable handles
+// correlation natively).
+//
+// Server side declares 3 queryables (`send_goal` / `cancel_goal` /
+// `get_result`), 2 publishers (`feedback` / `status`), and one `SA`
+// liveliness token anchored on the `send_goal` request type.
+//
+// Client side declares 3 `get(...)` callers (one per service role), 2
+// subscribers with goal-id filtering routed through `ActionPendingTable`,
+// and one `CA` liveliness token announcement.
+
+import Foundation
+import SwiftROS2Wire
+
+extension ZenohTransportSession {
+    public func createActionServer(
+        name: String,
+        actionTypeName: String,
+        roleTypeHashes: ActionRoleTypeHashes,
+        qos: TransportQoS,
+        handlers: TransportActionServerHandlers
+    ) throws -> any TransportActionServer {
+        guard !name.isEmpty else {
+            throw TransportError.invalidConfiguration("Action name cannot be empty")
+        }
+        guard !actionTypeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Action type name cannot be empty")
+        }
+        guard isConnected else { throw TransportError.notConnected }
+        guard let cfg = config else { throw TransportError.notConnected }
+
+        let codec = ZenohWireCodec(distro: resolvedWireMode ?? .jazzy)
+        let ns = extractNamespace(from: name)
+        let actionLeaf = extractTopicName(from: name)
+
+        let sendGoalKey = codec.makeActionKeyExpr(
+            role: .sendGoal, domainId: cfg.domainId, namespace: ns,
+            actionName: actionLeaf, actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.sendGoalRequest
+        )
+        let cancelGoalKey = codec.makeActionKeyExpr(
+            role: .cancelGoal, domainId: cfg.domainId, namespace: ns,
+            actionName: actionLeaf, actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.cancelGoalRequest
+        )
+        let getResultKey = codec.makeActionKeyExpr(
+            role: .getResult, domainId: cfg.domainId, namespace: ns,
+            actionName: actionLeaf, actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.getResultRequest
+        )
+        let feedbackKey = codec.makeActionKeyExpr(
+            role: .feedback, domainId: cfg.domainId, namespace: ns,
+            actionName: actionLeaf, actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.feedbackMessage
+        )
+        let statusKey = codec.makeActionKeyExpr(
+            role: .status, domainId: cfg.domainId, namespace: ns,
+            actionName: actionLeaf, actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.statusArray
+        )
+
+        let livelinessTokenKey = codec.makeActionLivelinessToken(
+            entityKind: .actionServer,
+            domainId: cfg.domainId,
+            sessionId: sessionId,
+            nodeId: "0",
+            entityId: "0",
+            namespace: ns,
+            nodeName: "swift_ros2_action_server",
+            actionName: actionLeaf,
+            actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.sendGoalRequest,
+            qos: TransportQoSMapper.toWireQoSPolicy(qos)
+        )
+
+        let server = ZenohTransportActionServerImpl(
+            client: client,
+            name: name,
+            handlers: handlers,
+            sendGoalKeyExpr: sendGoalKey,
+            cancelGoalKeyExpr: cancelGoalKey,
+            getResultKeyExpr: getResultKey,
+            feedbackKeyExpr: feedbackKey,
+            statusKeyExpr: statusKey
+        )
+
+        do {
+            let q1 = try client.declareQueryable(sendGoalKey) { [weak server] q in
+                server?.handleSendGoalQuery(q)
+            }
+            let q2 = try client.declareQueryable(cancelGoalKey) { [weak server] q in
+                server?.handleCancelGoalQuery(q)
+            }
+            let q3 = try client.declareQueryable(getResultKey) { [weak server] q in
+                server?.handleGetResultQuery(q)
+            }
+            let token = try client.declareLivelinessToken(livelinessTokenKey)
+            server.attach(queryables: [q1, q2, q3], livelinessToken: token)
+        } catch let e as ZenohError {
+            throw TransportError.subscriberCreationFailed(e.localizedDescription ?? "\(e)")
+        }
+
+        appendActionServer(server)
+        return server
+    }
+
+    public func createActionClient(
+        name: String,
+        actionTypeName: String,
+        roleTypeHashes: ActionRoleTypeHashes,
+        qos: TransportQoS
+    ) throws -> any TransportActionClient {
+        guard !name.isEmpty else {
+            throw TransportError.invalidConfiguration("Action name cannot be empty")
+        }
+        guard !actionTypeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Action type name cannot be empty")
+        }
+        guard isConnected else { throw TransportError.notConnected }
+        guard let cfg = config else { throw TransportError.notConnected }
+
+        let codec = ZenohWireCodec(distro: resolvedWireMode ?? .jazzy)
+        let ns = extractNamespace(from: name)
+        let actionLeaf = extractTopicName(from: name)
+
+        let sendGoalKey = codec.makeActionKeyExpr(
+            role: .sendGoal, domainId: cfg.domainId, namespace: ns,
+            actionName: actionLeaf, actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.sendGoalRequest
+        )
+        let cancelGoalKey = codec.makeActionKeyExpr(
+            role: .cancelGoal, domainId: cfg.domainId, namespace: ns,
+            actionName: actionLeaf, actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.cancelGoalRequest
+        )
+        let getResultKey = codec.makeActionKeyExpr(
+            role: .getResult, domainId: cfg.domainId, namespace: ns,
+            actionName: actionLeaf, actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.getResultRequest
+        )
+        let feedbackKey = codec.makeActionKeyExpr(
+            role: .feedback, domainId: cfg.domainId, namespace: ns,
+            actionName: actionLeaf, actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.feedbackMessage
+        )
+        let statusKey = codec.makeActionKeyExpr(
+            role: .status, domainId: cfg.domainId, namespace: ns,
+            actionName: actionLeaf, actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.statusArray
+        )
+
+        let livelinessTokenKey = codec.makeActionLivelinessToken(
+            entityKind: .actionClient,
+            domainId: cfg.domainId,
+            sessionId: sessionId,
+            nodeId: "0",
+            entityId: "0",
+            namespace: ns,
+            nodeName: "swift_ros2_action_client",
+            actionName: actionLeaf,
+            actionTypeName: actionTypeName,
+            roleTypeHash: roleTypeHashes.sendGoalRequest,
+            qos: TransportQoSMapper.toWireQoSPolicy(qos)
+        )
+
+        let cli = ZenohTransportActionClientImpl(
+            client: client,
+            name: name,
+            sendGoalKeyExpr: sendGoalKey,
+            cancelGoalKeyExpr: cancelGoalKey,
+            getResultKeyExpr: getResultKey,
+            feedbackKeyExpr: feedbackKey,
+            statusKeyExpr: statusKey
+        )
+
+        do {
+            let fbSub = try client.subscribe(keyExpr: feedbackKey) { [weak cli] sample in
+                cli?.handleFeedbackSample(payload: sample.payload)
+            }
+            let stSub = try client.subscribe(keyExpr: statusKey) { [weak cli] sample in
+                cli?.handleStatusSample(payload: sample.payload)
+            }
+            let token = try client.declareLivelinessToken(livelinessTokenKey)
+            cli.attach(feedbackSub: fbSub, statusSub: stSub, livelinessToken: token)
+        } catch let e as ZenohError {
+            throw TransportError.subscriberCreationFailed(e.localizedDescription ?? "\(e)")
+        }
+
+        appendActionClient(cli)
+        return cli
+    }
+
+    // MARK: - Internal lock helpers
+
+    func appendActionServer(_ s: ZenohTransportActionServerImpl) {
+        publishersLock.lock()
+        actionServers.append(s)
+        publishersLock.unlock()
+    }
+
+    func appendActionClient(_ c: ZenohTransportActionClientImpl) {
+        publishersLock.lock()
+        actionClients.append(c)
+        publishersLock.unlock()
+    }
+
+    func takeAllActionServers() -> [ZenohTransportActionServerImpl] {
+        publishersLock.lock()
+        let out = actionServers
+        actionServers.removeAll()
+        publishersLock.unlock()
+        return out
+    }
+
+    func takeAllActionClients() -> [ZenohTransportActionClientImpl] {
+        publishersLock.lock()
+        let out = actionClients
+        actionClients.removeAll()
+        publishersLock.unlock()
+        return out
+    }
+}
+
+// MARK: - Zenoh Transport Action Server
+
+final class ZenohTransportActionServerImpl: TransportActionServer, @unchecked Sendable {
+    let client: any ZenohClientProtocol
+    let name: String
+    let handlers: TransportActionServerHandlers
+    let sendGoalKeyExpr: String
+    let cancelGoalKeyExpr: String
+    let getResultKeyExpr: String
+    let feedbackKeyExpr: String
+    let statusKeyExpr: String
+
+    private var queryables: [any ZenohQueryableHandle] = []
+    private var livelinessToken: (any ZenohLivelinessTokenHandle)?
+    private let lock = NSLock()
+    private var closed = false
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed && !queryables.isEmpty
+    }
+
+    init(
+        client: any ZenohClientProtocol,
+        name: String,
+        handlers: TransportActionServerHandlers,
+        sendGoalKeyExpr: String,
+        cancelGoalKeyExpr: String,
+        getResultKeyExpr: String,
+        feedbackKeyExpr: String,
+        statusKeyExpr: String
+    ) {
+        self.client = client
+        self.name = name
+        self.handlers = handlers
+        self.sendGoalKeyExpr = sendGoalKeyExpr
+        self.cancelGoalKeyExpr = cancelGoalKeyExpr
+        self.getResultKeyExpr = getResultKeyExpr
+        self.feedbackKeyExpr = feedbackKeyExpr
+        self.statusKeyExpr = statusKeyExpr
+    }
+
+    func attach(
+        queryables: [any ZenohQueryableHandle],
+        livelinessToken: any ZenohLivelinessTokenHandle
+    ) {
+        lock.lock()
+        self.queryables = queryables
+        self.livelinessToken = livelinessToken
+        lock.unlock()
+    }
+
+    func handleSendGoalQuery(_ query: any ZenohQueryHandle) {
+        let payload = query.payload
+        let captured = handlers
+        Task {
+            do {
+                let (goalId, goalCDR) = try ActionFrameDecoder.decodeSendGoalRequest(from: payload)
+                let (accepted, sec, nsec) = try await captured.onSendGoal(goalId, goalCDR)
+                let reply = ActionFrameDecoder.encodeSendGoalResponse(
+                    accepted: accepted, stampSec: sec, stampNanosec: nsec
+                )
+                try? query.reply(payload: reply, attachment: nil)
+            } catch {
+                try? query.replyError(message: error.localizedDescription)
+            }
+        }
+    }
+
+    func handleCancelGoalQuery(_ query: any ZenohQueryHandle) {
+        let payload = query.payload
+        let captured = handlers
+        Task {
+            do {
+                let response = try await captured.onCancelGoal(payload)
+                try? query.reply(payload: response, attachment: nil)
+            } catch {
+                try? query.replyError(message: error.localizedDescription)
+            }
+        }
+    }
+
+    func handleGetResultQuery(_ query: any ZenohQueryHandle) {
+        let payload = query.payload
+        let captured = handlers
+        Task {
+            do {
+                let goalId = try ActionFrameDecoder.decodeGetResultRequest(from: payload)
+                let ack = try await captured.onGetResult(goalId)
+                let reply = ActionFrameDecoder.encodeGetResultResponse(
+                    status: ack.status, resultCDR: ack.resultCDR
+                )
+                try? query.reply(payload: reply, attachment: nil)
+            } catch {
+                try? query.replyError(message: error.localizedDescription)
+            }
+        }
+    }
+
+    func publishFeedback(goalId: [UInt8], feedbackCDR: Data) throws {
+        let frame = ActionFrameDecoder.encodeFeedbackMessage(
+            goalId: goalId, feedbackCDR: feedbackCDR
+        )
+        try client.put(keyExpr: feedbackKeyExpr, payload: frame, attachment: nil)
+    }
+
+    func publishStatus(entries: [ActionFrameDecoder.StatusEntry]) throws {
+        let frame = ActionFrameDecoder.encodeStatusArray(entries: entries)
+        try client.put(keyExpr: statusKeyExpr, payload: frame, attachment: nil)
+    }
+
+    func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let qs = queryables
+        let token = livelinessToken
+        queryables.removeAll()
+        livelinessToken = nil
+        lock.unlock()
+
+        for q in qs {
+            try? q.close()
+        }
+        try? token?.close()
+    }
+}
+
+// MARK: - Zenoh Transport Action Client
+
+final class ZenohTransportActionClientImpl: TransportActionClient, @unchecked Sendable {
+    private let client: any ZenohClientProtocol
+    let name: String
+    let sendGoalKeyExpr: String
+    let cancelGoalKeyExpr: String
+    let getResultKeyExpr: String
+    let feedbackKeyExpr: String
+    let statusKeyExpr: String
+
+    private var feedbackSub: (any ZenohSubscriberHandle)?
+    private var statusSub: (any ZenohSubscriberHandle)?
+    private var livelinessToken: (any ZenohLivelinessTokenHandle)?
+    private let lock = NSLock()
+    private var closed = false
+
+    let pending = ActionPendingTable()
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+
+    init(
+        client: any ZenohClientProtocol,
+        name: String,
+        sendGoalKeyExpr: String,
+        cancelGoalKeyExpr: String,
+        getResultKeyExpr: String,
+        feedbackKeyExpr: String,
+        statusKeyExpr: String
+    ) {
+        self.client = client
+        self.name = name
+        self.sendGoalKeyExpr = sendGoalKeyExpr
+        self.cancelGoalKeyExpr = cancelGoalKeyExpr
+        self.getResultKeyExpr = getResultKeyExpr
+        self.feedbackKeyExpr = feedbackKeyExpr
+        self.statusKeyExpr = statusKeyExpr
+    }
+
+    func attach(
+        feedbackSub: any ZenohSubscriberHandle,
+        statusSub: any ZenohSubscriberHandle,
+        livelinessToken: any ZenohLivelinessTokenHandle
+    ) {
+        lock.lock()
+        self.feedbackSub = feedbackSub
+        self.statusSub = statusSub
+        self.livelinessToken = livelinessToken
+        lock.unlock()
+    }
+
+    func waitForActionServer(timeout: Duration) async throws {
+        let probeMs: UInt32 = 200
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            let remaining = ZenohTransportActionClientImpl.durationToMillis(
+                deadline - ContinuousClock.now
+            )
+            if remaining == 0 { break }
+            let attempt = min(probeMs, remaining)
+            if await probeOnce(timeoutMs: attempt) {
+                return
+            }
+        }
+        throw TransportError.actionServerUnavailable
+    }
+
+    private func probeOnce(timeoutMs: UInt32) async -> Bool {
+        await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            let resumed = ActionOnceFlag()
+            do {
+                try client.get(
+                    keyExpr: sendGoalKeyExpr,
+                    payload: nil,
+                    attachment: nil,
+                    timeoutMs: timeoutMs,
+                    handler: { _ in
+                        if resumed.set() {
+                            cont.resume(returning: true)
+                        }
+                    },
+                    onFinish: {
+                        if resumed.set() {
+                            cont.resume(returning: false)
+                        }
+                    }
+                )
+            } catch {
+                if resumed.set() {
+                    cont.resume(returning: false)
+                }
+            }
+        }
+    }
+
+    func sendGoal(
+        goalId: [UInt8],
+        goalCDR: Data,
+        acceptanceTimeout: Duration
+    ) async throws -> SendGoalAck {
+        precondition(goalId.count == 16, "goalId must be 16 bytes")
+        var fbCont: AsyncStream<Data>.Continuation!
+        let feedback = AsyncStream<Data> { fbCont = $0 }
+        var stCont: AsyncStream<ActionStatusUpdate>.Continuation!
+        let status = AsyncStream<ActionStatusUpdate> { stCont = $0 }
+        await pending.registerStreams(goalId: goalId, feedback: fbCont, status: stCont)
+
+        let frame = ActionFrameDecoder.encodeSendGoalRequest(goalId: goalId, goalCDR: goalCDR)
+        let replyCDR = try await getOnce(
+            keyExpr: sendGoalKeyExpr,
+            payload: frame,
+            timeout: acceptanceTimeout
+        )
+        let resp = try ActionFrameDecoder.decodeSendGoalResponse(from: replyCDR)
+        if !resp.accepted {
+            await pending.cancel(goalId: goalId)
+        }
+        return SendGoalAck(
+            accepted: resp.accepted,
+            stampSec: resp.stampSec,
+            stampNanosec: resp.stampNanosec,
+            feedback: feedback,
+            status: status
+        )
+    }
+
+    func getResult(goalId: [UInt8], timeout: Duration) async throws -> GetResultAck {
+        precondition(goalId.count == 16, "goalId must be 16 bytes")
+        let frame = ActionFrameDecoder.encodeGetResultRequest(goalId: goalId)
+        let replyCDR = try await getOnce(
+            keyExpr: getResultKeyExpr,
+            payload: frame,
+            timeout: timeout
+        )
+        let (status, resultCDR) = try ActionFrameDecoder.decodeGetResultResponse(from: replyCDR)
+        return GetResultAck(status: status, resultCDR: resultCDR)
+    }
+
+    func cancelGoal(
+        goalId: [UInt8]?,
+        beforeStampSec: Int32?,
+        beforeStampNanosec: UInt32?,
+        timeout: Duration
+    ) async throws -> CancelGoalAck {
+        // Build CancelGoal_Request CDR by hand: action_msgs/srv/CancelGoal_Request
+        // is `GoalInfo goal_info { uuid[16], builtin_interfaces/Time stamp }`.
+        var frame = ActionFrameDecoder.cdrHeader
+        let id = goalId ?? [UInt8](repeating: 0, count: 16)
+        precondition(id.count == 16, "goalId must be 16 bytes")
+        frame.append(contentsOf: id)
+        var sec = (beforeStampSec ?? 0).littleEndian
+        var nsec = (beforeStampNanosec ?? 0).littleEndian
+        withUnsafeBytes(of: &sec) { frame.append(contentsOf: $0) }
+        withUnsafeBytes(of: &nsec) { frame.append(contentsOf: $0) }
+
+        let replyCDR = try await getOnce(
+            keyExpr: cancelGoalKeyExpr,
+            payload: frame,
+            timeout: timeout
+        )
+        // CancelGoal_Response CDR: `int8 return_code; GoalInfo[] goals_canceling`.
+        // Layout: [header (4) | code (1) | pad (3) | count (u32) | { uuid[16] | sec | nsec } * count ]
+        guard replyCDR.count >= 4 + 1 + 3 + 4 else {
+            throw ActionFrameDecoderError.payloadTooShort
+        }
+        let code = Int8(bitPattern: replyCDR[replyCDR.startIndex + 4])
+        let count = replyCDR.withUnsafeBytes {
+            $0.loadUnaligned(fromByteOffset: 8, as: UInt32.self).littleEndian
+        }
+        let needed = 4 + 1 + 3 + 4 + Int(count) * (16 + 4 + 4)
+        guard replyCDR.count >= needed else { throw ActionFrameDecoderError.payloadTooShort }
+        var out: [CancelGoalAck.GoalEntry] = []
+        out.reserveCapacity(Int(count))
+        var off = replyCDR.startIndex + 12
+        for _ in 0..<Int(count) {
+            let uuid = Array(replyCDR[off..<(off + 16)])
+            off += 16
+            let s = replyCDR.withUnsafeBytes {
+                $0.loadUnaligned(fromByteOffset: off - replyCDR.startIndex, as: Int32.self)
+                    .littleEndian
+            }
+            off += 4
+            let ns = replyCDR.withUnsafeBytes {
+                $0.loadUnaligned(fromByteOffset: off - replyCDR.startIndex, as: UInt32.self)
+                    .littleEndian
+            }
+            off += 4
+            out.append((uuid: uuid, stampSec: s, stampNanosec: ns))
+        }
+        return CancelGoalAck(returnCode: code, goalsCanceling: out)
+    }
+
+    func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let fb = feedbackSub
+        let st = statusSub
+        let token = livelinessToken
+        feedbackSub = nil
+        statusSub = nil
+        livelinessToken = nil
+        lock.unlock()
+        Task { [pending] in
+            await pending.failAll(TransportError.sessionClosed)
+        }
+        try? fb?.close()
+        try? st?.close()
+        try? token?.close()
+    }
+
+    func handleFeedbackSample(payload: Data) {
+        guard let (goalId, fb) = try? ActionFrameDecoder.decodeFeedbackMessage(from: payload) else {
+            return
+        }
+        Task { [pending] in
+            await pending.yieldFeedback(goalId: goalId, cdr: fb)
+        }
+    }
+
+    func handleStatusSample(payload: Data) {
+        guard let entries = try? ActionFrameDecoder.decodeStatusArray(from: payload) else { return }
+        Task { [pending] in
+            for e in entries {
+                await pending.yieldStatus(goalId: e.uuid, status: e.status)
+            }
+        }
+    }
+
+    private func getOnce(keyExpr: String, payload: Data, timeout: Duration) async throws -> Data {
+        let timeoutMs = ZenohTransportActionClientImpl.durationToMillis(timeout)
+        return try await withCheckedThrowingContinuation { cont in
+            let state = ActionGetOnceState()
+            do {
+                try client.get(
+                    keyExpr: keyExpr,
+                    payload: payload,
+                    attachment: nil,
+                    timeoutMs: timeoutMs,
+                    handler: { result in
+                        if case .success(let sample) = result {
+                            state.captureReply(sample.payload)
+                        }
+                    },
+                    onFinish: {
+                        state.finish(continuation: cont, timeout: timeout)
+                    }
+                )
+            } catch {
+                state.fail(continuation: cont, error: error)
+            }
+        }
+    }
+
+    static func durationToMillis(_ d: Duration) -> UInt32 {
+        let comps = d.components
+        let seconds = max(0, Int64(comps.seconds))
+        let attoseconds = Int64(comps.attoseconds)
+        let ms = seconds.multipliedReportingOverflow(by: 1_000)
+        if ms.overflow { return UInt32.max }
+        let total = ms.partialValue + attoseconds / 1_000_000_000_000_000
+        if total < 0 { return 0 }
+        if total > Int64(UInt32.max) { return UInt32.max }
+        return UInt32(total)
+    }
+}
+
+// MARK: - Internal helpers
+
+/// One-shot resume guard for the `waitForActionServer` probe — `set()` returns
+/// true exactly once, false on every later call.
+private final class ActionOnceFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+    func set() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if fired { return false }
+        fired = true
+        return true
+    }
+}
+
+/// Coordinates a single in-flight `getOnce` call so the reply / finish / fail
+/// paths only resume the continuation once. The first reply payload is
+/// captured; `onFinish` resumes with it (or with `requestTimeout` if no reply
+/// was captured). `fail` is invoked when `client.get` itself throws — it
+/// races against `onFinish` only if the bridge calls `onFinish` on the same
+/// thread before the throw propagates, which the lock guards against.
+private final class ActionGetOnceState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var receivedPayload: Data?
+    private var resolved = false
+
+    func captureReply(_ payload: Data) {
+        lock.lock()
+        if receivedPayload == nil {
+            receivedPayload = payload
+        }
+        lock.unlock()
+    }
+
+    func finish(continuation cont: CheckedContinuation<Data, Error>, timeout: Duration) {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            return
+        }
+        resolved = true
+        let payload = receivedPayload
+        lock.unlock()
+        if let payload = payload {
+            cont.resume(returning: payload)
+        } else {
+            cont.resume(throwing: TransportError.requestTimeout(timeout))
+        }
+    }
+
+    func fail(continuation cont: CheckedContinuation<Data, Error>, error: Error) {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            return
+        }
+        resolved = true
+        lock.unlock()
+        cont.resume(throwing: error)
+    }
+}

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Action.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Action.swift
@@ -91,21 +91,48 @@ extension ZenohTransportSession {
             statusKeyExpr: statusKey
         )
 
-        do {
-            let q1 = try client.declareQueryable(sendGoalKey) { [weak server] q in
-                server?.handleSendGoalQuery(q)
+        // Track every queryable / token created so a partial failure tears
+        // them all down before rethrowing — otherwise we leak Zenoh handles
+        // and live callbacks for a server that was never returned.
+        var createdQueryables: [any ZenohQueryableHandle] = []
+        var createdToken: (any ZenohLivelinessTokenHandle)?
+        func rollbackAndThrow(_ error: Error) throws -> Never {
+            try? createdToken?.close()
+            for q in createdQueryables { try? q.close() }
+            if let e = error as? ZenohError {
+                throw TransportError.subscriberCreationFailed(e.localizedDescription ?? "\(e)")
             }
-            let q2 = try client.declareQueryable(cancelGoalKey) { [weak server] q in
-                server?.handleCancelGoalQuery(q)
-            }
-            let q3 = try client.declareQueryable(getResultKey) { [weak server] q in
-                server?.handleGetResultQuery(q)
-            }
-            let token = try client.declareLivelinessToken(livelinessTokenKey)
-            server.attach(queryables: [q1, q2, q3], livelinessToken: token)
-        } catch let e as ZenohError {
-            throw TransportError.subscriberCreationFailed(e.localizedDescription ?? "\(e)")
+            throw error
         }
+        func declareQ(
+            _ key: String, _ handler: @escaping @Sendable (any ZenohQueryHandle) -> Void
+        ) throws -> any ZenohQueryableHandle {
+            do {
+                let q = try client.declareQueryable(key, handler: handler)
+                createdQueryables.append(q)
+                return q
+            } catch {
+                try rollbackAndThrow(error)
+            }
+        }
+
+        let q1 = try declareQ(sendGoalKey) { [weak server] q in
+            server?.handleSendGoalQuery(q)
+        }
+        let q2 = try declareQ(cancelGoalKey) { [weak server] q in
+            server?.handleCancelGoalQuery(q)
+        }
+        let q3 = try declareQ(getResultKey) { [weak server] q in
+            server?.handleGetResultQuery(q)
+        }
+        let token: any ZenohLivelinessTokenHandle
+        do {
+            token = try client.declareLivelinessToken(livelinessTokenKey)
+            createdToken = token
+        } catch {
+            try rollbackAndThrow(error)
+        }
+        server.attach(queryables: [q1, q2, q3], livelinessToken: token)
 
         appendActionServer(server)
         return server
@@ -180,18 +207,44 @@ extension ZenohTransportSession {
             statusKeyExpr: statusKey
         )
 
-        do {
-            let fbSub = try client.subscribe(keyExpr: feedbackKey) { [weak cli] sample in
-                cli?.handleFeedbackSample(payload: sample.payload)
+        // Same rollback pattern as the server path — clean up any
+        // already-created subscriber/token if a later call throws.
+        var createdSubs: [any ZenohSubscriberHandle] = []
+        var createdToken: (any ZenohLivelinessTokenHandle)?
+        func rollbackAndThrow(_ error: Error) throws -> Never {
+            try? createdToken?.close()
+            for s in createdSubs { try? s.close() }
+            if let e = error as? ZenohError {
+                throw TransportError.subscriberCreationFailed(e.localizedDescription ?? "\(e)")
             }
-            let stSub = try client.subscribe(keyExpr: statusKey) { [weak cli] sample in
-                cli?.handleStatusSample(payload: sample.payload)
-            }
-            let token = try client.declareLivelinessToken(livelinessTokenKey)
-            cli.attach(feedbackSub: fbSub, statusSub: stSub, livelinessToken: token)
-        } catch let e as ZenohError {
-            throw TransportError.subscriberCreationFailed(e.localizedDescription ?? "\(e)")
+            throw error
         }
+        func subscribeKey(
+            _ key: String, _ handler: @escaping @Sendable (ZenohSample) -> Void
+        ) throws -> any ZenohSubscriberHandle {
+            do {
+                let s = try client.subscribe(keyExpr: key, handler: handler)
+                createdSubs.append(s)
+                return s
+            } catch {
+                try rollbackAndThrow(error)
+            }
+        }
+
+        let fbSub = try subscribeKey(feedbackKey) { [weak cli] sample in
+            cli?.handleFeedbackSample(payload: sample.payload)
+        }
+        let stSub = try subscribeKey(statusKey) { [weak cli] sample in
+            cli?.handleStatusSample(payload: sample.payload)
+        }
+        let token: any ZenohLivelinessTokenHandle
+        do {
+            token = try client.declareLivelinessToken(livelinessTokenKey)
+            createdToken = token
+        } catch {
+            try rollbackAndThrow(error)
+        }
+        cli.attach(feedbackSub: fbSub, statusSub: stSub, livelinessToken: token)
 
         appendActionClient(cli)
         return cli
@@ -472,12 +525,28 @@ final class ZenohTransportActionClientImpl: TransportActionClient, @unchecked Se
         await pending.registerStreams(goalId: goalId, feedback: fbCont, status: stCont)
 
         let frame = ActionFrameDecoder.encodeSendGoalRequest(goalId: goalId, goalCDR: goalCDR)
-        let replyCDR = try await getOnce(
-            keyExpr: sendGoalKeyExpr,
-            payload: frame,
-            timeout: acceptanceTimeout
-        )
-        let resp = try ActionFrameDecoder.decodeSendGoalResponse(from: replyCDR)
+        let replyCDR: Data
+        do {
+            replyCDR = try await getOnce(
+                keyExpr: sendGoalKeyExpr,
+                payload: frame,
+                timeout: acceptanceTimeout
+            )
+        } catch {
+            // The request never completed (timeout / decode failure / get
+            // throw), so the caller never received a handle for this goal.
+            // Drop the pending entry to avoid misrouting future feedback /
+            // status samples to a handle that doesn't exist.
+            await pending.cancel(goalId: goalId)
+            throw error
+        }
+        let resp: (accepted: Bool, stampSec: Int32, stampNanosec: UInt32)
+        do {
+            resp = try ActionFrameDecoder.decodeSendGoalResponse(from: replyCDR)
+        } catch {
+            await pending.cancel(goalId: goalId)
+            throw error
+        }
         if !resp.accepted {
             await pending.cancel(goalId: goalId)
         }
@@ -499,6 +568,11 @@ final class ZenohTransportActionClientImpl: TransportActionClient, @unchecked Se
             timeout: timeout
         )
         let (status, resultCDR) = try ActionFrameDecoder.decodeGetResultResponse(from: replyCDR)
+        // Drain the per-goal entry from `pending` once the result is in
+        // hand — any future feedback / status samples for this goal are
+        // stale, and without this the entry leaks for the lifetime of the
+        // client. (Parallel to the DDS transport's behavior.)
+        await pending.cancel(goalId: goalId)
         return GetResultAck(status: status, resultCDR: resultCDR)
     }
 

--- a/Sources/SwiftROS2Transport/ZenohTransportSession.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession.swift
@@ -19,6 +19,8 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
     var publishers: [String: ZenohTransportPublisher] = [:]
     var serviceServers: [ZenohTransportServiceServerImpl] = []
     var serviceClients: [ZenohTransportServiceClientImpl] = []
+    var actionServers: [ZenohTransportActionServerImpl] = []
+    var actionClients: [ZenohTransportActionClientImpl] = []
     let publishersLock = NSLock()
     let entityManager: EntityManager
     let gidManager: GIDManager
@@ -97,6 +99,15 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
         let clients = takeAllServiceClients()
         for serviceClient in clients {
             try? serviceClient.close()
+        }
+
+        let aServers = takeAllActionServers()
+        for s in aServers {
+            try? s.close()
+        }
+        let aClients = takeAllActionClients()
+        for c in aClients {
+            try? c.close()
         }
 
         do {

--- a/Tests/SwiftROS2TransportTests/Mocks/MockZenohClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockZenohClient.swift
@@ -152,18 +152,25 @@ final class MockZenohClient: ZenohClientProtocol, @unchecked Sendable {
             throw e
         }
         gets.append((key: keyExpr, payload: payload, attachment: attachment, timeoutMs: timeoutMs))
+        // Snapshot the dynamic handler / next scripted reply under the lock,
+        // but call the dynamic handler outside it. Otherwise a handler that
+        // touches the mock (e.g. inspects `writes`) would deadlock on the
+        // same lock.
+        let dyn = getReplyHandler
+        let scripted: (payload: Data?, isError: Bool)? =
+            (dyn == nil && !getScripts.isEmpty) ? getScripts.removeFirst() : nil
+        lock.unlock()
+
         let script: (payload: Data?, isError: Bool)?
-        // Dynamic handler takes precedence over scripted replies.
-        if let dyn = getReplyHandler {
+        if let dyn = dyn {
             if let replyPayload = dyn(keyExpr, payload) {
                 script = (payload: replyPayload, isError: false)
             } else {
                 script = (payload: nil, isError: false)
             }
         } else {
-            script = getScripts.isEmpty ? nil : getScripts.removeFirst()
+            script = scripted
         }
-        lock.unlock()
 
         // Fire the scripted reply / finish on a background queue to mirror
         // the C bridge's "callbacks run on a zenoh-pico-owned thread"
@@ -190,8 +197,9 @@ final class MockZenohClient: ZenohClientProtocol, @unchecked Sendable {
     /// Test helper: deliver a synthetic query to every queryable registered on
     /// `keyExpr` and collect the resulting `reply(...)` payloads. Each invoked
     /// handler reads the query asynchronously (the action server fires a Task
-    /// internally), so this helper polls briefly until at least one reply is
-    /// recorded — sufficient for the in-process mock-driven tests.
+    /// internally), so this helper polls briefly until **every** invoked
+    /// handler has produced a reply (one reply per handler) or the 1s
+    /// poll budget elapses — sufficient for the in-process mock-driven tests.
     func deliverQuery(keyExpr: String, payload: Data) async throws -> [Data] {
         let handlers: [@Sendable (any ZenohQueryHandle) -> Void] = {
             lock.lock()

--- a/Tests/SwiftROS2TransportTests/Mocks/MockZenohClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockZenohClient.swift
@@ -40,6 +40,24 @@ final class MockZenohClient: ZenohClientProtocol, @unchecked Sendable {
     /// `nil` payload means "fire only onFinish" (timeout).
     private var getScripts: [(payload: Data?, isError: Bool)] = []
 
+    /// Optional dynamic reply handler for `get`. If set, takes precedence over
+    /// `getScripts` — invoked synchronously per `get` call. Returning non-nil
+    /// fires a successful sample reply; returning nil triggers timeout (only
+    /// `onFinish` fires). Used by the Action transport tests.
+    var getReplyHandler: (@Sendable (_ keyExpr: String, _ payload: Data?) -> Data?)?
+
+    /// Per-key capture of every `put` (string-keyed overload). Mirrors `puts`
+    /// but indexed for fast lookup by key — used by Action transport tests.
+    private(set) var putsByKey: [String: [(payload: Data, attachment: Data?)]] = [:]
+
+    /// Captured liveliness-token key expressions. Alias of
+    /// `livelinessDeclarations` used by the Action transport tests.
+    var declaredLivelinessTokens: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return livelinessDeclarations
+    }
+
     func open(locator: String) throws {
         lock.lock()
         defer { lock.unlock() }
@@ -88,6 +106,9 @@ final class MockZenohClient: ZenohClientProtocol, @unchecked Sendable {
         defer { lock.unlock() }
         if let e = putShouldThrow { throw e }
         puts.append((key: keyExpr, payload: payload, attachment: attachment))
+        var bucket = putsByKey[keyExpr] ?? []
+        bucket.append((payload: payload, attachment: attachment))
+        putsByKey[keyExpr] = bucket
     }
 
     func subscribe(keyExpr: String, handler: @escaping (ZenohSample) -> Void) throws -> any ZenohSubscriberHandle {
@@ -131,7 +152,17 @@ final class MockZenohClient: ZenohClientProtocol, @unchecked Sendable {
             throw e
         }
         gets.append((key: keyExpr, payload: payload, attachment: attachment, timeoutMs: timeoutMs))
-        let script: (payload: Data?, isError: Bool)? = getScripts.isEmpty ? nil : getScripts.removeFirst()
+        let script: (payload: Data?, isError: Bool)?
+        // Dynamic handler takes precedence over scripted replies.
+        if let dyn = getReplyHandler {
+            if let replyPayload = dyn(keyExpr, payload) {
+                script = (payload: replyPayload, isError: false)
+            } else {
+                script = (payload: nil, isError: false)
+            }
+        } else {
+            script = getScripts.isEmpty ? nil : getScripts.removeFirst()
+        }
         lock.unlock()
 
         // Fire the scripted reply / finish on a background queue to mirror
@@ -153,6 +184,59 @@ final class MockZenohClient: ZenohClientProtocol, @unchecked Sendable {
                 // payload == nil: timeout — only onFinish fires.
             }
             onFinish()
+        }
+    }
+
+    /// Test helper: deliver a synthetic query to every queryable registered on
+    /// `keyExpr` and collect the resulting `reply(...)` payloads. Each invoked
+    /// handler reads the query asynchronously (the action server fires a Task
+    /// internally), so this helper polls briefly until at least one reply is
+    /// recorded — sufficient for the in-process mock-driven tests.
+    func deliverQuery(keyExpr: String, payload: Data) async throws -> [Data] {
+        let handlers: [@Sendable (any ZenohQueryHandle) -> Void] = {
+            lock.lock()
+            defer { lock.unlock() }
+            return queryableDeclarations.filter { $0.key == keyExpr }.map { $0.handler }
+        }()
+        guard !handlers.isEmpty else { return [] }
+
+        let collector = QueryReplyCollector()
+        for handler in handlers {
+            let q = MockQueryHandle(
+                keyExpr: keyExpr, payload: payload, attachment: nil
+            ) { reply in
+                Task { await collector.append(reply) }
+            }
+            handler(q)
+        }
+        // Poll briefly for the asynchronous Task in the queryable handler to
+        // resolve. 1s upper bound matches the test expectations elsewhere.
+        let deadline = ContinuousClock.now.advanced(by: .seconds(1))
+        while ContinuousClock.now < deadline {
+            let snapshot = await collector.snapshot()
+            if snapshot.count >= handlers.count {
+                return snapshot.compactMap {
+                    if case .success(let p) = $0 { return p } else { return nil }
+                }
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return await collector.snapshot().compactMap {
+            if case .success(let p) = $0 { return p } else { return nil }
+        }
+    }
+
+    /// Test helper: deliver a synthetic subscriber sample to every subscriber
+    /// registered on `keyExpr`.
+    func deliverSubscriberSample(keyExpr: String, payload: Data, attachment: Data?) {
+        let handlers: [(ZenohSample) -> Void] = {
+            lock.lock()
+            defer { lock.unlock() }
+            return subscriptions.filter { $0.key == keyExpr }.map { $0.handler }
+        }()
+        let sample = ZenohSample(keyExpr: keyExpr, payload: payload, attachment: attachment)
+        for handler in handlers {
+            handler(sample)
         }
     }
 
@@ -261,6 +345,21 @@ final class MockQueryableHandle: ZenohQueryableHandle {
         lock.lock()
         defer { lock.unlock() }
         closeCount += 1
+    }
+}
+
+/// Collects asynchronous queryable replies produced by `deliverQuery`. Used
+/// to bridge the queryable handler's `Task { ... query.reply(...) }` shape
+/// back into a polling `await` site.
+actor QueryReplyCollector {
+    private var replies: [MockQueryHandle.Reply] = []
+
+    func append(_ reply: MockQueryHandle.Reply) {
+        replies.append(reply)
+    }
+
+    func snapshot() -> [MockQueryHandle.Reply] {
+        return replies
     }
 }
 

--- a/Tests/SwiftROS2TransportTests/ZenohActionTransportTests.swift
+++ b/Tests/SwiftROS2TransportTests/ZenohActionTransportTests.swift
@@ -1,0 +1,265 @@
+// ZenohActionTransportTests.swift
+// End-to-end action flows over the Zenoh transport via MockZenohClient.
+
+import Foundation
+import XCTest
+
+@testable import SwiftROS2Transport
+
+final class ZenohActionTransportTests: XCTestCase {
+    func testCloseWalksActionServersAndClients() async throws {
+        let mock = MockZenohClient()
+        let session = ZenohTransportSession(client: mock)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0))
+        defer { try? session.close() }
+
+        let server = try session.createActionServer(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default,
+            handlers: TransportActionServerHandlers(
+                onSendGoal: { _, _ in (true, 0, 0) },
+                onCancelGoal: { _ in Data() },
+                onGetResult: { _ in GetResultAck(status: 4, resultCDR: Data()) }
+            )
+        )
+        let client = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        XCTAssertTrue(server.isActive)
+        XCTAssertTrue(client.isActive)
+
+        try session.close()
+
+        XCTAssertFalse(server.isActive)
+        XCTAssertFalse(client.isActive)
+    }
+
+    func testServerSendGoalQueryRoutesToHandler() async throws {
+        let mock = MockZenohClient()
+        let session = ZenohTransportSession(client: mock)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0))
+        defer { try? session.close() }
+
+        let acceptedExpect = expectation(description: "onSendGoal called")
+        let server = try session.createActionServer(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default,
+            handlers: TransportActionServerHandlers(
+                onSendGoal: { goalId, _ in
+                    XCTAssertEqual(goalId.count, 16)
+                    acceptedExpect.fulfill()
+                    return (true, 7, 11)
+                },
+                onCancelGoal: { _ in Data() },
+                onGetResult: { _ in GetResultAck(status: 4, resultCDR: Data()) }
+            )
+        )
+        XCTAssertTrue(server.isActive)
+
+        let goalId = [UInt8](repeating: 0xAA, count: 16)
+        let frame = ActionFrameDecoder.encodeSendGoalRequest(goalId: goalId, goalCDR: Data())
+        let key = (server as! ZenohTransportActionServerImpl).sendGoalKeyExpr
+        let replies = try await mock.deliverQuery(keyExpr: key, payload: frame)
+
+        await fulfillment(of: [acceptedExpect], timeout: 1)
+        XCTAssertEqual(replies.count, 1)
+        let resp = try ActionFrameDecoder.decodeSendGoalResponse(from: replies[0])
+        XCTAssertTrue(resp.accepted)
+        XCTAssertEqual(resp.stampSec, 7)
+        XCTAssertEqual(resp.stampNanosec, 11)
+    }
+
+    func testServerPublishFeedbackEmitsToFeedbackKey() async throws {
+        let mock = MockZenohClient()
+        let session = ZenohTransportSession(client: mock)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0))
+        defer { try? session.close() }
+
+        let server = try session.createActionServer(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default,
+            handlers: TransportActionServerHandlers(
+                onSendGoal: { _, _ in (true, 0, 0) },
+                onCancelGoal: { _ in Data() },
+                onGetResult: { _ in GetResultAck(status: 4, resultCDR: Data()) }
+            )
+        )
+        let goalId = [UInt8](repeating: 0xAA, count: 16)
+        let impl = server as! ZenohTransportActionServerImpl
+        try impl.publishFeedback(goalId: goalId, feedbackCDR: Data([0x77]))
+        let writes = mock.putsByKey[impl.feedbackKeyExpr] ?? []
+        XCTAssertEqual(writes.count, 1)
+        let (parsedId, fb) = try ActionFrameDecoder.decodeFeedbackMessage(from: writes[0].payload)
+        XCTAssertEqual(parsedId, goalId)
+        XCTAssertEqual(fb, Data([0x77]))
+    }
+
+    func testServerDeclaresLivelinessToken() async throws {
+        let mock = MockZenohClient()
+        let session = ZenohTransportSession(client: mock)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0))
+        defer { try? session.close() }
+
+        _ = try session.createActionServer(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default,
+            handlers: TransportActionServerHandlers(
+                onSendGoal: { _, _ in (true, 0, 0) },
+                onCancelGoal: { _ in Data() },
+                onGetResult: { _ in GetResultAck(status: 4, resultCDR: Data()) }
+            )
+        )
+        XCTAssertTrue(mock.declaredLivelinessTokens.contains { $0.contains("/SA/") })
+    }
+
+    func testClientSendGoalAcceptedYieldsFeedback() async throws {
+        let mock = MockZenohClient()
+        let session = ZenohTransportSession(client: mock)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0))
+        defer { try? session.close() }
+
+        let client = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+
+        let goalId = [UInt8](repeating: 0xAA, count: 16)
+
+        // Mock get(): when called on send_goal key, reply with accepted=true.
+        mock.getReplyHandler = { keyExpr, _ in
+            guard keyExpr.contains("/_action/send_goal/") else { return nil }
+            return ActionFrameDecoder.encodeSendGoalResponse(
+                accepted: true, stampSec: 99, stampNanosec: 0
+            )
+        }
+
+        let ack = try await client.sendGoal(
+            goalId: goalId,
+            goalCDR: Data(),
+            acceptanceTimeout: .seconds(2)
+        )
+        XCTAssertTrue(ack.accepted)
+        XCTAssertEqual(ack.stampSec, 99)
+
+        // Drive a feedback subscriber sample.
+        let feedbackKey = (client as! ZenohTransportActionClientImpl).feedbackKeyExpr
+        let frame = ActionFrameDecoder.encodeFeedbackMessage(
+            goalId: goalId, feedbackCDR: Data([0x77])
+        )
+        mock.deliverSubscriberSample(keyExpr: feedbackKey, payload: frame, attachment: nil)
+
+        var received: Data?
+        for await fb in ack.feedback {
+            received = fb
+            break
+        }
+        XCTAssertEqual(received, Data([0x77]))
+    }
+
+    func testClientGetResultBlocksUntilReply() async throws {
+        let mock = MockZenohClient()
+        let session = ZenohTransportSession(client: mock)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0))
+        defer { try? session.close() }
+
+        let client = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        mock.getReplyHandler = { keyExpr, _ in
+            guard keyExpr.contains("/_action/get_result/") else { return nil }
+            return ActionFrameDecoder.encodeGetResultResponse(
+                status: 4, resultCDR: Data([0xAA, 0xBB]))
+        }
+
+        let ack = try await client.getResult(
+            goalId: [UInt8](repeating: 0xAA, count: 16),
+            timeout: .seconds(2)
+        )
+        XCTAssertEqual(ack.status, 4)
+        XCTAssertEqual(ack.resultCDR, Data([0xAA, 0xBB]))
+    }
+
+    func testClientStatusFiltersByGoalId() async throws {
+        let mock = MockZenohClient()
+        let session = ZenohTransportSession(client: mock)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0))
+        defer { try? session.close() }
+
+        let client = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        let myGoal = [UInt8](repeating: 0xAA, count: 16)
+        let otherGoal = [UInt8](repeating: 0xBB, count: 16)
+        mock.getReplyHandler = { keyExpr, _ in
+            guard keyExpr.contains("/_action/send_goal/") else { return nil }
+            return ActionFrameDecoder.encodeSendGoalResponse(
+                accepted: true, stampSec: 0, stampNanosec: 0)
+        }
+        let ack = try await client.sendGoal(
+            goalId: myGoal, goalCDR: Data(), acceptanceTimeout: .seconds(2))
+
+        let statusKey = (client as! ZenohTransportActionClientImpl).statusKeyExpr
+        let frame = ActionFrameDecoder.encodeStatusArray(entries: [
+            (uuid: otherGoal, stampSec: 0, stampNanosec: 0, status: 2),
+            (uuid: myGoal, stampSec: 0, stampNanosec: 0, status: 1),
+            (uuid: myGoal, stampSec: 0, stampNanosec: 0, status: 4),
+        ])
+        mock.deliverSubscriberSample(keyExpr: statusKey, payload: frame, attachment: nil)
+
+        var seen: [Int8] = []
+        for await u in ack.status {
+            seen.append(u.status)
+        }
+        XCTAssertEqual(seen, [1, 4])
+    }
+
+    func testWaitForActionServerThrowsOnTimeout() async throws {
+        let mock = MockZenohClient()
+        let session = ZenohTransportSession(client: mock)
+        try await session.open(config: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0))
+        defer { try? session.close() }
+
+        let client = try session.createActionClient(
+            name: "/fibonacci",
+            actionTypeName: "example_interfaces/action/Fibonacci",
+            roleTypeHashes: defaultHashes(),
+            qos: .default
+        )
+        // Default mock: no replies → probe always times out.
+        do {
+            try await client.waitForActionServer(timeout: .milliseconds(300))
+            XCTFail("expected actionServerUnavailable")
+        } catch let e as TransportError {
+            if case .actionServerUnavailable = e { return }
+            XCTFail("got \(e) instead of actionServerUnavailable")
+        }
+    }
+
+    fileprivate func defaultHashes() -> ActionRoleTypeHashes {
+        return ActionRoleTypeHashes(
+            sendGoalRequest: nil, sendGoalResponse: nil,
+            cancelGoalRequest: nil, cancelGoalResponse: nil,
+            getResultRequest: nil, getResultResponse: nil,
+            feedbackMessage: nil, statusArray: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5 of 6 for ROS 2 Actions support. Implements the Zenoh side of the action transport on top of the existing queryable / get / put / subscribe / liveliness primitives:

- `ZenohTransportSession.createActionServer(...)` / `createActionClient(...)` overrides.
- `ZenohTransportActionServerImpl` — 3 queryables (`send_goal`, `cancel_goal`, `get_result`) + 2 publishers (`feedback`, `status`) + `SA` liveliness anchor on the `send_goal` request type.
- `ZenohTransportActionClientImpl` — 3 `get(...)` callers + 2 subscribers with goal-id filtering routed through `ActionPendingTable` + `CA` liveliness token + `waitForActionServer` probe (200 ms `get` against the `send_goal` queryable; throws `TransportError.actionServerUnavailable` on timeout).
- `MockZenohClient` extensions for in-process end-to-end testing: `getReplyHandler`, `putsByKey`, `declaredLivelinessTokens`, `deliverQuery`, `deliverSubscriberSample`.
- 8 new transport-tests cover server queryable dispatch, feedback / status publication + liveliness, client send_goal / get_result / status filtering, and the `waitForActionServer` timeout path.

Reuses `ActionFrameDecoder` from Phase 4 unchanged — the synthesized wrapper CDR shapes are transport-agnostic. Umbrella API + examples follow in Phase 6.

This PR is stacked on top of #80 (Phase 4 DDS).

## Test plan

- [x] \`swift test --filter SwiftROS2TransportTests.ZenohActionTransportTests\` — 8/8 green
- [x] \`swift test --filter SwiftROS2TransportTests\` — 101/101 green
- [x] \`swift test --parallel\` — full suite green
- [x] \`swift format lint --strict\` — clean over Sources/SwiftROS2Transport + Tests/SwiftROS2TransportTests
- [x] \`swift build\` — clean
- [ ] CI cross-platform (Linux / Windows / Android) — Zenoh path stays Windows / Android-compatible since it does not pull in DDS