### PR TITLE
ci: add SwiftPM .build cache to all jobs (uniform cache PR 1 of 3)

### DIFF
--- a/.github/actions/swiftpm-build-cache/action.yml
+++ b/.github/actions/swiftpm-build-cache/action.yml
@@ -1,0 +1,54 @@
+name: SwiftPM build cache
+description: |
+  Cache SwiftPM's .build/ directory keyed by Package state, source
+  contents, and submodule HEAD SHAs. Per-job scope. Honors a
+  DISABLE_BUILD_CACHE=1 env escape hatch.
+
+inputs:
+  job-suffix:
+    description: |
+      Discriminator for jobs that share an OS+matrix slot (e.g. the three
+      macOS jobs: build-test / api-stability / docs). Empty string is
+      acceptable for jobs that already have a unique runner.os+matrix-key.
+    required: false
+    default: default
+  matrix-key:
+    description: |
+      Per-matrix discriminator (e.g. linux-jazzy-x86_64, android-aarch64).
+      Empty string for non-matrix jobs.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Compute submodule SHA digest
+      id: submodules
+      shell: bash
+      run: |
+        # Hash all submodule HEAD SHAs into a stable 16-hex digest.
+        # Any submodule pointer move (vendor/zenoh-pico,
+        # vendor/common_interfaces-*, vendor/rcl_interfaces-*) invalidates
+        # every cache entry — exactly the desired behavior because their
+        # contents feed into swift build (zenoh-pico C source) and the
+        # phase-7 build plugin (IDL inputs).
+        DIGEST=$(git submodule status --recursive 2>/dev/null \
+          | awk '{print $1}' \
+          | tr -d ' -+' \
+          | sort \
+          | sha256sum \
+          | awk '{print $1}' \
+          | cut -c1-16)
+        if [[ -z "$DIGEST" ]]; then
+          # No submodules registered — fall back to a fixed sentinel so
+          # the cache key is still valid.
+          DIGEST="nosubmodules"
+        fi
+        echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+    - name: Cache SwiftPM .build
+      if: ${{ env.DISABLE_BUILD_CACHE != '1' }}
+      uses: actions/cache@v4
+      with:
+        path: .build
+        key: swiftpm-build-${{ runner.os }}-${{ inputs.matrix-key }}-${{ inputs.job-suffix }}-${{ steps.submodules.outputs.digest }}-${{ hashFiles('Package.swift', 'Package.resolved', 'Sources/**/*.swift', 'Sources/**/*.c', 'Sources/**/*.h', 'Sources/**/*.cpp', 'Sources/**/*.m', 'Tests/**/*.swift', 'Tests/**/*.c', 'Tests/**/*.h') }}

--- a/.github/actions/swiftpm-build-cache/action.yml
+++ b/.github/actions/swiftpm-build-cache/action.yml
@@ -26,17 +26,20 @@ runs:
       id: submodules
       shell: bash
       run: |
+        set -euo pipefail
         # Hash all submodule HEAD SHAs into a stable 16-hex digest.
         # Any submodule pointer move (vendor/zenoh-pico,
         # vendor/common_interfaces-*, vendor/rcl_interfaces-*) invalidates
         # every cache entry — exactly the desired behavior because their
         # contents feed into swift build (zenoh-pico C source) and the
         # phase-7 build plugin (IDL inputs).
+        # `shasum -a 256` (BSD) is portable across macOS / Linux / Git Bash
+        # on Windows; `sha256sum` (GNU coreutils) is not part of macOS base.
         DIGEST=$(git submodule status --recursive 2>/dev/null \
           | awk '{print $1}' \
           | tr -d ' -+' \
           | sort \
-          | sha256sum \
+          | shasum -a 256 \
           | awk '{print $1}' \
           | cut -c1-16)
         if [[ -z "$DIGEST" ]]; then
@@ -51,4 +54,4 @@ runs:
       uses: actions/cache@v4
       with:
         path: .build
-        key: swiftpm-build-${{ runner.os }}-${{ inputs.matrix-key }}-${{ inputs.job-suffix }}-${{ steps.submodules.outputs.digest }}-${{ hashFiles('Package.swift', 'Package.resolved', 'Sources/**/*.swift', 'Sources/**/*.c', 'Sources/**/*.h', 'Sources/**/*.cpp', 'Sources/**/*.m', 'Tests/**/*.swift', 'Tests/**/*.c', 'Tests/**/*.h') }}
+        key: swiftpm-build-${{ runner.os }}-${{ inputs.matrix-key }}-${{ inputs.job-suffix }}-${{ steps.submodules.outputs.digest }}-${{ hashFiles('Package.swift', 'Package.resolved', 'Sources/**/*.swift', 'Sources/**/*.c', 'Sources/**/*.h', 'Sources/**/*.modulemap', 'Sources/**/*.msg', 'Sources/**/*.srv', 'Sources/**/*.action', 'Tests/**/*.swift', 'Tests/**/*.c', 'Tests/**/*.h') }}

--- a/.github/actions/swiftpm-build-cache/action.yml
+++ b/.github/actions/swiftpm-build-cache/action.yml
@@ -33,13 +33,25 @@ runs:
         # every cache entry — exactly the desired behavior because their
         # contents feed into swift build (zenoh-pico C source) and the
         # phase-7 build plugin (IDL inputs).
-        # `shasum -a 256` (BSD) is portable across macOS / Linux / Git Bash
-        # on Windows; `sha256sum` (GNU coreutils) is not part of macOS base.
+        # GitHub runner SHA-256 utility availability:
+        #   - Linux: `sha256sum` (GNU coreutils), no `shasum`.
+        #   - macOS: both `sha256sum` (Homebrew coreutils preinstalled)
+        #            and `shasum` (BSD, ships with the OS).
+        #   - Windows (Git Bash): `sha256sum` (msysgit), no `shasum`.
+        # `sha256sum` is the only one available on all three.
+        if command -v sha256sum >/dev/null 2>&1; then
+          HASH_CMD="sha256sum"
+        elif command -v shasum >/dev/null 2>&1; then
+          HASH_CMD="shasum -a 256"
+        else
+          echo "ERROR: no SHA-256 utility available on PATH" >&2
+          exit 1
+        fi
         DIGEST=$(git submodule status --recursive 2>/dev/null \
           | awk '{print $1}' \
           | tr -d ' -+' \
           | sort \
-          | shasum -a 256 \
+          | $HASH_CMD \
           | awk '{print $1}' \
           | cut -c1-16)
         if [[ -z "$DIGEST" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,8 @@ jobs:
           ls "$CYCLONEDDS_DIR/include/dds/dds.h"
           ls "$CYCLONEDDS_DIR/lib/ddsc.lib"
           ls "$CYCLONEDDS_DIR/bin/ddsc.dll"
+      - name: Cache SwiftPM .build
+        uses: ./.github/actions/swiftpm-build-cache
       - name: Build
         run: swift build
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,10 @@ jobs:
           swift sdk list
       - name: Swift version
         run: swift --version
+      - name: Cache SwiftPM .build
+        uses: ./.github/actions/swiftpm-build-cache
+        with:
+          matrix-key: android-${{ matrix.abi }}
       - name: Build
         # SWIFT_ROS2_TARGET_OS — Package.swift reads this to pick the
         # Android arm when cross-compiling from a Linux host, since

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
           submodules: recursive
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app
+      - name: Cache SwiftPM .build
+        uses: ./.github/actions/swiftpm-build-cache
+        with:
+          job-suffix: docs
       - name: Generate DocC
         run: swift package generate-documentation --target SwiftROS2
       - name: Check DocC coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app
       - name: Swift version
         run: swift --version
+      - name: Cache SwiftPM .build
+        uses: ./.github/actions/swiftpm-build-cache
+        with:
+          job-suffix: build-test
       - name: Build
         run: swift build
       - name: Test (with coverage)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,10 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app
       - name: Swift version
         run: swift --version
+      - name: Cache SwiftPM .build
+        uses: ./.github/actions/swiftpm-build-cache
+        with:
+          job-suffix: api-stability
       - name: Diagnose API breaking changes
         run: bash Scripts/diagnose-api-breaking-changes.sh 0.6.1 Scripts/api-breakage-allowlist.txt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,10 @@ jobs:
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
           export PKG_CONFIG_PATH="/opt/ros/${{ matrix.ros_distro }}/lib/${{ matrix.arch }}-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
           bash Scripts/build-linux-deps.sh
+      - name: Cache SwiftPM .build
+        uses: ./.github/actions/swiftpm-build-cache
+        with:
+          matrix-key: linux-${{ matrix.ros_distro }}-${{ matrix.arch }}
       - name: Build
         run: |
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash


### PR DESCRIPTION
## Summary
- Adds a composite action `.github/actions/swiftpm-build-cache` that caches SwiftPM's `.build/` directory.
- Cache key: `runner.os` + matrix discriminator + job suffix + a digest of all submodule HEAD SHAs + `hashFiles()` over `Package.{swift,resolved}` and every source/test file (including `*.modulemap`, `*.msg`, `*.srv`, `*.action` for the Phase-7 build plugin).
- Wires it into all 6 build jobs: `build-macos`, `check-api-stability`, `build-docs`, `build-linux` (matrix × 6), `build-windows`, `build-android` (matrix × 2).
- `verify-plugin-arms` is intentionally not wired — `swift package describe` doesn't compile, and four `SWIFT_ROS2_TARGET_OS` flips would thrash the cache.
- `DISABLE_BUILD_CACHE=1` env escape hatch for bisecting cache-vs-real failures.

This is **PR 1 of 3** in the uniform CI cache series. Layer 1 (Swift toolchain) and Layer 2 (system deps: vcpkg / apt / NDK / Swift Android SDK) follow once steady-state hit-rate looks healthy.

## Expected impact
- Cold cache (first push): wall clock ≈ today (~13 min on main, ~25 min on Phase-7-style content).
- Warm cache (no source change): Windows ~12 min → ~2-3 min; Linux/Android < 1:30 each; total CI ~3-5 min.

## Test plan
- [ ] First push (cold cache): observe Caches UI populates with `swiftpm-build-*` entries.
- [ ] No-op push (warm cache): confirm cache hits in step logs and per-job times match expected impact.
- [ ] Source-change push: confirm `hashFiles` invalidates and rebuild succeeds.
- [ ] `DISABLE_BUILD_CACHE=1` smoke: confirm cache step is skipped and behavior matches today's main.