### PR TITLE
release: cut 0.9.0 — swift-ros2-gen + README/MIGRATION refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Phase 5** — `.srv` support + std_srvs regeneration (#88).
   - **Phase 6** — `.action` support + per-action wrapper synthesis (`SendGoal_Request/Response`, `GetResult_Request/Response`, `FeedbackMessage`) + Fibonacci migration (#89).
   - **Phase 7** — SwiftPM build plugin (`SwiftROS2GenPlugin`) + `PluginSmoke` example target showing how to consume regenerated bindings from a downstream package (#90).
-  - **Phase 8** — hash-oracle CI job (compares generated hashes against a recorded baseline of live `ros2 topic info --verbose` output) and `--verify-hashes` CLI flag for local pre-flight checks (#91).
+  - **Phase 8** — `verify-hash-oracle` CI job in [`hash-oracle.yml`](.github/workflows/hash-oracle.yml) that diffs generated `RIHS01_*` hashes against the canonical `share/<pkg>/{msg,srv,action}/<Type>.json` files inside an `osrf/ros:<distro>-desktop` Docker image (jazzy required, kilted / rolling continue-on-error) and a matching `--verify-hashes <docker-image>` CLI flag for local pre-flight checks (#91).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [0.9.0] - 2026-05-04
+
+### Added
+
+- **`swift-ros2-gen` — IDL → Swift code generator (8-phase rollout).** A standalone CLI (`swift run swift-ros2-gen`) that reads ROS 2 `.msg` / `.srv` / `.action` IDL and emits `ROS2Message` / `ROS2ServiceType` / `ROS2Action` Swift sources with `CDRCodable` encoders and recorded `RIHS01_*` type hashes. Single-distro and multi-distro inputs both supported; multi-distro generation merges into one source file that branches on `encoder.isLegacySchema` / `decoder.isLegacySchema` for cross-distro field differences (e.g. `sensor_msgs/Range.variance`).
+  - **Phase 1** — `swift-ros2-gen` skeleton + std_msgs migration (#84).
+  - **Phase 2** — nested type references + geometry_msgs migration (#85).
+  - **Phase 3** — fixed / variable arrays, constants, default values + UUID + action_msgs migration (#86).
+  - **Phase 4** — distro-conditional generation + sensor_msgs migration (#87).
+  - **Phase 5** — `.srv` support + std_srvs regeneration (#88).
+  - **Phase 6** — `.action` support + per-action wrapper synthesis (`SendGoal_Request/Response`, `GetResult_Request/Response`, `FeedbackMessage`) + Fibonacci migration (#89).
+  - **Phase 7** — SwiftPM build plugin (`SwiftROS2GenPlugin`) + `PluginSmoke` example target showing how to consume regenerated bindings from a downstream package (#90).
+  - **Phase 8** — hash-oracle CI job (compares generated hashes against a recorded baseline of live `ros2 topic info --verbose` output) and `--verify-hashes` CLI flag for local pre-flight checks (#91).
+
+### Changed
+
+- (intentionally empty — codegen is purely additive; no public API changed.)
+
 ## [0.8.0] - 2026-05-03
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,7 +7,8 @@
 | 0.6.0 | 0.6.1 | **One:** the placeholder `ROS2Service` protocol in `SwiftROS2Messages` was renamed to `ROS2ServiceType` so the umbrella's typed Service Server class can take the simpler `ROS2Service<S>` name in 0.7.0. |
 | 0.6.x | 0.7.x | **One** if upgrading from 0.6.0 directly: the rename above. From 0.6.1 → 0.7.x there are no breaking changes — the Services API is purely additive. |
 | 0.7.x | 0.8.0 | **None.** Actions are purely additive — `ROS2Action`, `ROS2ActionServer`, `ROS2ActionClient`, `ActionGoalHandle`, `ActionResult`, `ActionGoalStatus`, `ActionError` are new. `ROS2ActionTypeInfo` gained five optional hash fields with source-compatible defaults (Phase 1). |
-| 0.8.x | 1.0.0 | Limited to the candidates below, decided after 0.8.0 ships based on a downstream survey. |
+| 0.8.x | 0.9.0 | **None.** `swift-ros2-gen` (CLI + SwiftPM build plugin + hash-oracle CI) is purely additive — no existing public API changed. |
+| 0.9.x | 1.0.0 | Limited to the candidates below, decided after 0.9.0 ships based on the downstream survey. |
 | 1.0.x | 1.x   | **None guaranteed.** Minor releases on the 1.x line will not break public API. |
 
 SwiftROS2 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once 1.0.0 is cut. Breaking changes after 1.0 require a major bump.
@@ -80,9 +81,41 @@ The umbrella exposes ``ActionGoalStatus`` (an `Int8`-backed enum) for the status
 
 ---
 
-## 0.8 → 1.0 — candidate change list
+## 0.8 → 0.9 — `swift-ros2-gen`
 
-> **Status:** the actual 1.0 break list is decided **after 0.7.0 ships**, based on a downstream-consumer survey (Conduit and any other known users). Each candidate below describes what *might* change, why it is being considered, and the recommended action you can take during 0.7.x to avoid surprise.
+0.9.0 ships the `swift-ros2-gen` code generator end-to-end: CLI, multi-distro merging, `.msg` / `.srv` / `.action` support, a SwiftPM build plugin, and a hash-oracle CI job. Every change is additive — no existing public symbol was renamed, removed, or had its shape changed.
+
+### Adding code generation to a downstream Apple project
+
+```swift
+// Package.swift — opt the target into the SwiftROS2Gen build plugin
+.target(
+    name: "MyMessages",
+    dependencies: [
+        .product(name: "SwiftROS2", package: "swift-ros2"),
+    ],
+    plugins: [
+        .plugin(name: "SwiftROS2GenPlugin", package: "swift-ros2"),
+    ]
+),
+```
+
+Drop a `swift-ros2-gen.yml` configuration file at the root of the target's directory listing the `.msg` / `.srv` / `.action` files (or whole package directories) to consume. The plugin runs `swift-ros2-gen` per build, writes generated sources into `.build/plugins/outputs/...`, and SwiftPM picks them up automatically. See `Examples/PluginSmoke/` for a working reference.
+
+### Verifying type hashes against a live ROS 2 install
+
+```bash
+swift run swift-ros2-gen --verify-hashes \
+    --input "sensor_msgs=/opt/ros/jazzy/share/sensor_msgs@jazzy"
+```
+
+Compares the regenerated `RIHS01_*` hashes against the hash baseline shipped with the package. The matching CI job (`gen-hash-oracle`) runs on every PR.
+
+---
+
+## 0.9 → 1.0 — candidate change list
+
+> **Status:** the actual 1.0 break list is decided **after 0.9.0 ships**, based on a downstream-consumer survey (Conduit and any other known users). Each candidate below describes what *might* change, why it is being considered, and the recommended action you can take during 0.9.x to avoid surprise.
 
 ### Candidate 1 — `TransportQoS` and `QoSPolicy`
 
@@ -149,15 +182,9 @@ The umbrella exposes ``ActionGoalStatus`` (an `Int8`-backed enum) for the status
 - **Recommended action:** drop direct references.
 - **Compatibility shim?** None planned.
 
-### Candidate 7 — Action public declarations with no implementation
+### Candidate 7 — Action public declarations with no implementation *(obsolete since 0.8.0)*
 
-- **Targets:** `ROS2ActionTypeInfo`, `ROS2Action` in `SwiftROS2Messages`.
-- **1.0 plan:** remove (or make `internal`).
-- **Rationale:** placeholders with no implementation. Freezing them would constrain the eventual Action API design.
-- **Replacement:** none (the feature is not provided today).
-- **Impact surface:** code that names these types or conforms to them.
-- **Recommended action:** remove any references — they do not do anything yet.
-- **Compatibility shim?** None.
+The 0.7.0 plan had assumed `ROS2ActionTypeInfo` and `ROS2Action` in `SwiftROS2Messages` would either be removed or made `internal` for 1.0. Both are now real, fully-implemented protocols backing the `ROS2ActionServer<H>` / `ROS2ActionClient<A>` umbrella that shipped in 0.8.0 (#77–#82). They will remain `public` in 1.0.0 — no action required from downstream code.
 
 > **Note:** the analogous Service placeholders (`ROS2ServiceTypeInfo`, `ROS2ServiceType`) were retained in 0.7.0 once the typed `ROS2Service<S>` / `ROS2Client<S>` umbrella landed — they are now real, implemented protocols, not placeholders.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -83,14 +83,14 @@ The umbrella exposes ``ActionGoalStatus`` (an `Int8`-backed enum) for the status
 
 ## 0.8 → 0.9 — `swift-ros2-gen`
 
-0.9.0 ships the `swift-ros2-gen` code generator end-to-end: CLI, multi-distro merging, `.msg` / `.srv` / `.action` support, a SwiftPM build plugin, and a hash-oracle CI job. Every change is additive — no existing public symbol was renamed, removed, or had its shape changed.
+0.9.0 ships the `swift-ros2-gen` code generator end-to-end: CLI (with `.msg` / `.srv` / `.action` support and multi-distro merging), a single-distro `.msg`-only SwiftPM build plugin, and a `verify-hash-oracle` CI job. Every change is additive — no existing public symbol was renamed, removed, or had its shape changed.
 
 ### Adding code generation to a downstream Apple project
 
 ```swift
 // Package.swift — opt the target into the SwiftROS2Gen build plugin
 .target(
-    name: "MyMessages",
+    name: "my_msgs",  // snake_case / lowercase — becomes the ROS package segment in typeInfo.typeName
     dependencies: [
         .product(name: "SwiftROS2", package: "swift-ros2"),
     ],
@@ -100,16 +100,23 @@ The umbrella exposes ``ActionGoalStatus`` (an `Int8`-backed enum) for the status
 ),
 ```
 
-Drop a `swift-ros2-gen.yml` configuration file at the root of the target's directory listing the `.msg` / `.srv` / `.action` files (or whole package directories) to consume. The plugin runs `swift-ros2-gen` per build, writes generated sources into `.build/plugins/outputs/...`, and SwiftPM picks them up automatically. See `Examples/PluginSmoke/` for a working reference.
+There is no configuration file. Drop the `.msg` files into the target's directory under `msg/` and build — the plugin walks `msg/` directly, hands every file to `swift-ros2-gen` with `<target-name>=<dir>@jazzy`, and writes the generated Swift under SwiftPM's per-target work directory.
+
+The plugin handles only the single-package single-distro (jazzy) `.msg` case. `.srv` and `.action` files in the target directory are skipped with a build warning. For multi-distro merging, multi-package builds, `.srv`, `.action`, or an explicit `--types` allow-list, invoke `swift run swift-ros2-gen` directly. A working setup lives at [`Sources/Examples/PluginSmoke/`](Sources/Examples/PluginSmoke).
 
 ### Verifying type hashes against a live ROS 2 install
 
+`--verify-hashes` takes a Docker image as its argument value (the verifier shells into the image and reads canonical `share/<pkg>/{msg,srv,action}/<Type>.json` files). The verifier resolves nested-type references, so every transitively-referenced package must appear on `--input`:
+
 ```bash
-swift run swift-ros2-gen --verify-hashes \
-    --input "sensor_msgs=/opt/ros/jazzy/share/sensor_msgs@jazzy"
+swift run swift-ros2-gen --verify-hashes osrf/ros:jazzy-desktop \
+    --input "builtin_interfaces=vendor/rcl_interfaces-jazzy/builtin_interfaces@jazzy" \
+    --input "std_msgs=vendor/common_interfaces-jazzy/std_msgs@jazzy" \
+    --input "geometry_msgs=vendor/common_interfaces-jazzy/geometry_msgs@jazzy" \
+    --input "sensor_msgs=vendor/common_interfaces-jazzy/sensor_msgs@jazzy"
 ```
 
-Compares the regenerated `RIHS01_*` hashes against the hash baseline shipped with the package. The matching CI job (`gen-hash-oracle`) runs on every PR.
+Diffs each generated `RIHS01_*` against the canonical rosidl JSON inside the named Docker image — there is no recorded baseline shipped in the package. The matching CI job is `verify-hash-oracle` in [`hash-oracle.yml`](.github/workflows/hash-oracle.yml); it is path-filtered on pull requests (only fires when generator / generated-source / vendored-IDL paths change) and unconditionally on `main` pushes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ public struct MyMsg: ROS2Message {
 }
 ```
 
-As of 0.9.0 the [`swift-ros2-gen`](#generate-swift-bindings-from-idl) code generator is the recommended way to produce these conformances — hand-written conformances like the example above become optional. The generator emits the same shape from `.msg` / `.srv` / `.action` files automatically and records `RIHS01_*` type hashes from a live ROS 2 install.
+As of 0.9.0 the [`swift-ros2-gen`](#generate-swift-bindings-from-idl) code generator is the recommended way to produce these conformances — hand-written conformances like the example above become optional. The generator emits the same shape from `.msg` / `.srv` / `.action` files automatically; `RIHS01_*` type hashes are computed in-process from the parsed IDL, then optionally cross-checked against a live ROS 2 install via `--verify-hashes`.
 
 ## Generate Swift bindings from IDL
 
@@ -288,11 +288,15 @@ As of 0.9.0 the [`swift-ros2-gen`](#generate-swift-bindings-from-idl) code gener
 
 ### One-shot CLI
 
+`sensor_msgs` types reference `std_msgs/Header`, `builtin_interfaces/Time`, and several `geometry_msgs` types — pass every transitively-referenced package on `--input` so nested-type resolution succeeds:
+
 ```bash
 swift run swift-ros2-gen \
-    --input "std_msgs=Vendor/common_interfaces-jazzy/std_msgs@jazzy" \
-    --input "sensor_msgs=Vendor/common_interfaces-humble/sensor_msgs@humble" \
-    --input "sensor_msgs=Vendor/common_interfaces-jazzy/sensor_msgs@jazzy" \
+    --input "builtin_interfaces=vendor/rcl_interfaces-jazzy/builtin_interfaces@jazzy" \
+    --input "std_msgs=vendor/common_interfaces-jazzy/std_msgs@jazzy" \
+    --input "geometry_msgs=vendor/common_interfaces-jazzy/geometry_msgs@jazzy" \
+    --input "sensor_msgs=vendor/common_interfaces-humble/sensor_msgs@humble" \
+    --input "sensor_msgs=vendor/common_interfaces-jazzy/sensor_msgs@jazzy" \
     --output Sources/MyMessages/Generated
 ```
 
@@ -314,17 +318,20 @@ For projects that want generated bindings to stay in sync with their IDL on ever
 )
 ```
 
-Drop the IDL into the target's directory under `msg/`, then build. The plugin uses the SwiftPM target name as the ROS package segment in the generated `typeInfo.typeName`, so the target name should match the intended ROS 2 package name (snake_case / lowercase) — `my_msgs`, not `MyMsgs`.
+Drop the IDL into the target's directory under `msg/`, then build. There is no configuration file — the plugin walks `msg/` directly, hands every `.msg` to `swift-ros2-gen` with `<target-name>=<dir>@jazzy`, and writes the output under SwiftPM's per-target work directory. The target name becomes the ROS package segment in the generated `typeInfo.typeName`, so name the target snake_case / lowercase — `my_msgs`, not `MyMsgs`.
 
-The plugin handles the single-package single-distro (jazzy) case. For multi-distro merging, multi-package builds, `.srv`, `.action`, or an explicit `--types` allow-list, invoke `swift run swift-ros2-gen` directly (see [`CLAUDE.md`](CLAUDE.md) for the full CLI grammar). See `Examples/PluginSmoke/` in this repo for a working setup.
+The plugin handles the single-package single-distro (jazzy) `.msg` case only. `.srv` and `.action` files in the target directory are skipped with a build warning. For multi-distro merging, multi-package builds, `.srv`, `.action`, or an explicit `--types` allow-list, invoke `swift run swift-ros2-gen` directly (`--help` lists every flag). A working setup lives at [`Sources/Examples/PluginSmoke/`](Sources/Examples/PluginSmoke).
 
 ### Verifying generated hashes against live ROS 2
 
-The repo ships a hash-oracle CI job that catches drift between the generated `RIHS01_*` type hashes and the actual hashes a running ROS 2 install reports. Reproduce locally with:
+The repo ships a hash-oracle CI job ([`.github/workflows/hash-oracle.yml`](.github/workflows/hash-oracle.yml), `verify-hash-oracle`, path-filtered to fire only when generator / generated-source / vendored-IDL paths change). It diffs each generated `RIHS01_*` against the canonical `share/<pkg>/{msg,srv,action}/<Type>.json` files inside an `osrf/ros:<distro>-desktop` Docker image — there is no recorded baseline shipped in the package; the oracle is the live image. Reproduce locally with the same command CI runs (`--verify-hashes` takes a Docker image as its value, and the verifier resolves nested-type references, so every transitively-referenced package must appear on `--input`):
 
 ```bash
-swift run swift-ros2-gen --verify-hashes \
-    --input "sensor_msgs=/opt/ros/jazzy/share/sensor_msgs@jazzy"
+swift run swift-ros2-gen --verify-hashes osrf/ros:jazzy-desktop \
+    --input "builtin_interfaces=vendor/rcl_interfaces-jazzy/builtin_interfaces@jazzy" \
+    --input "std_msgs=vendor/common_interfaces-jazzy/std_msgs@jazzy" \
+    --input "geometry_msgs=vendor/common_interfaces-jazzy/geometry_msgs@jazzy" \
+    --input "sensor_msgs=vendor/common_interfaces-jazzy/sensor_msgs@jazzy"
 ```
 
 ## Versioning
@@ -339,7 +346,7 @@ Each release has a corresponding [GitHub release](https://github.com/youtalk/swi
 
 | Tag        | Date       | Headline                                                                                              |
 |------------|------------|-------------------------------------------------------------------------------------------------------|
-| **0.9.0**  | 2026-05-04 | **`swift-ros2-gen`** — IDL → Swift code generator (CLI + SwiftPM build plugin) covering `.msg` / `.srv` / `.action`, multi-distro merging with `isLegacySchema` branches, and a hash-oracle CI job that pins `RIHS01_*` hashes against a recorded baseline. 8 PR rollout (Phase 1–8). |
+| **0.9.0**  | 2026-05-04 | **`swift-ros2-gen`** — IDL → Swift code generator (CLI + SwiftPM build plugin) covering `.msg` / `.srv` / `.action`, multi-distro merging with `isLegacySchema` branches, and a `verify-hash-oracle` CI job that diffs generated `RIHS01_*` hashes against the canonical `share/<pkg>/{msg,srv,action}/<Type>.json` files inside an `osrf/ros:<distro>-desktop` Docker image. 8 PR rollout (Phase 1–8). |
 | 0.8.0      | 2026-05-03 | **Actions + DDS on Windows** — typed `ROS2ActionServer<H>` / `ROS2ActionClient<A>` with `async`/`await`, feedback `AsyncStream`, status updates, cancellation; built-in `example_interfaces/action/Fibonacci`; full DDS path on Windows x86_64 via vcpkg (`CYCLONEDDS_DIR`). 6 PR rollout for Actions. |
 | 0.7.0      | 2026-05-01 | **Services** — typed `ROS2Service<S>` / `ROS2Client<S>` over both Zenoh (queryable + `get`) and DDS (rq/rr topics + sample-identity prefix); built-in `std_srvs/srv/Trigger`; DocC catalog with getting-started articles; CI `docs-build` job; per-target line-coverage gate. |
 | 0.6.0      | 2026-04-24 | **Android support** — arm64-v8a + x86_64 via the Swift 6.3.1 Android SDK; `zenoh-pico` source build with `ZENOH_ANDROID` (Bionic unix backend, vendored `pthread_cancel` / `_z_task_cancel` stubs); `SWIFT_ROS2_TARGET_OS` env override required for any cross-compile (allow-list-validated, fails the manifest compile on typos); `build-android` matrix (×2 ABIs) added to CI on `ubuntu-24.04` with NDK r27c. Zenoh only — DDS-on-Android tracked as future work. |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Native Swift client library for ROS 2. Publish and subscribe to ROS 2 topics ove
 
 > The four CI badges above all reflect the same `ci.yml` workflow status (GitHub Actions does not expose per-matrix-job badges). Each label is the OS family that workflow exercises — when the badges are green, every Apple / Linux / Windows / Android matrix entry passed.
 
-Shipping as **0.6.0** — Apple xcframeworks (iOS / iPadOS / macOS / Mac Catalyst / visionOS), `zenoh-pico` source build on Linux / Windows / Android.
+Shipping as **0.9.0** — Apple xcframeworks (iOS / iPadOS / macOS / Mac Catalyst / visionOS), `zenoh-pico` source build on Linux / Windows / Android, `swift-ros2-gen` IDL → Swift code generator + SwiftPM build plugin.
 
 ## Why
 
@@ -30,6 +30,8 @@ Bringing ROS 2 to a phone, headset, or laptop usually means cross-compiling `rcl
 - **Multi-distro wire format.** Humble, Jazzy, Kilted, Rolling. Select via `ROS2Distro` on `ROS2Context`; Zenoh defaults to Jazzy when unspecified. Schema differences (e.g. `sensor_msgs/Range` gaining `variance` after Humble) are gated automatically through `isLegacySchema`.
 - **23 built-in message types** spanning `sensor_msgs`, `geometry_msgs`, `std_msgs`, `audio_common_msgs`, and `tf2_msgs`. Pure-Swift XCDR v1 encoder + decoder cover both the publish and subscribe paths.
 - **Services** (Server / Client) — `rclcpp` / `rclpy`-shaped API with full Humble / Jazzy / Kilted / Rolling reach over Zenoh and DDS.
+- **Actions** (Server / Client) — typed `ROS2ActionServer<H>` / `ROS2ActionClient<A>` with goal handles, feedback `AsyncStream`, status updates, and cancellation. Built-in `example_interfaces/action/Fibonacci`. `async`/`await` everywhere, no callback shims.
+- **Code generation from `.msg` / `.srv` / `.action` IDL.** `swift-ros2-gen` CLI + SwiftPM build plugin emit `ROS2Message` / `ROS2ServiceType` / `ROS2Action` Swift conformances. Multi-distro merging branches on `isLegacySchema` for cross-distro field differences (e.g. `sensor_msgs/Range.variance`). Hash-oracle CI catches drift against live ROS 2.
 - **Production-proven.** Extracted from [Conduit, powered by ROS](https://apps.apple.com/app/id6757171237) — used cumulatively by **10,000+ ROS developers worldwide** and a former **#4 in the App Store's Developer Tools category**. Conduit streams 12 sensor topics from iOS / iPadOS / macOS / visionOS at up to 100 Hz over the same swift-ros2 publish path documented below.
 
 ## Platforms
@@ -68,7 +70,7 @@ In practice this means almost every consumer device that someone might want to a
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.6.0"),
+    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.9.0"),
 ],
 targets: [
     .target(
@@ -114,7 +116,7 @@ $env:Path = "$env:CYCLONEDDS_DIR\bin;$env:Path"
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.8.0"),
+    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.9.0"),
 ],
 targets: [
     .target(
@@ -278,13 +280,27 @@ public struct MyMsg: ROS2Message {
 }
 ```
 
-When the planned [`swift-ros2-gen`](#roadmap) code generator lands, hand-written conformances like this become optional — the generator will emit the same shape from `.msg` files automatically.
+As of 0.9.0 the [`swift-ros2-gen`](#generate-swift-bindings-from-idl) code generator is the recommended way to produce these conformances — hand-written conformances like the example above become optional. The generator emits the same shape from `.msg` / `.srv` / `.action` files automatically and records `RIHS01_*` type hashes from a live ROS 2 install.
 
-### Build plugin (SwiftPM)
+## Generate Swift bindings from IDL
 
-Phase 7 introduced `SwiftROS2GenPlugin`, a SwiftPM build-tool plugin that
-generates Swift wrappers for ROS 2 `.msg` files at build time. Drop the IDL
-into your target's directory under `msg/` and add the plugin to the target:
+`swift-ros2-gen` reads ROS 2 `.msg` / `.srv` / `.action` IDL files and emits Swift sources that conform to `ROS2Message` / `ROS2ServiceType` / `ROS2Action`. The generator handles fixed and variable arrays, constants, default values, nested type references, and merges multi-distro inputs into a single Swift source that branches on `isLegacySchema` for fields that differ between Humble and Jazzy+.
+
+### One-shot CLI
+
+```bash
+swift run swift-ros2-gen \
+    --input "std_msgs=Vendor/common_interfaces-jazzy/std_msgs@jazzy" \
+    --input "sensor_msgs=Vendor/common_interfaces-humble/sensor_msgs@humble" \
+    --input "sensor_msgs=Vendor/common_interfaces-jazzy/sensor_msgs@jazzy" \
+    --output Sources/MyMessages/Generated
+```
+
+Pass one `--input <pkg>=<path>@<distro>` per (package, distro) pair. The generator walks `msg/`, `srv/`, and `action/` subdirectories of each package automatically.
+
+### SwiftPM build plugin
+
+For projects that want generated bindings to stay in sync with their IDL on every build, opt the target into the `SwiftROS2GenPlugin`:
 
 ```swift
 .target(
@@ -298,20 +314,24 @@ into your target's directory under `msg/` and add the plugin to the target:
 )
 ```
 
-The plugin uses the SwiftPM target name as the ROS package segment in the
-generated `typeInfo.typeName`, so the target name should match the intended
-ROS 2 package name (snake_case / lowercase) — `my_msgs`, not `MyMsgs`.
+Drop the IDL into the target's directory under `msg/`, then build. The plugin uses the SwiftPM target name as the ROS package segment in the generated `typeInfo.typeName`, so the target name should match the intended ROS 2 package name (snake_case / lowercase) — `my_msgs`, not `MyMsgs`.
 
-The plugin handles the single-package single-distro (jazzy) case. For
-multi-distro merging, multi-package builds, `.srv`, `.action`, or an
-explicit `--types` allow-list, invoke `swift run swift-ros2-gen` directly
-(see [`CLAUDE.md`](CLAUDE.md) for the full CLI grammar).
+The plugin handles the single-package single-distro (jazzy) case. For multi-distro merging, multi-package builds, `.srv`, `.action`, or an explicit `--types` allow-list, invoke `swift run swift-ros2-gen` directly (see [`CLAUDE.md`](CLAUDE.md) for the full CLI grammar). See `Examples/PluginSmoke/` in this repo for a working setup.
+
+### Verifying generated hashes against live ROS 2
+
+The repo ships a hash-oracle CI job that catches drift between the generated `RIHS01_*` type hashes and the actual hashes a running ROS 2 install reports. Reproduce locally with:
+
+```bash
+swift run swift-ros2-gen --verify-hashes \
+    --input "sensor_msgs=/opt/ros/jazzy/share/sensor_msgs@jazzy"
+```
 
 ## Versioning
 
 Tags follow Apple-ecosystem bare semver (no `v` prefix): `0.2.0`, `1.0.0-rc.1`, etc. The [release workflow](.github/workflows/release-xcframework.yml) fires on any tag matching `[0-9]*.[0-9]*.[0-9]*` (optionally `-qualifier`), builds both xcframeworks for all six Apple slices (`iphoneos`, `iphonesimulator`, `macosx`, `maccatalyst`, `xros`, `xrsimulator`), and attaches them + `.checksum` files to the GitHub release named after the tag.
 
-The `0.x` series is pre-1.0 by design — breaking API changes are allowed between minor versions while the public surface stabilizes around the upcoming Services / Actions / `swift-ros2-gen` work (see [Roadmap](#roadmap)). 1.0.0 is gated on those landing.
+The `0.x` series was pre-1.0 by design — breaking API changes were allowed between minor versions while the public surface stabilized around Services (0.7.0), Actions (0.8.0), and `swift-ros2-gen` (0.9.0). With those milestones landed, 1.0.0 will freeze the public API surface; subsequent 1.x releases follow standard SemVer.
 
 ## Release history
 
@@ -319,7 +339,10 @@ Each release has a corresponding [GitHub release](https://github.com/youtalk/swi
 
 | Tag        | Date       | Headline                                                                                              |
 |------------|------------|-------------------------------------------------------------------------------------------------------|
-| **0.6.0**  | 2026-04-24 | **Android support** — arm64-v8a + x86_64 via the Swift 6.3.1 Android SDK; `zenoh-pico` source build with `ZENOH_ANDROID` (Bionic unix backend, vendored `pthread_cancel` / `_z_task_cancel` stubs); `SWIFT_ROS2_TARGET_OS` env override required for any cross-compile (allow-list-validated, fails the manifest compile on typos); `build-android` matrix (×2 ABIs) added to CI on `ubuntu-24.04` with NDK r27c. Zenoh only — DDS-on-Android tracked as future work. |
+| **0.9.0**  | 2026-05-04 | **`swift-ros2-gen`** — IDL → Swift code generator (CLI + SwiftPM build plugin) covering `.msg` / `.srv` / `.action`, multi-distro merging with `isLegacySchema` branches, and a hash-oracle CI job that pins `RIHS01_*` hashes against a recorded baseline. 8 PR rollout (Phase 1–8). |
+| 0.8.0      | 2026-05-03 | **Actions + DDS on Windows** — typed `ROS2ActionServer<H>` / `ROS2ActionClient<A>` with `async`/`await`, feedback `AsyncStream`, status updates, cancellation; built-in `example_interfaces/action/Fibonacci`; full DDS path on Windows x86_64 via vcpkg (`CYCLONEDDS_DIR`). 6 PR rollout for Actions. |
+| 0.7.0      | 2026-05-01 | **Services** — typed `ROS2Service<S>` / `ROS2Client<S>` over both Zenoh (queryable + `get`) and DDS (rq/rr topics + sample-identity prefix); built-in `std_srvs/srv/Trigger`; DocC catalog with getting-started articles; CI `docs-build` job; per-target line-coverage gate. |
+| 0.6.0      | 2026-04-24 | **Android support** — arm64-v8a + x86_64 via the Swift 6.3.1 Android SDK; `zenoh-pico` source build with `ZENOH_ANDROID` (Bionic unix backend, vendored `pthread_cancel` / `_z_task_cancel` stubs); `SWIFT_ROS2_TARGET_OS` env override required for any cross-compile (allow-list-validated, fails the manifest compile on typos); `build-android` matrix (×2 ABIs) added to CI on `ubuntu-24.04` with NDK r27c. Zenoh only — DDS-on-Android tracked as future work. |
 | 0.5.0      | 2026-04-24 | **Windows x86_64 support** — three-arm `Package.swift` platform split, `zenoh-pico` source build with `ZENOH_WINDOWS` and Winsock + Iphlpapi linkage, `build-windows` job on `windows-latest` (Swift 6.3.1). Zenoh only.                                                                                              |
 | 0.4.0      | 2026-04-20 | **DDS subscriber** — `raw_cdr_serdata_from_ser` fragchain walk in `CDDSBridge`, `bridge_dds_reader_t` + listener callback, `DDSReaderHandle` / `createRawReader` / `destroyReader` on `DDSClientProtocol`, `DDSTransportSession.createSubscriber` wired through; `swift run listener dds` enabled. Minimal `talker` / `listener` example executables added. |
 | 0.3.1      | 2026-04-19 | **Hardened CDR decoder** — bounds-checks untrusted sequence + string lengths before `reserveCapacity`; fails fast on malformed null-terminated strings instead of silently dropping bytes. |
@@ -332,10 +355,9 @@ Past releases shipped roughly one breaking platform / transport / API change per
 
 ### Near-term (the 1.0.0 gate)
 
-- **`swift-ros2-gen`** — code generator that takes `.msg` / `.srv` / `.action` files and emits `ROS2Message` / `ROS2Service` / `ROS2Action` Swift conformances. Goal: drop the hand-written `encode(to:)` / `init(from:)` ceremony required for every custom type today, and bring the catalog of built-in messages closer to what `rclcpp` ships out of the box.
-- **Services (request / reply)** — Zenoh: composed over `z_query_*` queryables. DDS: composed over the request-reply pattern in CycloneDDS. Public API will mirror `rcl`'s shape (`createService(_:type:handler:)` / `createClient(_:type:).call(_:)`). Additive — won't break the existing publisher / subscription API.
-- **Actions (goal / feedback / result)** — composed Services + Topics, mirroring `rcl_action`. Depends on Services landing first.
-- **Expanded message catalog** — `nav_msgs`, `visualization_msgs`, `diagnostic_msgs`, more of `geometry_msgs`. Hand-rolled until `swift-ros2-gen` ships, generated after.
+The headline 1.0.0 work — Services (0.7.0), Actions (0.8.0), and `swift-ros2-gen` (0.9.0) — has all landed. The 1.0.0 cut itself is a public-API freeze: plumbing types currently exposed (`TransportQoS`, `QoSPolicy`, `DDSBridge*`, `ZenohClientProtocol` / `DDSClientProtocol` and related handle types, `EntityManager` / `GIDManager`, `ZenohTransportPublisher`, `DeclaredKeyExpr` / `ZenohSubscriber` / `LivelinessToken`) get pulled out of the public surface. End-user APIs (`ROS2Context`, `ROS2Node`, `ROS2Publisher`, `ROS2Subscription`, `ROS2Service`, `ROS2Client`, `ROS2ActionServer`, `ROS2ActionClient`, `QoSProfile`, `TransportConfig`, all message / service / action types) are unchanged. See [`MIGRATION.md`](MIGRATION.md) for the full candidate list.
+
+- **Expanded message catalog** — `nav_msgs`, `visualization_msgs`, `diagnostic_msgs`, more of `geometry_msgs`. Now generated via `swift-ros2-gen` rather than hand-rolled.
 
 ### Medium-term
 


### PR DESCRIPTION
## Summary

- Promotes the merged-but-unreleased `swift-ros2-gen` Phase 1–8 work into a tagged 0.9.0 feature release.
- Refreshes README from its stale 0.6.0 wording — bumps shipping/install version, adds a top-level **Generate Swift bindings from IDL** section (CLI + SwiftPM build plugin + hash-oracle), audits Features / Platforms / Release history / Roadmap to reflect Services (0.7.0), Actions (0.8.0), DDS-on-Windows-via-vcpkg (0.8.0), Android, and codegen (0.9.0).
- Adds 0.8 → 0.9 entry to MIGRATION; renames the long-form `0.8 → 1.0` candidate section to `0.9 → 1.0` and marks Candidate 7 (Action placeholders) obsolete now that Actions are real.

## Test plan
- [x] `swift format lint --recursive --strict --configuration .swift-format Package.swift Sources Tests`
- [x] `swift build`
- [x] `swift test --parallel`
- [ ] CI green on every matrix entry.