### PR TITLE
feat(api): ROS 2 Actions umbrella API + Fibonacci example (phase 6 of 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+## [0.8.0] - 2026-05-03
+
+### Added
+- **ROS 2 Actions — full server / client.** Six-phase rollout shipping `ROS2Action` type-system foundation, wire codecs, transport protocols, DDS transport, Zenoh transport, and the typed `ROS2ActionServer<H>` / `ROS2ActionClient<A>` umbrella API. Pure Swift Concurrency surface — `async throws` + `AsyncStream` for feedback / status, no callback shims. Built-in `example_interfaces/action/Fibonacci`. Examples: `swift run action-server zenoh` / `swift run action-client zenoh`. DocC chapter under `SwiftROS2/Documentation.docc/Articles/Actions.md`.
+- **ROS 2 Actions — umbrella API + examples (phase 6 of 6).**
+  - `ROS2ActionServer<H>`, `ROS2ActionClient<A>`, `ActionGoalHandle<A>`, `ActionServerHandler` protocol, public enums (`GoalResponse`, `CancelResponse`, `ActionGoalStatus`, `ActionResult`), `ActionError`.
+  - `QoSProfile.actionDefault` — reliable / volatile / keep-last 10 (matches `rmw_qos_profile_services_default`).
+  - `ROS2Node.createActionServer(_:name:qos:handler:)` and `createActionClient(_:name:qos:)`. `ROS2Node.destroy()` now also walks action servers / clients.
+  - `ActionStatusEntry` public struct + `PublishesActionFeedback` public protocol on `SwiftROS2Transport` (the seam the umbrella server uses to publish feedback / status snapshots through the transport without a transport-specific downcast). `DDSTransportActionServerImpl` and `ZenohTransportActionServerImpl` conform.
+  - `action-server` / `action-client` example binaries (Apple / Linux / DDS-on-Windows — gated alongside the umbrella).
+  - LINUX_IP-gated `FibonacciActionTests` integration test.
+  - DocC `Actions.md` chapter; `MIGRATION.md` 0.7 → 0.8 entry.
 - **ROS 2 Actions — type-system foundation (phase 1 of 6, targeting 0.8.0).** Pure type-system work; no wire / transport / API changes yet.
   - `ROS2ActionTypeInfo` extended with synthesized-wrapper hashes (`sendGoalRequestTypeHash`, `sendGoalResponseTypeHash`, `getResultRequestTypeHash`, `getResultResponseTypeHash`, `feedbackMessageTypeHash`). Source- and ABI-compatible: the original 3-hash initializer is preserved as an explicit overload; the 8-hash initializer is a separate entry point.
   - `BuiltinInterfacesTime` (`builtin_interfaces/msg/Time`) — spec-correct `int32 sec`, `uint32 nanosec`. Distinct from `Header` (which keeps its legacy `UInt32 sec`).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,7 +6,8 @@
 |---|---|---|
 | 0.6.0 | 0.6.1 | **One:** the placeholder `ROS2Service` protocol in `SwiftROS2Messages` was renamed to `ROS2ServiceType` so the umbrella's typed Service Server class can take the simpler `ROS2Service<S>` name in 0.7.0. |
 | 0.6.x | 0.7.x | **One** if upgrading from 0.6.0 directly: the rename above. From 0.6.1 → 0.7.x there are no breaking changes — the Services API is purely additive. |
-| 0.7.x | 1.0.0 | Limited to the candidates below, decided after 0.7.0 ships based on a downstream survey. |
+| 0.7.x | 0.8.0 | **None.** Actions are purely additive — `ROS2Action`, `ROS2ActionServer`, `ROS2ActionClient`, `ActionGoalHandle`, `ActionResult`, `ActionGoalStatus`, `ActionError` are new. `ROS2ActionTypeInfo` gained five optional hash fields with source-compatible defaults (Phase 1). |
+| 0.8.x | 1.0.0 | Limited to the candidates below, decided after 0.8.0 ships based on a downstream survey. |
 | 1.0.x | 1.x   | **None guaranteed.** Minor releases on the 1.x line will not break public API. |
 
 SwiftROS2 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once 1.0.0 is cut. Breaking changes after 1.0 require a major bump.
@@ -42,7 +43,44 @@ No public type, function, protocol, or property already shipping in 0.6.1 is ren
 
 ---
 
-## 0.7 → 1.0 — candidate change list
+## 0.7 → 0.8 — Actions
+
+0.8.0 ships the ROS 2 Actions umbrella — six PRs, every one of them additive. No existing public symbol was renamed, removed, or had its shape changed.
+
+### Adding action support to existing code
+
+If you have a Conduit-style app that already calls `node.createPublisher` / `createService`, the action surface follows the same pattern:
+
+```swift
+let server = try await node.createActionServer(
+    FibonacciAction.self,
+    name: "/fibonacci",
+    handler: MyHandler()  // an actor conforming to ActionServerHandler
+)
+
+let client = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
+try await client.waitForActionServer(timeout: .seconds(5))
+let handle = try await client.sendGoal(FibonacciAction.Goal(order: 10))
+let result = try await handle.result()
+```
+
+See the `Actions.md` DocC chapter for the full walk-through.
+
+### `ROS2ActionTypeInfo`
+
+The struct gained five optional `*TypeHash` fields for the synthesized wrapper messages. The existing 3-hash initializer is preserved unchanged; the new 8-hash initializer is a separate entry point. No callers need to change unless they want to opt into wire-correct synthesized hashes.
+
+### Per-role QoS
+
+`QoSProfile.actionDefault` is the new default for `createActionServer` / `createActionClient`. The transport layer applies a `transient_local / depth 1` override on the `_action/status` topic automatically.
+
+### Naming note: `ActionGoalStatus` vs `GoalStatus`
+
+The umbrella exposes ``ActionGoalStatus`` (an `Int8`-backed enum) for the status surface returned by `ActionResult` / `handle.statusUpdates`. The wire-level `GoalStatus` struct (the embedded CDR payload of `GoalStatusArray`) ships in `SwiftROS2Messages` and re-exports through the umbrella, so both names are visible — they are intentionally different shapes for different layers.
+
+---
+
+## 0.8 → 1.0 — candidate change list
 
 > **Status:** the actual 1.0 break list is decided **after 0.7.0 ships**, based on a downstream-consumer survey (Conduit and any other known users). Each candidate below describes what *might* change, why it is being considered, and the recommended action you can take during 0.7.x to avoid surprise.
 

--- a/Package.swift
+++ b/Package.swift
@@ -371,6 +371,16 @@ if canBuildDDS {
             dependencies: ["SwiftROS2"],
             path: "Sources/Examples/SrvClient"
         ),
+        .executableTarget(
+            name: "action-server",
+            dependencies: ["SwiftROS2"],
+            path: "Sources/Examples/ActionServer"
+        ),
+        .executableTarget(
+            name: "action-client",
+            dependencies: ["SwiftROS2"],
+            path: "Sources/Examples/ActionClient"
+        ),
 
         .testTarget(
             name: "SwiftROS2Tests",

--- a/Sources/Examples/ActionClient/main.swift
+++ b/Sources/Examples/ActionClient/main.swift
@@ -1,0 +1,56 @@
+// Minimal example_interfaces/action/Fibonacci client.
+//
+// Usage:
+//   swift run action-client zenoh [tcp/<host>:7447] [domain_id] [order]
+//   swift run action-client dds   [domain_id] [order]
+
+import Foundation
+import SwiftROS2
+
+let args = Array(CommandLine.arguments.dropFirst())
+let transportName = args.first ?? "zenoh"
+let transport: TransportConfig
+let order: Int32
+switch transportName {
+case "zenoh":
+    let locator = args.dropFirst().first ?? "tcp/127.0.0.1:7447"
+    let domainId = args.dropFirst(2).first.flatMap(Int.init) ?? 0
+    order = args.dropFirst(3).first.flatMap(Int32.init) ?? 10
+    transport = .zenoh(locator: locator, domainId: domainId)
+case "dds":
+    let domainId = args.dropFirst().first.flatMap(Int.init) ?? 0
+    order = args.dropFirst(2).first.flatMap(Int32.init) ?? 10
+    transport = .ddsMulticast(domainId: domainId)
+default:
+    FileHandle.standardError.write(Data("Unknown transport '\(transportName)'\n".utf8))
+    exit(2)
+}
+
+let ctx = try await ROS2Context(transport: transport, distro: .jazzy)
+let node = try await ctx.createNode(name: "fibonacci_action_client")
+let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
+
+print("Waiting for /fibonacci server...")
+do {
+    try await cli.waitForActionServer(timeout: .seconds(5))
+} catch {
+    FileHandle.standardError.write(Data("Server did not appear: \(error)\n".utf8))
+    await ctx.shutdown()
+    exit(1)
+}
+
+print("Sending goal order=\(order)")
+let handle = try await cli.sendGoal(FibonacciAction.Goal(order: order))
+let feedbackTask = Task {
+    for await fb in handle.feedback {
+        print("Feedback: \(fb.partialSequence)")
+    }
+}
+let result = try await handle.result()
+feedbackTask.cancel()
+switch result {
+case .succeeded(let r): print("Succeeded: \(r.sequence)")
+case .canceled: print("Canceled")
+case .aborted(let r): print("Aborted: \(r ?? "nil")")
+}
+await ctx.shutdown()

--- a/Sources/Examples/ActionServer/main.swift
+++ b/Sources/Examples/ActionServer/main.swift
@@ -1,0 +1,72 @@
+// Minimal example_interfaces/action/Fibonacci server.
+//
+// Usage:
+//   swift run action-server zenoh [tcp/<host>:7447] [domain_id]
+//   swift run action-server dds   [domain_id]
+
+import Foundation
+import SwiftROS2
+
+actor FibonacciHandler: ActionServerHandler {
+    typealias Action = FibonacciAction
+
+    private var pendingOrder: Int32 = 10
+
+    func handleGoal(_ goal: FibonacciAction.Goal) async -> GoalResponse {
+        print("Received Fibonacci goal: order=\(goal.order)")
+        guard goal.order > 0 else { return .reject }
+        pendingOrder = goal.order
+        return .accept
+    }
+
+    func handleCancel(_ handle: ActionGoalHandle<FibonacciAction>) async -> CancelResponse {
+        print("Received cancel request for goal=\(handle.goalId.uuidString)")
+        return .accept
+    }
+
+    func execute(_ handle: ActionGoalHandle<FibonacciAction>) async throws
+        -> FibonacciAction.Result
+    {
+        let order = pendingOrder
+        var sequence: [Int32] = [0, 1]
+        for _ in 0..<max(0, Int(order) - 2) {
+            try Task.checkCancellation()
+            if await handle.isCancelRequested {
+                throw CancellationError()
+            }
+            sequence.append(sequence[sequence.count - 1] + sequence[sequence.count - 2])
+            try await handle.publishFeedback(FibonacciAction.Feedback(partialSequence: sequence))
+            try await Task.sleep(nanoseconds: 200_000_000)
+        }
+        return FibonacciAction.Result(sequence: sequence)
+    }
+}
+
+let args = Array(CommandLine.arguments.dropFirst())
+let transportName = args.first ?? "zenoh"
+let transport: TransportConfig
+switch transportName {
+case "zenoh":
+    let locator = args.dropFirst().first ?? "tcp/127.0.0.1:7447"
+    let domainId = args.dropFirst(2).first.flatMap(Int.init) ?? 0
+    transport = .zenoh(locator: locator, domainId: domainId)
+case "dds":
+    let domainId = args.dropFirst().first.flatMap(Int.init) ?? 0
+    transport = .ddsMulticast(domainId: domainId)
+default:
+    FileHandle.standardError.write(Data("Unknown transport '\(transportName)'\n".utf8))
+    exit(2)
+}
+
+let ctx = try await ROS2Context(transport: transport, distro: .jazzy)
+let node = try await ctx.createNode(name: "fibonacci_action_server")
+let srv = try await node.createActionServer(
+    FibonacciAction.self,
+    name: "/fibonacci",
+    handler: FibonacciHandler()
+)
+print("Action server /fibonacci ready (\(srv.name))")
+while !Task.isCancelled {
+    try await Task.sleep(nanoseconds: 1_000_000_000)
+}
+await ctx.shutdown()

--- a/Sources/SwiftROS2/ActionGoalHandle.swift
+++ b/Sources/SwiftROS2/ActionGoalHandle.swift
@@ -1,0 +1,156 @@
+// ActionGoalHandle.swift
+// Typed per-goal handle, shared between server and client sides.
+
+import Foundation
+import SwiftROS2CDR
+import SwiftROS2Messages
+import SwiftROS2Transport
+
+/// Handle for a single in-flight ROS 2 action goal.
+///
+/// Created by `ROS2ActionClient<A>.sendGoal(...)` (client side) or by the
+/// internal accept path of `ROS2ActionServer<H>` (server side). Each side
+/// gets a different subset of capabilities — calling `publishFeedback` on a
+/// client-side handle, or `result(timeout:)` on a server-side handle, throws
+/// `ActionError.wrongSide`.
+public final class ActionGoalHandle<A: ROS2Action>: @unchecked Sendable {
+    enum Side: Sendable {
+        case server
+        case client
+    }
+
+    public let goalId: Foundation.UUID
+    public let acceptedAt: BuiltinInterfacesTime
+
+    /// Per-goal feedback stream. Yields one decoded `A.Feedback` per
+    /// `_action/feedback` arrival filtered to this goal. Finishes on
+    /// terminal status.
+    public let feedback: AsyncStream<A.Feedback>
+
+    /// Per-goal status update stream (opt-in). Yields one `ActionGoalStatus`
+    /// per filtered status entry. Finishes on terminal status.
+    public let statusUpdates: AsyncStream<ActionGoalStatus>
+
+    private let side: Side
+    private let resultProvider: @Sendable () async throws -> ActionResult<A.Result>
+
+    // Server-side mutable state (cancel-request flag + feedback publisher).
+    private let stateLock = NSLock()
+    private var _isCancelRequested: Bool = false
+    private var _publishFeedback: (@Sendable (Data) throws -> Void)?
+    private var _cancelClosure: (@Sendable (Duration) async throws -> Void)?
+
+    init(
+        side: Side,
+        goalId: Foundation.UUID,
+        acceptedAt: BuiltinInterfacesTime,
+        feedbackStream: AsyncStream<A.Feedback>,
+        statusStream: AsyncStream<ActionGoalStatus>,
+        resultProvider: @escaping @Sendable () async throws -> ActionResult<A.Result>
+    ) {
+        self.side = side
+        self.goalId = goalId
+        self.acceptedAt = acceptedAt
+        self.feedback = feedbackStream
+        self.statusUpdates = statusStream
+        self.resultProvider = resultProvider
+    }
+
+    /// Server-side: install the closure that sends a typed `Feedback` over the wire.
+    /// Internal — set by `ROS2ActionServer` immediately after construction.
+    func _attachPublishFeedback(_ fn: @escaping @Sendable (Data) throws -> Void) {
+        stateLock.lock()
+        _publishFeedback = fn
+        stateLock.unlock()
+    }
+
+    /// Client-side: install the closure that issues a `cancel_goal` request.
+    func _attachCancelClosure(_ c: @escaping @Sendable (Duration) async throws -> Void) {
+        stateLock.lock()
+        _cancelClosure = c
+        stateLock.unlock()
+    }
+
+    /// Server-side: latest cancel-request state. Toggled by the umbrella when
+    /// the client requests cancellation and the handler accepts.
+    public var isCancelRequested: Bool {
+        get async {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isCancelRequested
+        }
+    }
+
+    /// Internal mutator used by the server's cancel path + tests.
+    func _setCancelRequested(_ v: Bool) async {
+        stateLock.lock()
+        _isCancelRequested = v
+        stateLock.unlock()
+    }
+
+    /// Server-side: publish a typed feedback message for this goal.
+    ///
+    /// Throws `ActionError.wrongSide` if called on a client-side handle.
+    public func publishFeedback(_ fb: A.Feedback) async throws {
+        guard side == .server else { throw ActionError.wrongSide }
+        let encoder = CDREncoder(isLegacySchema: false)
+        do {
+            try fb.encode(to: encoder)
+        } catch {
+            throw ActionError.requestEncodingFailed(error.localizedDescription)
+        }
+        let cdr = encoder.getData()
+        stateLock.lock()
+        let publisher = _publishFeedback
+        stateLock.unlock()
+        guard let publisher = publisher else {
+            throw ActionError.serverClosed
+        }
+        do {
+            try publisher(cdr)
+        } catch {
+            throw ActionError.mapping(error)
+        }
+    }
+
+    /// Client-side: wait for the goal's terminal state and decoded result.
+    ///
+    /// `timeout: nil` waits forever. Throws `ActionError.wrongSide` on the server side.
+    public func result(timeout: Duration? = nil) async throws -> ActionResult<A.Result> {
+        guard side == .client else { throw ActionError.wrongSide }
+        if let timeout = timeout {
+            return try await withTimeout(timeout) {
+                try await self.resultProvider()
+            }
+        }
+        return try await resultProvider()
+    }
+
+    /// Client-side: cancel just this goal.
+    public func cancel(timeout: Duration? = .seconds(5)) async throws {
+        guard side == .client else { throw ActionError.wrongSide }
+        stateLock.lock()
+        let canceler = _cancelClosure
+        stateLock.unlock()
+        guard let canceler = canceler else {
+            throw ActionError.clientClosed
+        }
+        try await canceler(timeout ?? .seconds(5))
+    }
+
+    private func withTimeout<T: Sendable>(
+        _ timeout: Duration,
+        _ body: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await body() }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw ActionError.resultTimedOut
+            }
+            let value = try await group.next()!
+            group.cancelAll()
+            return value
+        }
+    }
+}

--- a/Sources/SwiftROS2/ActionGoalHandle.swift
+++ b/Sources/SwiftROS2/ActionGoalHandle.swift
@@ -32,13 +32,17 @@ public final class ActionGoalHandle<A: ROS2Action>: @unchecked Sendable {
     public let statusUpdates: AsyncStream<ActionGoalStatus>
 
     private let side: Side
-    private let resultProvider: @Sendable () async throws -> ActionResult<A.Result>
+    /// Threaded the user's `result(timeout:)` value through to the underlying
+    /// transport `getResult` call. `nil` means "wait forever" — the provider
+    /// translates that into the transport's largest representable timeout.
+    private let resultProvider: @Sendable (Duration?) async throws -> ActionResult<A.Result>
 
     // Server-side mutable state (cancel-request flag + feedback publisher).
     private let stateLock = NSLock()
     private var _isCancelRequested: Bool = false
     private var _publishFeedback: (@Sendable (Data) throws -> Void)?
     private var _cancelClosure: (@Sendable (Duration) async throws -> Void)?
+    private let isLegacySchema: Bool
 
     init(
         side: Side,
@@ -46,13 +50,15 @@ public final class ActionGoalHandle<A: ROS2Action>: @unchecked Sendable {
         acceptedAt: BuiltinInterfacesTime,
         feedbackStream: AsyncStream<A.Feedback>,
         statusStream: AsyncStream<ActionGoalStatus>,
-        resultProvider: @escaping @Sendable () async throws -> ActionResult<A.Result>
+        isLegacySchema: Bool,
+        resultProvider: @escaping @Sendable (Duration?) async throws -> ActionResult<A.Result>
     ) {
         self.side = side
         self.goalId = goalId
         self.acceptedAt = acceptedAt
         self.feedback = feedbackStream
         self.statusUpdates = statusStream
+        self.isLegacySchema = isLegacySchema
         self.resultProvider = resultProvider
     }
 
@@ -93,7 +99,9 @@ public final class ActionGoalHandle<A: ROS2Action>: @unchecked Sendable {
     /// Throws `ActionError.wrongSide` if called on a client-side handle.
     public func publishFeedback(_ fb: A.Feedback) async throws {
         guard side == .server else { throw ActionError.wrongSide }
-        let encoder = CDREncoder(isLegacySchema: false)
+        // Use the schema choice that the owning context registered with us
+        // — `false` is wrong on Humble where some message shapes differ.
+        let encoder = CDREncoder(isLegacySchema: isLegacySchema)
         do {
             try fb.encode(to: encoder)
         } catch {
@@ -115,15 +123,12 @@ public final class ActionGoalHandle<A: ROS2Action>: @unchecked Sendable {
 
     /// Client-side: wait for the goal's terminal state and decoded result.
     ///
-    /// `timeout: nil` waits forever. Throws `ActionError.wrongSide` on the server side.
+    /// `timeout: nil` waits forever (the provider passes the transport's
+    /// largest representable timeout downstream). Throws
+    /// `ActionError.wrongSide` on the server side.
     public func result(timeout: Duration? = nil) async throws -> ActionResult<A.Result> {
         guard side == .client else { throw ActionError.wrongSide }
-        if let timeout = timeout {
-            return try await withTimeout(timeout) {
-                try await self.resultProvider()
-            }
-        }
-        return try await resultProvider()
+        return try await resultProvider(timeout)
     }
 
     /// Client-side: cancel just this goal.
@@ -138,19 +143,4 @@ public final class ActionGoalHandle<A: ROS2Action>: @unchecked Sendable {
         try await canceler(timeout ?? .seconds(5))
     }
 
-    private func withTimeout<T: Sendable>(
-        _ timeout: Duration,
-        _ body: @escaping @Sendable () async throws -> T
-    ) async throws -> T {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask { try await body() }
-            group.addTask {
-                try await Task.sleep(for: timeout)
-                throw ActionError.resultTimedOut
-            }
-            let value = try await group.next()!
-            group.cancelAll()
-            return value
-        }
-    }
 }

--- a/Sources/SwiftROS2/ActionServerHandler.swift
+++ b/Sources/SwiftROS2/ActionServerHandler.swift
@@ -1,0 +1,33 @@
+// ActionServerHandler.swift
+// User-supplied protocol for ROS 2 Action servers.
+
+import SwiftROS2Messages
+
+/// User-implemented protocol for an action server.
+///
+/// Typically implemented as an `actor`. The umbrella `ROS2ActionServer<H>`
+/// owns one Task per accepted goal and dispatches into these methods.
+///
+/// Lifecycle: `handleGoal` decides accept / reject; on accept the umbrella
+/// spawns a Task that calls `execute`; if a cancel arrives during execution,
+/// the umbrella calls `handleCancel` (the handler decides accept / reject) and
+/// — on accept — cancels the executing Task. The handler's `execute`
+/// implementation must check `await handle.isCancelRequested` periodically and
+/// throw `CancellationError` (or any error) to abort.
+public protocol ActionServerHandler: Sendable {
+    associatedtype Action: ROS2Action
+
+    /// Decide whether to accept a new goal. Called once per inbound goal,
+    /// before the umbrella spawns the executing Task.
+    func handleGoal(_ goal: Action.Goal) async -> GoalResponse
+
+    /// Decide whether to honor a cancel request. Called when the client side
+    /// requests cancellation of a goal that is currently executing.
+    func handleCancel(_ handle: ActionGoalHandle<Action>) async -> CancelResponse
+
+    /// Run the goal. Must produce the final `Action.Result` or throw to abort
+    /// (the umbrella translates the throw into `ActionGoalStatus.aborted`).
+    /// Periodically check `await handle.isCancelRequested` and throw
+    /// `CancellationError` when set to honor a cooperatively-handled cancel.
+    func execute(_ handle: ActionGoalHandle<Action>) async throws -> Action.Result
+}

--- a/Sources/SwiftROS2/ActionTypes.swift
+++ b/Sources/SwiftROS2/ActionTypes.swift
@@ -1,0 +1,85 @@
+// ActionTypes.swift
+// Public enums for the ROS 2 Actions umbrella API.
+
+import Foundation
+
+/// Server-side decision for `ActionServerHandler.handleGoal`.
+public enum GoalResponse: Sendable, Equatable {
+    case accept
+    case reject
+}
+
+/// Server-side decision for `ActionServerHandler.handleCancel`.
+public enum CancelResponse: Sendable, Equatable {
+    case accept
+    case reject
+}
+
+/// `action_msgs/msg/GoalStatus` raw values exposed to user code.
+///
+/// Named `ActionGoalStatus` to avoid colliding with the wire-level
+/// `SwiftROS2Messages.GoalStatus` struct (the embedded CDR payload of
+/// `GoalStatusArray`). Both are re-exported through the umbrella.
+public enum ActionGoalStatus: Int8, Sendable, Equatable, CaseIterable {
+    case unknown = 0
+    case accepted = 1
+    case executing = 2
+    case canceling = 3
+    case succeeded = 4
+    case canceled = 5
+    case aborted = 6
+
+    /// Whether this is a terminal state — true means the goal is finished and
+    /// the per-goal feedback / status streams will close after this value.
+    public var isTerminal: Bool {
+        switch self {
+        case .succeeded, .canceled, .aborted: return true
+        default: return false
+        }
+    }
+}
+
+/// Result of awaiting an action goal's terminal state.
+///
+/// Call `await handle.result()` to await this.
+public enum ActionResult<R: Sendable>: Sendable {
+    case succeeded(R)
+    case aborted(reason: String?)
+    case canceled
+}
+
+/// Errors thrown by the action umbrella API.
+public enum ActionError: Error, LocalizedError, Sendable {
+    case actionServerUnavailable
+    case goalRejected
+    case goalCanceled
+    case goalAborted(reason: String?)
+    case acceptanceTimedOut
+    case resultTimedOut
+    case cancelRejected
+    case wrongSide
+    case clientClosed
+    case serverClosed
+    case requestEncodingFailed(String)
+    case responseDecodingFailed(String)
+    case mapping(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .actionServerUnavailable: return "Action server is not reachable"
+        case .goalRejected: return "Action goal was rejected by the server"
+        case .goalCanceled: return "Action goal was canceled"
+        case .goalAborted(let r): return "Action goal was aborted\(r.map { ": \($0)" } ?? "")"
+        case .acceptanceTimedOut: return "Action goal acceptance timed out"
+        case .resultTimedOut: return "Action goal result timed out"
+        case .cancelRejected: return "Action cancel request was rejected"
+        case .wrongSide:
+            return "Operation is not valid on this side (e.g. publishFeedback called on a client-side handle)"
+        case .clientClosed: return "Action client is closed"
+        case .serverClosed: return "Action server is closed"
+        case .requestEncodingFailed(let m): return "Encoding failed: \(m)"
+        case .responseDecodingFailed(let m): return "Decoding failed: \(m)"
+        case .mapping(let e): return "Underlying error: \(e)"
+        }
+    }
+}

--- a/Sources/SwiftROS2/Documentation.docc/Articles/Actions.md
+++ b/Sources/SwiftROS2/Documentation.docc/Articles/Actions.md
@@ -1,0 +1,116 @@
+# ROS 2 Actions
+
+Long-running, cancelable, feedback-emitting RPCs over Zenoh or DDS.
+
+## Overview
+
+A ROS 2 action is built from three message types — `Goal`, `Result`, and `Feedback` — and
+two more capabilities the simple Service contract doesn't have:
+
+1. **Cancelability.** The client can ask the server to abort an in-flight goal.
+2. **Streaming feedback.** While the goal is executing, the server publishes intermediate
+   updates that the client iterates as an `AsyncStream`.
+
+`swift-ros2` exposes both sides through a pure Swift Concurrency surface: no callback
+shims, no thread pinning. The umbrella `SwiftROS2` module ships everything you need.
+
+## Defining an action type
+
+Conform an `enum` to ``SwiftROS2Messages/ROS2Action`` and supply three nested types:
+
+```swift
+import SwiftROS2
+
+public enum MyAction: ROS2Action {
+    public static let typeInfo = ROS2ActionTypeInfo(
+        actionName: "my_pkg/action/My",
+        goalTypeHash: "RIHS01_…",
+        // … five more synthesized hashes; see SwiftROS2Messages/BuiltinActions/ExampleInterfaces/Fibonacci.swift
+        resultTypeHash: nil,
+        feedbackTypeHash: nil,
+        sendGoalRequestTypeHash: nil,
+        sendGoalResponseTypeHash: nil,
+        getResultRequestTypeHash: nil,
+        getResultResponseTypeHash: nil,
+        feedbackMessageTypeHash: nil
+    )
+    public struct Goal: CDRCodable, Sendable, Equatable { /* … */ }
+    public struct Result: CDRCodable, Sendable, Equatable { /* … */ }
+    public struct Feedback: CDRCodable, Sendable, Equatable { /* … */ }
+}
+```
+
+For convenience, ``SwiftROS2Messages/FibonacciAction`` is built in.
+
+## Server side
+
+Implement ``ActionServerHandler`` — typically as an `actor`:
+
+```swift
+actor MyHandler: ActionServerHandler {
+    typealias Action = MyAction
+    func handleGoal(_ g: MyAction.Goal) async -> GoalResponse { .accept }
+    func handleCancel(_ h: ActionGoalHandle<MyAction>) async -> CancelResponse { .accept }
+    func execute(_ h: ActionGoalHandle<MyAction>) async throws -> MyAction.Result {
+        for _ in 1...10 {
+            try Task.checkCancellation()
+            if await h.isCancelRequested { throw CancellationError() }
+            try await h.publishFeedback(MyAction.Feedback(/* … */))
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        return MyAction.Result(/* … */)
+    }
+}
+
+let server = try await node.createActionServer(
+    MyAction.self,
+    name: "/my_action",
+    handler: MyHandler()
+)
+```
+
+## Client side
+
+```swift
+let client = try await node.createActionClient(MyAction.self, name: "/my_action")
+try await client.waitForActionServer(timeout: .seconds(5))
+let handle = try await client.sendGoal(MyAction.Goal(/* … */))
+
+Task {
+    for await fb in handle.feedback {
+        print("Feedback: \(fb)")
+    }
+}
+
+let result = try await handle.result()
+switch result {
+case .succeeded(let r): print("Got \(r)")
+case .canceled: print("Canceled")
+case .aborted(let reason): print("Aborted: \(reason ?? "nil")")
+}
+```
+
+To cancel a single goal: `try await handle.cancel()`.
+To cancel every active goal at-or-before a timestamp: `try await client.cancelGoals(beforeStamp: …)`.
+
+## QoS
+
+The default ``QoSProfile/actionDefault`` is `reliable / volatile / keep-last 10` — same as
+`rmw_qos_profile_services_default` on rclcpp. The transport layer applies a per-role
+override on the `_action/status` topic (`transient_local / depth 1`) so late-joining
+clients see the latest known status.
+
+## Topics under the hood
+
+For an action `<ns>/<name>`, the wire layer materializes:
+
+| Role | Kind | Wire name |
+|---|---|---|
+| `send_goal` | service | `<ns>/<name>/_action/send_goal` |
+| `cancel_goal` | service | `<ns>/<name>/_action/cancel_goal` |
+| `get_result` | service | `<ns>/<name>/_action/get_result` |
+| `feedback` | topic | `<ns>/<name>/_action/feedback` |
+| `status` | topic | `<ns>/<name>/_action/status` |
+
+You don't see these from Swift code — they're formatted by ``SwiftROS2Wire/ZenohWireCodec``
+and ``SwiftROS2Wire/DDSWireCodec``.

--- a/Sources/SwiftROS2/Documentation.docc/SwiftROS2.md
+++ b/Sources/SwiftROS2/Documentation.docc/SwiftROS2.md
@@ -22,6 +22,7 @@ transports natively:
 ### Reference
 
 - <doc:WireFormat>
+- <doc:Actions>
 
 ### Core types
 
@@ -30,3 +31,15 @@ transports natively:
 - ``ROS2Publisher``
 - ``ROS2Subscription``
 - ``QoSProfile``
+
+### Actions
+
+- ``ROS2ActionServer``
+- ``ROS2ActionClient``
+- ``ActionGoalHandle``
+- ``ActionServerHandler``
+- ``ActionResult``
+- ``ActionGoalStatus``
+- ``GoalResponse``
+- ``CancelResponse``
+- ``ActionError``

--- a/Sources/SwiftROS2/Internal/WeakHolder.swift
+++ b/Sources/SwiftROS2/Internal/WeakHolder.swift
@@ -1,0 +1,10 @@
+// WeakHolder.swift
+// Tiny generic that holds a weak reference. Used by the umbrella to break
+// the retain cycle between `ROS2ActionServer<H>` and the per-role handler
+// closure bag (`TransportActionServerHandlers`) that the transport keeps.
+
+import Foundation
+
+final class WeakHolder<T: AnyObject>: @unchecked Sendable {
+    weak var value: T?
+}

--- a/Sources/SwiftROS2/Node.swift
+++ b/Sources/SwiftROS2/Node.swift
@@ -29,6 +29,8 @@ public final class ROS2Node: @unchecked Sendable {
     private var subscriptions: [AnyObject] = []
     private var services: [AnyObject] = []
     private var clients: [AnyObject] = []
+    private var actionServers: [AnyObject] = []
+    private var actionClients: [AnyObject] = []
     private let lock = NSLock()
 
     init(
@@ -205,11 +207,89 @@ public final class ROS2Node: @unchecked Sendable {
         return client
     }
 
+    // MARK: - Action
+
+    /// Create an action server for a specific ``ROS2Action``.
+    public func createActionServer<H: ActionServerHandler>(
+        _ actionType: H.Action.Type,
+        name: String,
+        qos: QoSProfile = .actionDefault,
+        handler: H
+    ) async throws -> ROS2ActionServer<H> {
+        let fullName = buildFullTopic(name)
+        let typeInfo = H.Action.typeInfo
+        let transportQoS = qos.toTransportQoS()
+        let supportsHash = context.distro.supportsTypeHash
+        let hashes = ActionRoleTypeHashes(
+            sendGoalRequest: supportsHash ? typeInfo.sendGoalRequestTypeHash : nil,
+            sendGoalResponse: supportsHash ? typeInfo.sendGoalResponseTypeHash : nil,
+            cancelGoalRequest: supportsHash ? CancelGoalSrv.typeInfo.requestTypeHash : nil,
+            cancelGoalResponse: supportsHash ? CancelGoalSrv.typeInfo.responseTypeHash : nil,
+            getResultRequest: supportsHash ? typeInfo.getResultRequestTypeHash : nil,
+            getResultResponse: supportsHash ? typeInfo.getResultResponseTypeHash : nil,
+            feedbackMessage: supportsHash ? typeInfo.feedbackMessageTypeHash : nil,
+            statusArray: supportsHash ? GoalStatusArray.typeInfo.typeHash : nil
+        )
+
+        let serverHolder = WeakHolder<ROS2ActionServer<H>>()
+        let handlers = ROS2ActionServer<H>.makeHandlers { serverHolder.value }
+        let transportServer = try session.createActionServer(
+            name: fullName,
+            actionTypeName: typeInfo.actionName,
+            roleTypeHashes: hashes,
+            qos: transportQoS,
+            handlers: handlers
+        )
+        let server = ROS2ActionServer<H>(
+            transport: transportServer,
+            handler: handler,
+            isLegacySchema: context.distro.isLegacySchema
+        )
+        serverHolder.value = server
+        appendActionServer(server)
+        return server
+    }
+
+    /// Create an action client for a specific ``ROS2Action``.
+    public func createActionClient<A: ROS2Action>(
+        _ actionType: A.Type,
+        name: String,
+        qos: QoSProfile = .actionDefault
+    ) async throws -> ROS2ActionClient<A> {
+        let fullName = buildFullTopic(name)
+        let typeInfo = A.typeInfo
+        let transportQoS = qos.toTransportQoS()
+        let supportsHash = context.distro.supportsTypeHash
+        let hashes = ActionRoleTypeHashes(
+            sendGoalRequest: supportsHash ? typeInfo.sendGoalRequestTypeHash : nil,
+            sendGoalResponse: supportsHash ? typeInfo.sendGoalResponseTypeHash : nil,
+            cancelGoalRequest: supportsHash ? CancelGoalSrv.typeInfo.requestTypeHash : nil,
+            cancelGoalResponse: supportsHash ? CancelGoalSrv.typeInfo.responseTypeHash : nil,
+            getResultRequest: supportsHash ? typeInfo.getResultRequestTypeHash : nil,
+            getResultResponse: supportsHash ? typeInfo.getResultResponseTypeHash : nil,
+            feedbackMessage: supportsHash ? typeInfo.feedbackMessageTypeHash : nil,
+            statusArray: supportsHash ? GoalStatusArray.typeInfo.typeHash : nil
+        )
+
+        let transportClient = try session.createActionClient(
+            name: fullName,
+            actionTypeName: typeInfo.actionName,
+            roleTypeHashes: hashes,
+            qos: transportQoS
+        )
+        let client = ROS2ActionClient<A>(
+            transport: transportClient,
+            isLegacySchema: context.distro.isLegacySchema
+        )
+        appendActionClient(client)
+        return client
+    }
+
     // MARK: - Lifecycle
 
     /// Destroy this node and release all resources
     public func destroy() async {
-        let (pubs, subs, svcs, clis) = takeAllEntities()
+        let (pubs, subs, svcs, clis, aSrvs, aClis) = takeAllEntities()
         for pub in pubs {
             if let p = pub as? PublisherCloseable {
                 try? p.closePublisher()
@@ -228,6 +308,16 @@ public final class ROS2Node: @unchecked Sendable {
         for cli in clis {
             if let c = cli as? ClientCloseable {
                 try? c.closeClient()
+            }
+        }
+        for s in aSrvs {
+            if let s = s as? ActionServerCloseable {
+                try? s.closeActionServer()
+            }
+        }
+        for c in aClis {
+            if let c = c as? ActionClientCloseable {
+                try? c.closeActionClient()
             }
         }
     }
@@ -258,18 +348,36 @@ public final class ROS2Node: @unchecked Sendable {
         lock.unlock()
     }
 
-    private func takeAllEntities() -> ([AnyObject], [AnyObject], [AnyObject], [AnyObject]) {
+    private func appendActionServer(_ server: AnyObject) {
+        lock.lock()
+        actionServers.append(server)
+        lock.unlock()
+    }
+
+    private func appendActionClient(_ client: AnyObject) {
+        lock.lock()
+        actionClients.append(client)
+        lock.unlock()
+    }
+
+    private func takeAllEntities() -> (
+        [AnyObject], [AnyObject], [AnyObject], [AnyObject], [AnyObject], [AnyObject]
+    ) {
         lock.lock()
         let pubs = publishers
         let subs = subscriptions
         let svcs = services
         let clis = clients
+        let aSrvs = actionServers
+        let aClis = actionClients
         publishers.removeAll()
         subscriptions.removeAll()
         services.removeAll()
         clients.removeAll()
+        actionServers.removeAll()
+        actionClients.removeAll()
         lock.unlock()
-        return (pubs, subs, svcs, clis)
+        return (pubs, subs, svcs, clis, aSrvs, aClis)
     }
 
     // MARK: - Helpers

--- a/Sources/SwiftROS2/QoSProfile.swift
+++ b/Sources/SwiftROS2/QoSProfile.swift
@@ -66,6 +66,18 @@ public struct QoSProfile: Sendable, Equatable {
         history: .keepLast(10)
     )
 
+    /// Default QoS for ROS 2 Action services and topics.
+    ///
+    /// Reliable, volatile, keep-last 10 — matches rclcpp's
+    /// `rmw_qos_profile_services_default` for the three service roles. The
+    /// status topic is bumped to `transientLocal` keep-last 1 inside the
+    /// transport layer.
+    public static let actionDefault = QoSProfile(
+        reliability: .reliable,
+        durability: .volatile,
+        history: .keepLast(10)
+    )
+
     /// Default profile
     public static let `default` = sensorData
 

--- a/Sources/SwiftROS2/ROS2ActionClient.swift
+++ b/Sources/SwiftROS2/ROS2ActionClient.swift
@@ -105,12 +105,17 @@ public final class ROS2ActionClient<A: ROS2Action>: @unchecked Sendable, ActionC
             stContCap.finish()
         }
 
-        // Result provider — single-shot getResult call.
+        // Result provider — single-shot getResult call. The user's
+        // `result(timeout:)` value is threaded all the way through; `nil`
+        // is "wait forever" and translates to the transport's largest
+        // representable timeout.
         let txn: any TransportActionClient = transport
-        let provider: @Sendable () async throws -> ActionResult<A.Result> = {
+        let provider: @Sendable (Duration?) async throws -> ActionResult<A.Result> = {
+            userTimeout in
             let r: GetResultAck
             do {
-                r = try await txn.getResult(goalId: goalIdBytes, timeout: .seconds(60 * 60))
+                let effective = userTimeout ?? .seconds(Int.max)
+                r = try await txn.getResult(goalId: goalIdBytes, timeout: effective)
             } catch let e as TransportError {
                 if case .requestTimeout = e { throw ActionError.resultTimedOut }
                 throw ActionError.mapping(e)
@@ -145,6 +150,7 @@ public final class ROS2ActionClient<A: ROS2Action>: @unchecked Sendable, ActionC
             acceptedAt: stamp,
             feedbackStream: typedFB,
             statusStream: typedST,
+            isLegacySchema: isLegacySchema,
             resultProvider: provider
         )
         let cancelTransport: any TransportActionClient = transport

--- a/Sources/SwiftROS2/ROS2ActionClient.swift
+++ b/Sources/SwiftROS2/ROS2ActionClient.swift
@@ -1,0 +1,244 @@
+// ROS2ActionClient.swift
+// Typed client wrapper around TransportActionClient.
+
+import Foundation
+import SwiftROS2CDR
+import SwiftROS2Messages
+import SwiftROS2Transport
+
+/// Typed action client for a specific `ROS2Action`.
+public final class ROS2ActionClient<A: ROS2Action>: @unchecked Sendable, ActionClientCloseable {
+    private let transport: any TransportActionClient
+    private let isLegacySchema: Bool
+    private let lock = NSLock()
+    private var closed = false
+
+    public var name: String { transport.name }
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed && transport.isActive
+    }
+
+    init(transport: any TransportActionClient, isLegacySchema: Bool) {
+        self.transport = transport
+        self.isLegacySchema = isLegacySchema
+    }
+
+    /// Wait until the action server is reachable.
+    public func waitForActionServer(timeout: Duration) async throws {
+        do {
+            try await transport.waitForActionServer(timeout: timeout)
+        } catch let e as TransportError {
+            if case .actionServerUnavailable = e {
+                throw ActionError.actionServerUnavailable
+            }
+            throw ActionError.mapping(e)
+        } catch {
+            throw ActionError.mapping(error)
+        }
+    }
+
+    /// Send a goal and return a typed `ActionGoalHandle`.
+    public func sendGoal(
+        _ goal: A.Goal,
+        acceptanceTimeout: Duration = .seconds(5)
+    ) async throws -> ActionGoalHandle<A> {
+        let goalUUID = Foundation.UUID()
+        let goalIdBytes = Self.uuidBytes(goalUUID)
+
+        let encoder = CDREncoder(isLegacySchema: isLegacySchema)
+        do {
+            try goal.encode(to: encoder)
+        } catch {
+            throw ActionError.requestEncodingFailed(error.localizedDescription)
+        }
+        let goalCDR = encoder.getData()
+
+        let ack: SendGoalAck
+        do {
+            ack = try await transport.sendGoal(
+                goalId: goalIdBytes,
+                goalCDR: goalCDR,
+                acceptanceTimeout: acceptanceTimeout
+            )
+        } catch let e as TransportError {
+            if case .requestTimeout = e { throw ActionError.acceptanceTimedOut }
+            throw ActionError.mapping(e)
+        } catch {
+            throw ActionError.mapping(error)
+        }
+
+        guard ack.accepted else {
+            throw ActionError.goalRejected
+        }
+
+        // Typed feedback stream.
+        let isLegacy = isLegacySchema
+        var fbCont: AsyncStream<A.Feedback>.Continuation!
+        let typedFB = AsyncStream<A.Feedback> { fbCont = $0 }
+        let fbContCap = fbCont!
+        Task {
+            for await raw in ack.feedback {
+                do {
+                    let dec = try CDRDecoder(
+                        data: Self.prependHeaderIfMissing(raw),
+                        isLegacySchema: isLegacy
+                    )
+                    let typed = try A.Feedback(from: dec)
+                    fbContCap.yield(typed)
+                } catch {
+                    // Silent drop — feedback is best-effort.
+                }
+            }
+            fbContCap.finish()
+        }
+
+        // Typed status stream.
+        var stCont: AsyncStream<ActionGoalStatus>.Continuation!
+        let typedST = AsyncStream<ActionGoalStatus> { stCont = $0 }
+        let stContCap = stCont!
+        Task {
+            for await u in ack.status {
+                stContCap.yield(ActionGoalStatus(rawValue: u.status) ?? .unknown)
+            }
+            stContCap.finish()
+        }
+
+        // Result provider — single-shot getResult call.
+        let txn: any TransportActionClient = transport
+        let provider: @Sendable () async throws -> ActionResult<A.Result> = {
+            let r: GetResultAck
+            do {
+                r = try await txn.getResult(goalId: goalIdBytes, timeout: .seconds(60 * 60))
+            } catch let e as TransportError {
+                if case .requestTimeout = e { throw ActionError.resultTimedOut }
+                throw ActionError.mapping(e)
+            } catch {
+                throw ActionError.mapping(error)
+            }
+            switch ActionGoalStatus(rawValue: r.status) ?? .unknown {
+            case .succeeded:
+                do {
+                    let dec = try CDRDecoder(
+                        data: Self.prependHeaderIfMissing(r.resultCDR),
+                        isLegacySchema: isLegacy
+                    )
+                    return .succeeded(try A.Result(from: dec))
+                } catch {
+                    throw ActionError.responseDecodingFailed(error.localizedDescription)
+                }
+            case .canceled: return .canceled
+            case .aborted: return .aborted(reason: nil)
+            default:
+                throw ActionError.mapping(
+                    TransportError.unsupportedFeature("unexpected terminal status \(r.status)")
+                )
+            }
+        }
+
+        // Build the client-side handle.
+        let stamp = BuiltinInterfacesTime(sec: ack.stampSec, nanosec: ack.stampNanosec)
+        let handle = ActionGoalHandle<A>(
+            side: .client,
+            goalId: goalUUID,
+            acceptedAt: stamp,
+            feedbackStream: typedFB,
+            statusStream: typedST,
+            resultProvider: provider
+        )
+        let cancelTransport: any TransportActionClient = transport
+        handle._attachCancelClosure { timeout in
+            _ = try await cancelTransport.cancelGoal(
+                goalId: goalIdBytes,
+                beforeStampSec: nil,
+                beforeStampNanosec: nil,
+                timeout: timeout
+            )
+        }
+        return handle
+    }
+
+    /// Cancel every active goal whose acceptance stamp is at or before `beforeStamp`.
+    @discardableResult
+    public func cancelGoals(
+        beforeStamp: BuiltinInterfacesTime,
+        timeout: Duration = .seconds(5)
+    ) async throws -> [Foundation.UUID] {
+        let ack: CancelGoalAck
+        do {
+            ack = try await transport.cancelGoal(
+                goalId: nil,
+                beforeStampSec: beforeStamp.sec,
+                beforeStampNanosec: beforeStamp.nanosec,
+                timeout: timeout
+            )
+        } catch {
+            throw ActionError.mapping(error)
+        }
+        return ack.goalsCanceling.map { entry in
+            Self.uuidFromBytes(entry.uuid)
+        }
+    }
+
+    /// Cancel the client; close the underlying transport handle.
+    public func cancel() {
+        try? closeActionClient()
+    }
+
+    func closeActionClient() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        lock.unlock()
+        try? transport.close()
+    }
+
+    // MARK: - CDR helpers
+
+    /// The transport layer's `feedback` and `getResult.resultCDR` payloads are
+    /// the bare body — they don't carry a CDR encapsulation header. The
+    /// `CDRDecoder(data:)` constructor requires the 4-byte header. Prepend it
+    /// if the payload doesn't already start with `00 01 00 00`.
+    static func prependHeaderIfMissing(_ data: Data) -> Data {
+        if data.count >= 4 {
+            let base = data.startIndex
+            if data[base] == 0x00, data[base + 1] == 0x01,
+                data[base + 2] == 0x00, data[base + 3] == 0x00
+            {
+                return data
+            }
+        }
+        var out = Data(capacity: 4 + data.count)
+        out.append(contentsOf: [0x00, 0x01, 0x00, 0x00])
+        out.append(data)
+        return out
+    }
+
+    // MARK: - UUID helpers
+
+    static func uuidBytes(_ uuid: Foundation.UUID) -> [UInt8] {
+        let t = uuid.uuid
+        return [
+            t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7,
+            t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15,
+        ]
+    }
+
+    static func uuidFromBytes(_ b: [UInt8]) -> Foundation.UUID {
+        precondition(b.count == 16)
+        return Foundation.UUID(
+            uuid: (
+                b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+                b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]
+            ))
+    }
+}
+
+/// Internal protocol for type-erased action-client cleanup.
+protocol ActionClientCloseable {
+    func closeActionClient() throws
+}

--- a/Sources/SwiftROS2/ROS2ActionServer.swift
+++ b/Sources/SwiftROS2/ROS2ActionServer.swift
@@ -1,0 +1,343 @@
+// ROS2ActionServer.swift
+// Typed server wrapper around TransportActionServer.
+
+import Foundation
+import SwiftROS2CDR
+import SwiftROS2Messages
+import SwiftROS2Transport
+
+/// Typed action server for a specific `ROS2Action`.
+public final class ROS2ActionServer<H: ActionServerHandler>: @unchecked Sendable,
+    ActionServerCloseable
+{
+    private let transport: any TransportActionServer
+    private let handler: H
+    private let isLegacySchema: Bool
+
+    public var name: String { transport.name }
+    public var isActive: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return !closed && transport.isActive
+    }
+
+    // Per-goal state — tracked so cancel + status array publication can find it.
+    private final class GoalEntry {
+        let handle: ActionGoalHandle<H.Action>
+        var task: Task<Void, Never>?
+        var status: ActionGoalStatus
+        var resultCache: GetResultAck?
+        var resultWaiters: [CheckedContinuation<GetResultAck, Error>]
+        var fbCont: AsyncStream<H.Action.Feedback>.Continuation
+        var stCont: AsyncStream<ActionGoalStatus>.Continuation
+
+        init(
+            handle: ActionGoalHandle<H.Action>,
+            status: ActionGoalStatus,
+            fbCont: AsyncStream<H.Action.Feedback>.Continuation,
+            stCont: AsyncStream<ActionGoalStatus>.Continuation
+        ) {
+            self.handle = handle
+            self.status = status
+            self.resultWaiters = []
+            self.fbCont = fbCont
+            self.stCont = stCont
+        }
+    }
+
+    private let stateLock = NSLock()
+    private var goals: [Data: GoalEntry] = [:]  // key: 16-byte goal_id
+    private var closed = false
+
+    init(transport: any TransportActionServer, handler: H, isLegacySchema: Bool) {
+        self.transport = transport
+        self.handler = handler
+        self.isLegacySchema = isLegacySchema
+    }
+
+    /// Cancel the server; closes the underlying transport handle and cancels every running goal.
+    public func cancel() {
+        try? closeActionServer()
+    }
+
+    func closeActionServer() throws {
+        stateLock.lock()
+        guard !closed else {
+            stateLock.unlock()
+            return
+        }
+        closed = true
+        let snapshot = Array(goals.values)
+        goals.removeAll()
+        stateLock.unlock()
+        for entry in snapshot {
+            entry.task?.cancel()
+            for w in entry.resultWaiters {
+                w.resume(throwing: ActionError.serverClosed)
+            }
+            entry.fbCont.finish()
+            entry.stCont.finish()
+        }
+        try? transport.close()
+    }
+
+    // MARK: - Internal — handler bag the umbrella plugs into the transport
+
+    static func makeHandlers(
+        for server: @escaping @Sendable () -> ROS2ActionServer<H>?
+    ) -> TransportActionServerHandlers {
+        return TransportActionServerHandlers(
+            onSendGoal: { goalId, goalCDR in
+                guard let s = server() else { return (false, 0, 0) }
+                return await s.handleSendGoal(goalId: goalId, goalCDR: goalCDR)
+            },
+            onCancelGoal: { reqCDR in
+                guard let s = server() else {
+                    return Self.encodeCancelGoalResponse(returnCode: 1, entries: [])
+                }
+                return await s.handleCancelGoal(requestCDR: reqCDR)
+            },
+            onGetResult: { goalId in
+                guard let s = server() else {
+                    return GetResultAck(
+                        status: ActionGoalStatus.unknown.rawValue, resultCDR: Data()
+                    )
+                }
+                return try await s.handleGetResult(goalId: goalId)
+            }
+        )
+    }
+
+    private func handleSendGoal(goalId: [UInt8], goalCDR: Data) async -> (
+        Bool, Int32, UInt32
+    ) {
+        let typedGoal: H.Action.Goal
+        do {
+            let dec = try CDRDecoder(
+                data: ROS2ActionClient<H.Action>.prependHeaderIfMissing(goalCDR),
+                isLegacySchema: isLegacySchema
+            )
+            typedGoal = try H.Action.Goal(from: dec)
+        } catch {
+            return (false, 0, 0)
+        }
+        let resp = await handler.handleGoal(typedGoal)
+        guard resp == .accept else { return (false, 0, 0) }
+
+        // Build the server-side handle.
+        let now = Date()
+        let secs = now.timeIntervalSince1970
+        let stamp = BuiltinInterfacesTime(
+            sec: Int32(secs),
+            nanosec: UInt32(secs.truncatingRemainder(dividingBy: 1) * 1_000_000_000)
+        )
+        var fbCont: AsyncStream<H.Action.Feedback>.Continuation!
+        let fbStream = AsyncStream<H.Action.Feedback> { fbCont = $0 }
+        var stCont: AsyncStream<ActionGoalStatus>.Continuation!
+        let stStream = AsyncStream<ActionGoalStatus> { stCont = $0 }
+        let goalUUID = Self.uuidFromBytes(goalId)
+        let key = Data(goalId)
+        let unused: @Sendable () async throws -> ActionResult<H.Action.Result> = {
+            throw ActionError.wrongSide
+        }
+        let handle = ActionGoalHandle<H.Action>(
+            side: .server,
+            goalId: goalUUID,
+            acceptedAt: stamp,
+            feedbackStream: fbStream,
+            statusStream: stStream,
+            resultProvider: unused
+        )
+        // Wire publishFeedback through the transport's feedback writer.
+        let transportRef = transport
+        let goalIdCopy = goalId
+        handle._attachPublishFeedback { cdr in
+            guard let serverImpl = transportRef as? PublishesActionFeedback else { return }
+            try serverImpl.publishFeedback(goalId: goalIdCopy, feedbackCDR: cdr)
+        }
+
+        let entry = GoalEntry(
+            handle: handle,
+            status: .accepted,
+            fbCont: fbCont!,
+            stCont: stCont!
+        )
+
+        let task: Task<Void, Never> = Task { [weak self, weak entry] in
+            guard let self else { return }
+            entry?.stCont.yield(.executing)
+            self.transitionStatus(.executing, for: key)
+            do {
+                let result = try await self.handler.execute(handle)
+                let encoder = CDREncoder(isLegacySchema: self.isLegacySchema)
+                try result.encode(to: encoder)
+                self.cacheResult(
+                    GetResultAck(
+                        status: ActionGoalStatus.succeeded.rawValue,
+                        resultCDR: encoder.getData()
+                    ), for: key)
+                self.transitionStatus(.succeeded, for: key)
+                entry?.stCont.yield(.succeeded)
+            } catch is CancellationError {
+                self.cacheResult(
+                    GetResultAck(
+                        status: ActionGoalStatus.canceled.rawValue, resultCDR: Data()
+                    ), for: key)
+                self.transitionStatus(.canceled, for: key)
+                entry?.stCont.yield(.canceled)
+            } catch {
+                self.cacheResult(
+                    GetResultAck(
+                        status: ActionGoalStatus.aborted.rawValue, resultCDR: Data()
+                    ), for: key)
+                self.transitionStatus(.aborted, for: key)
+                entry?.stCont.yield(.aborted)
+            }
+            entry?.fbCont.finish()
+            entry?.stCont.finish()
+        }
+        entry.task = task
+
+        stateLock.lock()
+        goals[key] = entry
+        stateLock.unlock()
+
+        // Eagerly publish the accepted status so a watching client sees it immediately.
+        publishStatusSnapshot()
+
+        return (true, stamp.sec, stamp.nanosec)
+    }
+
+    private func handleCancelGoal(requestCDR: Data) async -> Data {
+        // CancelGoal_Request CDR: header (4) + uuid[16] + sec(4) + nsec(4).
+        guard requestCDR.count >= 4 + 16 + 8 else {
+            return Self.encodeCancelGoalResponse(returnCode: 1, entries: [])
+        }
+        let id = Array(
+            requestCDR[(requestCDR.startIndex + 4)..<(requestCDR.startIndex + 4 + 16)])
+        let key = Data(id)
+        stateLock.lock()
+        let entry = goals[key]
+        stateLock.unlock()
+        guard let entry = entry else {
+            return Self.encodeCancelGoalResponse(returnCode: 2, entries: [])
+        }
+        let resp = await handler.handleCancel(entry.handle)
+        switch resp {
+        case .accept:
+            await entry.handle._setCancelRequested(true)
+            entry.task?.cancel()
+            return Self.encodeCancelGoalResponse(
+                returnCode: 0,
+                entries: [
+                    (
+                        uuid: id, stampSec: entry.handle.acceptedAt.sec,
+                        stampNanosec: entry.handle.acceptedAt.nanosec
+                    )
+                ]
+            )
+        case .reject:
+            return Self.encodeCancelGoalResponse(returnCode: 1, entries: [])
+        }
+    }
+
+    private func handleGetResult(goalId: [UInt8]) async throws -> GetResultAck {
+        let key = Data(goalId)
+        stateLock.lock()
+        if let cached = goals[key]?.resultCache {
+            stateLock.unlock()
+            return cached
+        }
+        stateLock.unlock()
+
+        return try await withCheckedThrowingContinuation { cont in
+            stateLock.lock()
+            if let entry = goals[key] {
+                if let cached = entry.resultCache {
+                    stateLock.unlock()
+                    cont.resume(returning: cached)
+                    return
+                }
+                entry.resultWaiters.append(cont)
+                stateLock.unlock()
+            } else {
+                stateLock.unlock()
+                cont.resume(
+                    throwing: ActionError.mapping(
+                        TransportError.unsupportedFeature("unknown goal_id")))
+            }
+        }
+    }
+
+    private func cacheResult(_ ack: GetResultAck, for key: Data) {
+        stateLock.lock()
+        guard let entry = goals[key] else {
+            stateLock.unlock()
+            return
+        }
+        entry.resultCache = ack
+        let waiters = entry.resultWaiters
+        entry.resultWaiters = []
+        stateLock.unlock()
+        for w in waiters {
+            w.resume(returning: ack)
+        }
+    }
+
+    private func transitionStatus(_ s: ActionGoalStatus, for key: Data) {
+        stateLock.lock()
+        if let entry = goals[key] {
+            entry.status = s
+        }
+        stateLock.unlock()
+        publishStatusSnapshot()
+    }
+
+    private func publishStatusSnapshot() {
+        stateLock.lock()
+        let snapshot: [ActionStatusEntry] = goals.map { (key, entry) in
+            ActionStatusEntry(
+                uuid: Array(key),
+                stampSec: entry.handle.acceptedAt.sec,
+                stampNanosec: entry.handle.acceptedAt.nanosec,
+                status: entry.status.rawValue
+            )
+        }
+        stateLock.unlock()
+        guard let serverImpl = transport as? PublishesActionFeedback else { return }
+        try? serverImpl.publishStatus(entries: snapshot)
+    }
+
+    private static func encodeCancelGoalResponse(
+        returnCode: Int8,
+        entries: [(uuid: [UInt8], stampSec: Int32, stampNanosec: UInt32)]
+    ) -> Data {
+        var out = Data([0x00, 0x01, 0x00, 0x00])
+        out.append(UInt8(bitPattern: returnCode))
+        out.append(contentsOf: [0, 0, 0])
+        var count = UInt32(entries.count).littleEndian
+        withUnsafeBytes(of: &count) { out.append(contentsOf: $0) }
+        for e in entries {
+            out.append(contentsOf: e.uuid)
+            var s = e.stampSec.littleEndian
+            var n = e.stampNanosec.littleEndian
+            withUnsafeBytes(of: &s) { out.append(contentsOf: $0) }
+            withUnsafeBytes(of: &n) { out.append(contentsOf: $0) }
+        }
+        return out
+    }
+
+    static func uuidFromBytes(_ b: [UInt8]) -> Foundation.UUID {
+        precondition(b.count == 16)
+        return Foundation.UUID(
+            uuid: (
+                b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+                b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]
+            ))
+    }
+}
+
+/// Internal protocol for type-erased action-server cleanup.
+protocol ActionServerCloseable {
+    func closeActionServer() throws
+}

--- a/Sources/SwiftROS2/ROS2ActionServer.swift
+++ b/Sources/SwiftROS2/ROS2ActionServer.swift
@@ -137,16 +137,17 @@ public final class ROS2ActionServer<H: ActionServerHandler>: @unchecked Sendable
         let stStream = AsyncStream<ActionGoalStatus> { stCont = $0 }
         let goalUUID = Self.uuidFromBytes(goalId)
         let key = Data(goalId)
-        let unused: @Sendable () async throws -> ActionResult<H.Action.Result> = {
-            throw ActionError.wrongSide
-        }
+        // Server-side handles never call `result()` — the umbrella server
+        // owns the executing Task directly. The provider just throws
+        // `wrongSide` if anyone reaches for it.
         let handle = ActionGoalHandle<H.Action>(
             side: .server,
             goalId: goalUUID,
             acceptedAt: stamp,
             feedbackStream: fbStream,
             statusStream: stStream,
-            resultProvider: unused
+            isLegacySchema: isLegacySchema,
+            resultProvider: { _ in throw ActionError.wrongSide }
         )
         // Wire publishFeedback through the transport's feedback writer.
         let transportRef = transport
@@ -162,6 +163,15 @@ public final class ROS2ActionServer<H: ActionServerHandler>: @unchecked Sendable
             fbCont: fbCont!,
             stCont: stCont!
         )
+
+        // Insert the entry into `goals` BEFORE spawning the executing Task.
+        // Otherwise the Task can run immediately, hit `transitionStatus` /
+        // `cacheResult`, find no entry, and silently drop the status / result
+        // updates — which would make `getResult` hang forever for a goal
+        // that actually completed.
+        stateLock.lock()
+        goals[key] = entry
+        stateLock.unlock()
 
         let task: Task<Void, Never> = Task { [weak self, weak entry] in
             guard let self else { return }
@@ -198,10 +208,6 @@ public final class ROS2ActionServer<H: ActionServerHandler>: @unchecked Sendable
         }
         entry.task = task
 
-        stateLock.lock()
-        goals[key] = entry
-        stateLock.unlock()
-
         // Eagerly publish the accepted status so a watching client sees it immediately.
         publishStatusSnapshot()
 
@@ -210,35 +216,73 @@ public final class ROS2ActionServer<H: ActionServerHandler>: @unchecked Sendable
 
     private func handleCancelGoal(requestCDR: Data) async -> Data {
         // CancelGoal_Request CDR: header (4) + uuid[16] + sec(4) + nsec(4).
+        // Per `action_msgs/srv/CancelGoal`:
+        //   - `goal_id == 0` and `stamp == 0` → cancel ALL active goals.
+        //   - `goal_id == 0` and `stamp != 0` → cancel every goal accepted
+        //     at-or-before `stamp`.
+        //   - `goal_id != 0` and `stamp == 0` → cancel the specific goal.
+        //   - both set                         → cancel that goal AND every
+        //     other goal accepted at-or-before `stamp`.
         guard requestCDR.count >= 4 + 16 + 8 else {
             return Self.encodeCancelGoalResponse(returnCode: 1, entries: [])
         }
-        let id = Array(
-            requestCDR[(requestCDR.startIndex + 4)..<(requestCDR.startIndex + 4 + 16)])
-        let key = Data(id)
+        let base = requestCDR.startIndex
+        let id = Array(requestCDR[(base + 4)..<(base + 4 + 16)])
+        let stampSec = requestCDR.withUnsafeBytes {
+            $0.load(fromByteOffset: 4 + 16, as: Int32.self).littleEndian
+        }
+        let stampNsec = requestCDR.withUnsafeBytes {
+            $0.load(fromByteOffset: 4 + 16 + 4, as: UInt32.self).littleEndian
+        }
+        let zeroId = id.allSatisfy { $0 == 0 }
+        let zeroStamp = stampSec == 0 && stampNsec == 0
+
+        // Pick the candidate set under the lock, then route every chosen
+        // goal through the user's `handleCancel` outside the lock.
         stateLock.lock()
-        let entry = goals[key]
+        let candidates: [(key: Data, entry: GoalEntry)] = goals.compactMap { (k, v) in
+            let matchesId = !zeroId && k == Data(id)
+            let matchesStamp =
+                !zeroStamp
+                && (v.handle.acceptedAt.sec < stampSec
+                    || (v.handle.acceptedAt.sec == stampSec
+                        && v.handle.acceptedAt.nanosec <= stampNsec))
+            let matchesAll = zeroId && zeroStamp
+            return (matchesId || matchesStamp || matchesAll) ? (k, v) : nil
+        }
         stateLock.unlock()
-        guard let entry = entry else {
-            return Self.encodeCancelGoalResponse(returnCode: 2, entries: [])
+
+        if candidates.isEmpty {
+            // Lookup-by-id with no match → UNKNOWN_GOAL_ID. Otherwise a
+            // stamp/all sweep with nothing to cancel is REJECTED (no-op).
+            let code: Int8 = (!zeroId && zeroStamp) ? 2 : 1
+            return Self.encodeCancelGoalResponse(returnCode: code, entries: [])
         }
-        let resp = await handler.handleCancel(entry.handle)
-        switch resp {
-        case .accept:
+
+        var canceling: [(uuid: [UInt8], stampSec: Int32, stampNanosec: UInt32)] = []
+        for (key, entry) in candidates {
+            let resp = await handler.handleCancel(entry.handle)
+            guard resp == .accept else { continue }
             await entry.handle._setCancelRequested(true)
+            // Per the action contract, an accepted cancel transitions the
+            // goal to CANCELING immediately; the executing Task observes
+            // `isCancelRequested` (or `Task.isCancelled`) and races to a
+            // terminal state, after which `transitionStatus(.canceled)` /
+            // `.aborted` runs in the goal task.
+            self.transitionStatus(.canceling, for: key)
+            entry.stCont.yield(.canceling)
             entry.task?.cancel()
-            return Self.encodeCancelGoalResponse(
-                returnCode: 0,
-                entries: [
-                    (
-                        uuid: id, stampSec: entry.handle.acceptedAt.sec,
-                        stampNanosec: entry.handle.acceptedAt.nanosec
-                    )
-                ]
-            )
-        case .reject:
-            return Self.encodeCancelGoalResponse(returnCode: 1, entries: [])
+            canceling.append(
+                (
+                    uuid: Array(key),
+                    stampSec: entry.handle.acceptedAt.sec,
+                    stampNanosec: entry.handle.acceptedAt.nanosec
+                ))
         }
+        // returnCode 0 = NONE (success); 1 = REJECTED (handler rejected
+        // every candidate); UNKNOWN was already handled above.
+        let code: Int8 = canceling.isEmpty ? 1 : 0
+        return Self.encodeCancelGoalResponse(returnCode: code, entries: canceling)
     }
 
     private func handleGetResult(goalId: [UInt8]) async throws -> GetResultAck {

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Action.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Action.swift
@@ -517,6 +517,17 @@ final class DDSTransportActionServerImpl: TransportActionServer, @unchecked Send
         try client.writeRawCDR(writer: writer, data: frame, timestamp: 0)
     }
 
+    /// Server-side: publish a full status array via the public protocol seam.
+    ///
+    /// The umbrella `ROS2ActionServer` calls this through
+    /// `PublishesActionFeedback`; tests still call the tuple-typed helper above.
+    func publishStatus(entries: [ActionStatusEntry]) throws {
+        let tuples: [ActionFrameDecoder.StatusEntry] = entries.map {
+            (uuid: $0.uuid, stampSec: $0.stampSec, stampNanosec: $0.stampNanosec, status: $0.status)
+        }
+        try publishStatus(entries: tuples)
+    }
+
     private func replyWriterSnapshot(
         _ keyPath: ReferenceWritableKeyPath<DDSTransportActionServerImpl, (any DDSWriterHandle)?>
     ) -> (any DDSWriterHandle)? {
@@ -557,6 +568,8 @@ final class DDSTransportActionServerImpl: TransportActionServer, @unchecked Send
         }
     }
 }
+
+extension DDSTransportActionServerImpl: PublishesActionFeedback {}
 
 // MARK: - DDS Transport Action Client
 

--- a/Sources/SwiftROS2Transport/TransportActionTypes.swift
+++ b/Sources/SwiftROS2Transport/TransportActionTypes.swift
@@ -218,6 +218,38 @@ public protocol TransportActionClient: AnyObject, Sendable {
     func close() throws
 }
 
+// MARK: - PublishesActionFeedback
+
+/// One status array entry on the wire — uuid (16 bytes) + acceptance stamp + status byte.
+///
+/// Public so the umbrella `ROS2ActionServer` can construct snapshots and pass
+/// them through `PublishesActionFeedback.publishStatus(entries:)` without
+/// importing the internal `ActionFrameDecoder`.
+public struct ActionStatusEntry: Sendable, Equatable {
+    public let uuid: [UInt8]
+    public let stampSec: Int32
+    public let stampNanosec: UInt32
+    public let status: Int8
+
+    public init(uuid: [UInt8], stampSec: Int32, stampNanosec: UInt32, status: Int8) {
+        self.uuid = uuid
+        self.stampSec = stampSec
+        self.stampNanosec = stampNanosec
+        self.status = status
+    }
+}
+
+/// Internal seam that the umbrella `ROS2ActionServer` uses to publish per-goal
+/// feedback frames and the goal-status array. The DDS / Zenoh server impls
+/// conform to this — the umbrella downcasts `transport as? PublishesActionFeedback`.
+///
+/// Public so cross-module conformance works (Swift's module-private rule means
+/// the conformance must live in the same module that owns the protocol).
+public protocol PublishesActionFeedback: AnyObject {
+    func publishFeedback(goalId: [UInt8], feedbackCDR: Data) throws
+    func publishStatus(entries: [ActionStatusEntry]) throws
+}
+
 // MARK: - ActionPendingTable
 
 /// Per-action-client correlation table.

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Action.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Action.swift
@@ -393,6 +393,14 @@ final class ZenohTransportActionServerImpl: TransportActionServer, @unchecked Se
         try client.put(keyExpr: statusKeyExpr, payload: frame, attachment: nil)
     }
 
+    /// Public-protocol witness called by the umbrella `ROS2ActionServer`.
+    func publishStatus(entries: [ActionStatusEntry]) throws {
+        let tuples: [ActionFrameDecoder.StatusEntry] = entries.map {
+            (uuid: $0.uuid, stampSec: $0.stampSec, stampNanosec: $0.stampNanosec, status: $0.status)
+        }
+        try publishStatus(entries: tuples)
+    }
+
     func close() throws {
         lock.lock()
         guard !closed else {
@@ -770,3 +778,5 @@ private final class ActionGetOnceState: @unchecked Sendable {
         cont.resume(throwing: error)
     }
 }
+
+extension ZenohTransportActionServerImpl: PublishesActionFeedback {}

--- a/Tests/SwiftROS2IntegrationTests/FibonacciActionTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/FibonacciActionTests.swift
@@ -1,0 +1,39 @@
+// FibonacciActionTests.swift
+// LAN-gated end-to-end Fibonacci round-trip against a real ROS 2 host.
+//
+// Requires:
+// - `LINUX_IP` env var set to the host running `rmw_zenohd` (skipped if absent).
+// - On the host:
+//     ros2 run rmw_zenoh_cpp rmw_zenohd
+//     RMW_IMPLEMENTATION=rmw_zenoh_cpp ros2 run action_tutorials_cpp fibonacci_action_server
+//
+// Skips gracefully when `LINUX_IP` is not set so CI stays deterministic.
+
+import Foundation
+import XCTest
+
+@testable import SwiftROS2
+@testable import SwiftROS2Messages
+
+final class FibonacciActionTests: XCTestCase {
+    func testFibonacciRoundTripZenoh() async throws {
+        guard let ip = ProcessInfo.processInfo.environment["LINUX_IP"], !ip.isEmpty else {
+            throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)")
+        }
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/\(ip):7447", domainId: 0, wireMode: .jazzy),
+            distro: .jazzy
+        )
+        let node = try await ctx.createNode(name: "fib_test")
+        let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
+        try await cli.waitForActionServer(timeout: .seconds(5))
+        let handle = try await cli.sendGoal(FibonacciAction.Goal(order: 5))
+        let result = try await handle.result(timeout: .seconds(20))
+        if case .succeeded(let r) = result {
+            XCTAssertEqual(r.sequence, [0, 1, 1, 2, 3, 5])
+        } else {
+            XCTFail("non-success terminal: \(result)")
+        }
+        await ctx.shutdown()
+    }
+}

--- a/Tests/SwiftROS2Tests/ActionClientTests.swift
+++ b/Tests/SwiftROS2Tests/ActionClientTests.swift
@@ -1,0 +1,125 @@
+// ActionClientTests.swift
+// Mock-session-driven tests for ROS2ActionClient.
+
+import Foundation
+import XCTest
+
+@testable import SwiftROS2
+@testable import SwiftROS2CDR
+@testable import SwiftROS2Messages
+@testable import SwiftROS2Transport
+
+final class ActionClientTests: XCTestCase {
+    func testSendGoalAcceptedReturnsHandle() async throws {
+        let mock = MockTransportSession()
+        mock.actionClientFactory = { _, _, _, _ in MockActionClient.makeAccepting() }
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+            distro: .jazzy,
+            session: mock
+        )
+        let node = try await ctx.createNode(name: "t")
+        let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
+        let handle = try await cli.sendGoal(FibonacciAction.Goal(order: 5))
+        XCTAssertEqual(handle.acceptedAt.sec, 1)
+        XCTAssertEqual(handle.acceptedAt.nanosec, 2)
+        await ctx.shutdown()
+    }
+
+    func testSendGoalRejectedThrows() async throws {
+        let mock = MockTransportSession()
+        mock.actionClientFactory = { _, _, _, _ in MockActionClient.makeRejecting() }
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+            distro: .jazzy,
+            session: mock
+        )
+        let node = try await ctx.createNode(name: "t")
+        let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
+        do {
+            _ = try await cli.sendGoal(FibonacciAction.Goal(order: 5))
+            XCTFail("expected goalRejected")
+        } catch let e as ActionError {
+            if case .goalRejected = e {
+                await ctx.shutdown()
+                return
+            }
+            XCTFail("got \(e)")
+        }
+        await ctx.shutdown()
+    }
+
+    func testFeedbackDecodesToTypedSequence() async throws {
+        let fb1 = Self.encodeFeedback([1, 1, 2])
+        let fb2 = Self.encodeFeedback([1, 1, 2, 3])
+        let mock = MockTransportSession()
+        mock.actionClientFactory = { _, _, _, _ in
+            MockActionClient.makeAccepting(feedbackCDRs: [fb1, fb2])
+        }
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+            distro: .jazzy,
+            session: mock
+        )
+        let node = try await ctx.createNode(name: "t")
+        let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
+        let handle = try await cli.sendGoal(FibonacciAction.Goal(order: 5))
+        var seen: [[Int32]] = []
+        for await fb in handle.feedback {
+            seen.append(fb.partialSequence)
+            if seen.count == 2 { break }
+        }
+        XCTAssertEqual(seen, [[1, 1, 2], [1, 1, 2, 3]])
+        await ctx.shutdown()
+    }
+
+    func testResultSucceededDecodesPayload() async throws {
+        let resultCDR = Self.encodeResult([0, 1, 1, 2, 3])
+        let mock = MockTransportSession()
+        mock.actionClientFactory = { _, _, _, _ in
+            MockActionClient.makeAccepting(getResultStatus: 4, getResultCDR: resultCDR)
+        }
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+            distro: .jazzy,
+            session: mock
+        )
+        let node = try await ctx.createNode(name: "t")
+        let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
+        let handle = try await cli.sendGoal(FibonacciAction.Goal(order: 5))
+        let r = try await handle.result(timeout: .seconds(2))
+        if case .succeeded(let payload) = r {
+            XCTAssertEqual(payload.sequence, [0, 1, 1, 2, 3])
+        } else {
+            XCTFail("expected succeeded, got \(r)")
+        }
+        await ctx.shutdown()
+    }
+
+    func testCancelGoalsBeforeStampReturnsEmptyForCleanRun() async throws {
+        let mock = MockTransportSession()
+        mock.actionClientFactory = { _, _, _, _ in MockActionClient.makeAccepting() }
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+            distro: .jazzy,
+            session: mock
+        )
+        let node = try await ctx.createNode(name: "t")
+        let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
+        let canceled = try await cli.cancelGoals(beforeStamp: BuiltinInterfacesTime(sec: 9, nanosec: 0))
+        XCTAssertEqual(canceled, [])
+        await ctx.shutdown()
+    }
+
+    private static func encodeFeedback(_ seq: [Int32]) -> Data {
+        let encoder = CDREncoder(isLegacySchema: false)
+        try! FibonacciAction.Feedback(partialSequence: seq).encode(to: encoder)
+        return encoder.getData()
+    }
+
+    private static func encodeResult(_ seq: [Int32]) -> Data {
+        let encoder = CDREncoder(isLegacySchema: false)
+        try! FibonacciAction.Result(sequence: seq).encode(to: encoder)
+        return encoder.getData()
+    }
+}

--- a/Tests/SwiftROS2Tests/ActionGoalHandleTests.swift
+++ b/Tests/SwiftROS2Tests/ActionGoalHandleTests.swift
@@ -1,0 +1,64 @@
+// ActionGoalHandleTests.swift
+// Per-side capability gating.
+
+import Foundation
+import XCTest
+
+@testable import SwiftROS2
+@testable import SwiftROS2Messages
+
+final class ActionGoalHandleTests: XCTestCase {
+    func testClientHandlePublishFeedbackThrowsWrongSide() async throws {
+        let handle = ActionGoalHandle<FibonacciAction>(
+            side: .client,
+            goalId: Foundation.UUID(),
+            acceptedAt: BuiltinInterfacesTime(),
+            feedbackStream: AsyncStream { _ in },
+            statusStream: AsyncStream { _ in },
+            resultProvider: { throw ActionError.clientClosed }
+        )
+        do {
+            try await handle.publishFeedback(
+                FibonacciAction.Feedback(partialSequence: [])
+            )
+            XCTFail("expected wrongSide")
+        } catch let e as ActionError {
+            if case .wrongSide = e { return }
+            XCTFail("got \(e)")
+        }
+    }
+
+    func testServerHandleResultThrowsWrongSide() async throws {
+        let handle = ActionGoalHandle<FibonacciAction>(
+            side: .server,
+            goalId: Foundation.UUID(),
+            acceptedAt: BuiltinInterfacesTime(),
+            feedbackStream: AsyncStream { _ in },
+            statusStream: AsyncStream { _ in },
+            resultProvider: { throw ActionError.serverClosed }
+        )
+        do {
+            _ = try await handle.result(timeout: nil)
+            XCTFail("expected wrongSide")
+        } catch let e as ActionError {
+            if case .wrongSide = e { return }
+            XCTFail("got \(e)")
+        }
+    }
+
+    func testServerHandleIsCancelRequestedReturnsLatest() async {
+        let handle = ActionGoalHandle<FibonacciAction>(
+            side: .server,
+            goalId: Foundation.UUID(),
+            acceptedAt: BuiltinInterfacesTime(),
+            feedbackStream: AsyncStream { _ in },
+            statusStream: AsyncStream { _ in },
+            resultProvider: { throw ActionError.serverClosed }
+        )
+        let initial = await handle.isCancelRequested
+        XCTAssertFalse(initial)
+        await handle._setCancelRequested(true)
+        let after = await handle.isCancelRequested
+        XCTAssertTrue(after)
+    }
+}

--- a/Tests/SwiftROS2Tests/ActionGoalHandleTests.swift
+++ b/Tests/SwiftROS2Tests/ActionGoalHandleTests.swift
@@ -15,7 +15,8 @@ final class ActionGoalHandleTests: XCTestCase {
             acceptedAt: BuiltinInterfacesTime(),
             feedbackStream: AsyncStream { _ in },
             statusStream: AsyncStream { _ in },
-            resultProvider: { throw ActionError.clientClosed }
+            isLegacySchema: false,
+            resultProvider: { _ in throw ActionError.clientClosed }
         )
         do {
             try await handle.publishFeedback(
@@ -35,7 +36,8 @@ final class ActionGoalHandleTests: XCTestCase {
             acceptedAt: BuiltinInterfacesTime(),
             feedbackStream: AsyncStream { _ in },
             statusStream: AsyncStream { _ in },
-            resultProvider: { throw ActionError.serverClosed }
+            isLegacySchema: false,
+            resultProvider: { _ in throw ActionError.serverClosed }
         )
         do {
             _ = try await handle.result(timeout: nil)
@@ -53,7 +55,8 @@ final class ActionGoalHandleTests: XCTestCase {
             acceptedAt: BuiltinInterfacesTime(),
             feedbackStream: AsyncStream { _ in },
             statusStream: AsyncStream { _ in },
-            resultProvider: { throw ActionError.serverClosed }
+            isLegacySchema: false,
+            resultProvider: { _ in throw ActionError.serverClosed }
         )
         let initial = await handle.isCancelRequested
         XCTAssertFalse(initial)

--- a/Tests/SwiftROS2Tests/ActionServerHandlerTests.swift
+++ b/Tests/SwiftROS2Tests/ActionServerHandlerTests.swift
@@ -1,0 +1,25 @@
+// ActionServerHandlerTests.swift
+// Verify a sample actor conforms to ActionServerHandler.
+
+import XCTest
+
+@testable import SwiftROS2
+@testable import SwiftROS2Messages
+
+actor _NoopHandler: ActionServerHandler {
+    typealias Action = FibonacciAction
+    func handleGoal(_ goal: FibonacciAction.Goal) async -> GoalResponse { .accept }
+    func handleCancel(_ handle: ActionGoalHandle<FibonacciAction>) async -> CancelResponse {
+        .accept
+    }
+    func execute(_ handle: ActionGoalHandle<FibonacciAction>) async throws -> FibonacciAction.Result {
+        return FibonacciAction.Result(sequence: [0, 1, 1])
+    }
+}
+
+final class ActionServerHandlerTests: XCTestCase {
+    func testActorCanConformToHandler() async {
+        let handler: any ActionServerHandler = _NoopHandler()
+        XCTAssertNotNil(handler)
+    }
+}

--- a/Tests/SwiftROS2Tests/ActionServerTests.swift
+++ b/Tests/SwiftROS2Tests/ActionServerTests.swift
@@ -1,0 +1,115 @@
+// ActionServerTests.swift
+// Mock-session-driven tests for ROS2ActionServer.
+
+import Foundation
+import XCTest
+
+@testable import SwiftROS2
+@testable import SwiftROS2CDR
+@testable import SwiftROS2Messages
+@testable import SwiftROS2Transport
+
+actor _AcceptingHandler: ActionServerHandler {
+    typealias Action = FibonacciAction
+    private(set) var lastGoal: FibonacciAction.Goal?
+
+    func handleGoal(_ goal: FibonacciAction.Goal) async -> GoalResponse {
+        lastGoal = goal
+        return .accept
+    }
+
+    func handleCancel(_ handle: ActionGoalHandle<FibonacciAction>) async -> CancelResponse {
+        .accept
+    }
+
+    func execute(_ handle: ActionGoalHandle<FibonacciAction>) async throws
+        -> FibonacciAction.Result
+    {
+        return FibonacciAction.Result(sequence: [0, 1, 1, 2, 3])
+    }
+}
+
+actor _RejectingHandler: ActionServerHandler {
+    typealias Action = FibonacciAction
+    func handleGoal(_ goal: FibonacciAction.Goal) async -> GoalResponse { .reject }
+    func handleCancel(_ handle: ActionGoalHandle<FibonacciAction>) async -> CancelResponse {
+        .reject
+    }
+    func execute(_ handle: ActionGoalHandle<FibonacciAction>) async throws
+        -> FibonacciAction.Result
+    {
+        XCTFail("should never execute on reject")
+        throw ActionError.goalRejected
+    }
+}
+
+final class ActionServerTests: XCTestCase {
+    func testAcceptPathRunsExecuteAndCachesResult() async throws {
+        let mock = MockTransportSession()
+        let captured = MockActionServer.Box()
+        mock.actionServerFactory = { _, _, _, _, handlers in
+            captured.handlers = handlers
+            return MockActionServer()
+        }
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+            distro: .jazzy,
+            session: mock
+        )
+        let node = try await ctx.createNode(name: "t")
+        _ = try await node.createActionServer(
+            FibonacciAction.self,
+            name: "/fibonacci",
+            handler: _AcceptingHandler()
+        )
+
+        // Drive a goal through the captured handlers.
+        let goalId = [UInt8](repeating: 0xAA, count: 16)
+        let encoder = CDREncoder(isLegacySchema: false)
+        try FibonacciAction.Goal(order: 5).encode(to: encoder)
+        let goalCDR = encoder.getData()
+
+        let (accepted, _, _) = try await captured.handlers!.onSendGoal(goalId, goalCDR)
+        XCTAssertTrue(accepted)
+
+        // Wait for the goal Task to complete by polling getResult.
+        var ack: GetResultAck?
+        for _ in 0..<40 {
+            if let r = try? await captured.handlers!.onGetResult(goalId) {
+                if r.status == ActionGoalStatus.succeeded.rawValue {
+                    ack = r
+                    break
+                }
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTAssertEqual(ack?.status, ActionGoalStatus.succeeded.rawValue)
+        await ctx.shutdown()
+    }
+
+    func testRejectPathReturnsAcceptedFalse() async throws {
+        let mock = MockTransportSession()
+        let captured = MockActionServer.Box()
+        mock.actionServerFactory = { _, _, _, _, handlers in
+            captured.handlers = handlers
+            return MockActionServer()
+        }
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+            distro: .jazzy,
+            session: mock
+        )
+        let node = try await ctx.createNode(name: "t")
+        _ = try await node.createActionServer(
+            FibonacciAction.self,
+            name: "/fibonacci",
+            handler: _RejectingHandler()
+        )
+        let goalId = [UInt8](repeating: 0xBB, count: 16)
+        let encoder = CDREncoder(isLegacySchema: false)
+        try FibonacciAction.Goal(order: 5).encode(to: encoder)
+        let (accepted, _, _) = try await captured.handlers!.onSendGoal(goalId, encoder.getData())
+        XCTAssertFalse(accepted)
+        await ctx.shutdown()
+    }
+}

--- a/Tests/SwiftROS2Tests/ActionTypesTests.swift
+++ b/Tests/SwiftROS2Tests/ActionTypesTests.swift
@@ -1,0 +1,63 @@
+// ActionTypesTests.swift
+// Public-surface shape tests for action enums and ActionError.
+
+import XCTest
+
+@testable import SwiftROS2
+
+final class ActionTypesTests: XCTestCase {
+    func testGoalStatusRawValues() {
+        XCTAssertEqual(ActionGoalStatus.unknown.rawValue, 0)
+        XCTAssertEqual(ActionGoalStatus.accepted.rawValue, 1)
+        XCTAssertEqual(ActionGoalStatus.executing.rawValue, 2)
+        XCTAssertEqual(ActionGoalStatus.canceling.rawValue, 3)
+        XCTAssertEqual(ActionGoalStatus.succeeded.rawValue, 4)
+        XCTAssertEqual(ActionGoalStatus.canceled.rawValue, 5)
+        XCTAssertEqual(ActionGoalStatus.aborted.rawValue, 6)
+    }
+
+    func testGoalStatusTerminalFlag() {
+        XCTAssertTrue(ActionGoalStatus.succeeded.isTerminal)
+        XCTAssertTrue(ActionGoalStatus.canceled.isTerminal)
+        XCTAssertTrue(ActionGoalStatus.aborted.isTerminal)
+        XCTAssertFalse(ActionGoalStatus.unknown.isTerminal)
+        XCTAssertFalse(ActionGoalStatus.accepted.isTerminal)
+        XCTAssertFalse(ActionGoalStatus.executing.isTerminal)
+        XCTAssertFalse(ActionGoalStatus.canceling.isTerminal)
+    }
+
+    func testGoalResponseAndCancelResponseAreDecidable() {
+        XCTAssertNotEqual(GoalResponse.accept, GoalResponse.reject)
+        XCTAssertNotEqual(CancelResponse.accept, CancelResponse.reject)
+    }
+
+    func testActionResultCarriesPayload() {
+        let r1: ActionResult<Int> = .succeeded(42)
+        let r2: ActionResult<Int> = .aborted(reason: "nope")
+        let r3: ActionResult<Int> = .canceled
+        if case .succeeded(let v) = r1 {
+            XCTAssertEqual(v, 42)
+        } else {
+            XCTFail("expected succeeded")
+        }
+        if case .aborted(let r) = r2 {
+            XCTAssertEqual(r, "nope")
+        } else {
+            XCTFail("expected aborted")
+        }
+        if case .canceled = r3 {
+        } else {
+            XCTFail("expected canceled")
+        }
+    }
+
+    func testActionErrorPayloads() {
+        XCTAssertNotNil(ActionError.actionServerUnavailable.errorDescription)
+        XCTAssertNotNil(ActionError.goalRejected.errorDescription)
+        XCTAssertNotNil(ActionError.goalCanceled.errorDescription)
+        XCTAssertNotNil(ActionError.acceptanceTimedOut.errorDescription)
+        XCTAssertNotNil(ActionError.wrongSide.errorDescription)
+        XCTAssertNotNil(ActionError.goalAborted(reason: "x").errorDescription)
+        XCTAssertNotNil(ActionError.requestEncodingFailed("x").errorDescription)
+    }
+}

--- a/Tests/SwiftROS2Tests/Mocks/MockActionClient.swift
+++ b/Tests/SwiftROS2Tests/Mocks/MockActionClient.swift
@@ -1,0 +1,139 @@
+// MockActionClient.swift
+// In-memory TransportActionClient for SwiftROS2 umbrella unit tests.
+
+import Foundation
+import SwiftROS2Transport
+
+final class MockActionClient: TransportActionClient, @unchecked Sendable {
+    let name: String
+    private let lock = NSLock()
+    private var closed = false
+
+    /// Decision returned by `sendGoal`.
+    enum Acceptance {
+        case accept
+        case reject
+    }
+
+    private let acceptance: Acceptance
+    private let feedbackCDRs: [Data]
+    private let statusUpdates: [Int8]
+    private let getResultStatus: Int8
+    private let getResultCDR: Data
+    private let cancelReturnCode: Int8
+    private let waitShouldThrow: TransportError?
+
+    init(
+        name: String = "/mock_action",
+        acceptance: Acceptance = .accept,
+        feedbackCDRs: [Data] = [],
+        statusUpdates: [Int8] = [],
+        getResultStatus: Int8 = 4,  // succeeded
+        getResultCDR: Data = Data(),
+        cancelReturnCode: Int8 = 0,
+        waitShouldThrow: TransportError? = nil
+    ) {
+        self.name = name
+        self.acceptance = acceptance
+        self.feedbackCDRs = feedbackCDRs
+        self.statusUpdates = statusUpdates
+        self.getResultStatus = getResultStatus
+        self.getResultCDR = getResultCDR
+        self.cancelReturnCode = cancelReturnCode
+        self.waitShouldThrow = waitShouldThrow
+    }
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+
+    func waitForActionServer(timeout: Duration) async throws {
+        if let e = waitShouldThrow { throw e }
+    }
+
+    func sendGoal(
+        goalId: [UInt8],
+        goalCDR: Data,
+        acceptanceTimeout: Duration
+    ) async throws -> SendGoalAck {
+        precondition(goalId.count == 16)
+        var fbCont: AsyncStream<Data>.Continuation!
+        let feedback = AsyncStream<Data> { fbCont = $0 }
+        let fbContCap = fbCont!
+        var stCont: AsyncStream<ActionStatusUpdate>.Continuation!
+        let status = AsyncStream<ActionStatusUpdate> { stCont = $0 }
+        let stContCap = stCont!
+
+        switch acceptance {
+        case .accept:
+            // Yield seeded feedback / status frames asynchronously.
+            let fbs = feedbackCDRs
+            let sts = statusUpdates
+            Task {
+                for f in fbs {
+                    fbContCap.yield(f)
+                }
+                fbContCap.finish()
+            }
+            Task {
+                for s in sts {
+                    stContCap.yield(ActionStatusUpdate(status: s))
+                }
+                stContCap.finish()
+            }
+            return SendGoalAck(
+                accepted: true, stampSec: 1, stampNanosec: 2,
+                feedback: feedback, status: status
+            )
+        case .reject:
+            fbContCap.finish()
+            stContCap.finish()
+            return SendGoalAck(
+                accepted: false, stampSec: 0, stampNanosec: 0,
+                feedback: feedback, status: status
+            )
+        }
+    }
+
+    func getResult(goalId: [UInt8], timeout: Duration) async throws -> GetResultAck {
+        return GetResultAck(status: getResultStatus, resultCDR: getResultCDR)
+    }
+
+    func cancelGoal(
+        goalId: [UInt8]?,
+        beforeStampSec: Int32?,
+        beforeStampNanosec: UInt32?,
+        timeout: Duration
+    ) async throws -> CancelGoalAck {
+        return CancelGoalAck(returnCode: cancelReturnCode, goalsCanceling: [])
+    }
+
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        closed = true
+    }
+
+    // MARK: - Convenience constructors used by tests
+
+    static func makeAccepting(
+        feedbackCDRs: [Data] = [],
+        statusUpdates: [Int8] = [],
+        getResultStatus: Int8 = 4,
+        getResultCDR: Data = Data()
+    ) -> MockActionClient {
+        return MockActionClient(
+            acceptance: .accept,
+            feedbackCDRs: feedbackCDRs,
+            statusUpdates: statusUpdates,
+            getResultStatus: getResultStatus,
+            getResultCDR: getResultCDR
+        )
+    }
+
+    static func makeRejecting() -> MockActionClient {
+        return MockActionClient(acceptance: .reject)
+    }
+}

--- a/Tests/SwiftROS2Tests/Mocks/MockActionServer.swift
+++ b/Tests/SwiftROS2Tests/Mocks/MockActionServer.swift
@@ -1,0 +1,78 @@
+// MockActionServer.swift
+// In-memory TransportActionServer for SwiftROS2 umbrella unit tests.
+//
+// Conforms to PublishesActionFeedback so the umbrella can publish feedback
+// and status snapshots without needing a real DDS / Zenoh transport.
+
+import Foundation
+import SwiftROS2Transport
+
+final class MockActionServer: TransportActionServer, PublishesActionFeedback, @unchecked Sendable {
+    let name: String
+    private let lock = NSLock()
+    private var closed = false
+
+    private var _publishedFeedbacks: [(goalId: [UInt8], cdr: Data)] = []
+    private var _publishedStatuses: [[ActionStatusEntry]] = []
+
+    init(name: String = "/mock_action") {
+        self.name = name
+    }
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        closed = true
+    }
+
+    func publishFeedback(goalId: [UInt8], feedbackCDR: Data) throws {
+        lock.lock()
+        _publishedFeedbacks.append((goalId, feedbackCDR))
+        lock.unlock()
+    }
+
+    func publishStatus(entries: [ActionStatusEntry]) throws {
+        lock.lock()
+        _publishedStatuses.append(entries)
+        lock.unlock()
+    }
+
+    var publishedFeedbacks: [(goalId: [UInt8], cdr: Data)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _publishedFeedbacks
+    }
+
+    var publishedStatuses: [[ActionStatusEntry]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _publishedStatuses
+    }
+
+    /// Captured handlers — populated by the test factory closure.
+    /// Use `Box` to share a single mutable reference between the factory
+    /// closure (which constructs the server) and the test that drives it.
+    final class Box: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _handlers: TransportActionServerHandlers?
+        var handlers: TransportActionServerHandlers? {
+            get {
+                lock.lock()
+                defer { lock.unlock() }
+                return _handlers
+            }
+            set {
+                lock.lock()
+                _handlers = newValue
+                lock.unlock()
+            }
+        }
+        init() {}
+    }
+}

--- a/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
+++ b/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
@@ -239,6 +239,52 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
         }
     }
 
+    // MARK: - Action overrides
+
+    /// Optional factory used by `createActionServer` if set. Signature:
+    /// `(name, actionTypeName, roleTypeHashes, qos, handlers) -> any TransportActionServer`.
+    var actionServerFactory:
+        (
+            @Sendable (
+                String, String, ActionRoleTypeHashes, TransportQoS,
+                TransportActionServerHandlers
+            ) -> any TransportActionServer
+        )?
+
+    /// Optional factory used by `createActionClient` if set. Signature:
+    /// `(name, actionTypeName, roleTypeHashes, qos) -> any TransportActionClient`.
+    var actionClientFactory:
+        (
+            @Sendable (
+                String, String, ActionRoleTypeHashes, TransportQoS
+            ) -> any TransportActionClient
+        )?
+
+    func createActionServer(
+        name: String,
+        actionTypeName: String,
+        roleTypeHashes: ActionRoleTypeHashes,
+        qos: TransportQoS,
+        handlers: TransportActionServerHandlers
+    ) throws -> any TransportActionServer {
+        if let f = actionServerFactory {
+            return f(name, actionTypeName, roleTypeHashes, qos, handlers)
+        }
+        throw TransportError.unsupportedFeature("MockTransportSession action server")
+    }
+
+    func createActionClient(
+        name: String,
+        actionTypeName: String,
+        roleTypeHashes: ActionRoleTypeHashes,
+        qos: TransportQoS
+    ) throws -> any TransportActionClient {
+        if let f = actionClientFactory {
+            return f(name, actionTypeName, roleTypeHashes, qos)
+        }
+        throw TransportError.unsupportedFeature("MockTransportSession action client")
+    }
+
     // MARK: - Service test helpers
 
     /// Make subsequent `createServiceServer` / `createServiceClient` calls

--- a/Tests/SwiftROS2Tests/NodeActionTests.swift
+++ b/Tests/SwiftROS2Tests/NodeActionTests.swift
@@ -1,0 +1,47 @@
+// NodeActionTests.swift
+// ROS2Node.createActionServer / createActionClient integration.
+
+import XCTest
+
+@testable import SwiftROS2
+@testable import SwiftROS2Messages
+@testable import SwiftROS2Transport
+
+final class NodeActionTests: XCTestCase {
+    func testNodeDestroyClosesActionEntities() async throws {
+        let mock = MockTransportSession()
+        mock.actionClientFactory = { _, _, _, _ in MockActionClient.makeAccepting() }
+        mock.actionServerFactory = { _, _, _, _, _ in MockActionServer() }
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+            distro: .jazzy,
+            session: mock
+        )
+        let node = try await ctx.createNode(name: "t")
+        let server = try await node.createActionServer(
+            FibonacciAction.self, name: "/fibonacci",
+            handler: _AcceptingHandler()
+        )
+        let client = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
+        XCTAssertTrue(server.isActive)
+        XCTAssertTrue(client.isActive)
+        await node.destroy()
+        XCTAssertFalse(server.isActive)
+        XCTAssertFalse(client.isActive)
+        await ctx.shutdown()
+    }
+
+    func testCreateActionClientEmitsConfiguredEntity() async throws {
+        let mock = MockTransportSession()
+        mock.actionClientFactory = { _, _, _, _ in MockActionClient.makeAccepting() }
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+            distro: .jazzy,
+            session: mock
+        )
+        let node = try await ctx.createNode(name: "t")
+        let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
+        XCTAssertTrue(cli.isActive)
+        await ctx.shutdown()
+    }
+}


### PR DESCRIPTION
## Summary

Final phase for ROS 2 Actions support. Ships the public typed API + examples + DocC + integration test, and cuts the 0.8.0 release.

- `ROS2ActionServer<H>`, `ROS2ActionClient<A>`, `ActionGoalHandle<A>`, `ActionServerHandler`, public enums (`GoalResponse`, `CancelResponse`, `ActionGoalStatus`, `ActionResult`) + `ActionError`.
- `QoSProfile.actionDefault` (reliable / volatile / keep-last 10).
- `ROS2Node.createActionServer` / `createActionClient` with full lifecycle integration into `node.destroy()`.
- `ActionStatusEntry` + `PublishesActionFeedback` public on `SwiftROS2Transport` so the umbrella server can publish feedback / status snapshots without a transport-specific downcast. `DDSTransportActionServerImpl` and `ZenohTransportActionServerImpl` conform.
- `action-server` / `action-client` example binaries.
- LINUX_IP-gated `FibonacciActionTests` integration test.
- DocC `Actions.md` chapter; `MIGRATION.md` 0.7 → 0.8 entry; `CHANGELOG.md` cuts `[0.8.0]` from `[Unreleased]`.

After merge, tag `0.8.0` to fire the xcframework release workflow, then open a follow-up PR to bump `releaseBaseURL` + checksums in `Package.swift`.

## Notes vs the original plan

- The umbrella enum was named `ActionGoalStatus` rather than `GoalStatus` to avoid colliding with the existing `SwiftROS2Messages.GoalStatus` struct (the embedded CDR payload of `GoalStatusArray`, shipped in Phase 1) which already re-exports through the umbrella.
- `ROS2Context` already exposes a `session:` injection parameter; tests use that directly instead of adding a new `sessionFactory:` test seam.
- `closeClient` / `closeService` were already taken on the existing `Service` / `Client` `Closeable` protocols, so the action-side cleanup protocols are `ActionClientCloseable` / `ActionServerCloseable` with `closeActionClient` / `closeActionServer`.
- The umbrella's feedback / result decode prepends the 4-byte CDR encapsulation header before handing payloads to `CDRDecoder`, since the transport's `ActionFrameDecoder` returns the bare body without a header.

## Test plan

- [x] `swift build` — clean (Apple, all targets).
- [x] `swift test --parallel` — 354 tests green locally.
- [x] `swift format lint --strict` — clean.
- [ ] LINUX_IP-gated `FibonacciActionTests` against `ros2 run action_tutorials_cpp fibonacci_action_server` over Zenoh (skipped without env).
- [ ] CI cross-platform sweep (Linux x86_64 / aarch64, Windows, Android).

## Stacked PR base

This PR is the top of the six-phase Actions stack and bases on `feat/actions-phase-5-zenoh`. Merge order: phases 2 -> 3 -> 4 -> 5 -> 6.