### PR TITLE
ci+docs: enforce link-only invariant on CZenohPico / CCycloneDDS (#26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,30 @@ jobs:
       - name: Lint
         run: swift format lint --recursive --strict --configuration .swift-format Package.swift Sources Tests
 
+  lint-link-only-imports:
+    name: Lint (link-only C targets — never import from Swift)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reject `import CZenohPico` / `import CCycloneDDS`
+        # CZenohPico and CCycloneDDS are link-only binary targets — they
+        # are consumed at the C level by CZenohBridge / CDDSBridge with
+        # platform-specific cSettings defines applied. On Apple, the
+        # `.xcframework`'s auto-synthesised modulemap means a stray
+        # `import CZenohPico` in Swift compiles silently; on Linux the
+        # source-build path has no synthesised modulemap, so the same
+        # import would fail there. Catch it at lint time across all
+        # platforms instead of letting one CI matrix entry fail
+        # confusingly. See https://github.com/youtalk/swift-ros2/issues/26.
+        run: |
+          set -euo pipefail
+          if grep -rEn '^import C(ZenohPico|CycloneDDS)\b' Sources Tests; then
+            echo
+            echo "::error::Found a Swift `import` of a link-only C target above."
+            echo "::error::Use `import SwiftROS2Zenoh` / `import SwiftROS2DDS` to reach the bridges."
+            exit 1
+          fi
+
   build-macos:
     name: Build & Test (macOS)
     needs: [lint-swift-format]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,13 @@ jobs:
         # import would fail there. Catch it at lint time across all
         # platforms instead of letting one CI matrix entry fail
         # confusingly. See https://github.com/youtalk/swift-ros2/issues/26.
+        #
+        # Pattern uses `grep -P` (PCRE) rather than `grep -E` so `\b`
+        # is the well-defined word-boundary it looks like, not the
+        # POSIX-ERE backspace escape (a GNU extension at best).
         run: |
           set -euo pipefail
-          if grep -rEn '^import C(ZenohPico|CycloneDDS)\b' Sources Tests; then
+          if grep -rPn '^import C(ZenohPico|CycloneDDS)\b' Sources Tests; then
             echo
             echo "::error::Found a Swift `import` of a link-only C target above."
             echo "::error::Use `import SwiftROS2Zenoh` / `import SwiftROS2DDS` to reach the bridges."

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ import SwiftROS2DDS        — DDSClient (CycloneDDS FFI through CDDSBridge)
 
 The architecture is documented in more detail under [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
-> **Link-only C targets.** `CZenohPico` and `CCycloneDDS` are link-only binary targets — they are consumed at the C level by `CZenohBridge` / `CDDSBridge` (with platform-specific preprocessor defines applied through `cSettings`) and **never `import`ed from Swift directly**. On Apple, `.xcframework`'s auto-synthesised modulemap means `import CZenohPico` happens to compile silently — but the equivalent on a future Linux `.artifactbundle` would not, so a CI lint guards against any `^import C(ZenohPico|CycloneDDS)\b` from leaking in. Reach the C bridges via `import SwiftROS2Zenoh` / `import SwiftROS2DDS`.
+> **Link-only C targets.** `CZenohPico` and `CCycloneDDS` are link-only binary targets — they are consumed at the C level by `CZenohBridge` / `CDDSBridge` (with platform-specific preprocessor defines applied through `cSettings`) and **never `import`ed from Swift directly**. On Apple, `.xcframework`'s auto-synthesised modulemap means `import CZenohPico` happens to compile silently — but the equivalent on a future Linux `.artifactbundle` would not, so a CI lint (`grep -P '^import C(ZenohPico|CycloneDDS)\b'` over `Sources` and `Tests`) guards against any such import from leaking in. Reach the C bridges via `import SwiftROS2Zenoh` / `import SwiftROS2DDS`.
 
 ### Built-in message types
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ import SwiftROS2DDS        — DDSClient (CycloneDDS FFI through CDDSBridge)
 
 The architecture is documented in more detail under [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
+> **Link-only C targets.** `CZenohPico` and `CCycloneDDS` are link-only binary targets — they are consumed at the C level by `CZenohBridge` / `CDDSBridge` (with platform-specific preprocessor defines applied through `cSettings`) and **never `import`ed from Swift directly**. On Apple, `.xcframework`'s auto-synthesised modulemap means `import CZenohPico` happens to compile silently — but the equivalent on a future Linux `.artifactbundle` would not, so a CI lint guards against any `^import C(ZenohPico|CycloneDDS)\b` from leaking in. Reach the C bridges via `import SwiftROS2Zenoh` / `import SwiftROS2DDS`.
+
 ### Built-in message types
 
 - **`sensor_msgs`** (13) — `BatteryState`, `CameraInfo`, `CompressedImage`, `FluidPressure`, `Illuminance`, `Image`, `Imu`, `Joy`, `MagneticField`, `NavSatFix`, `PointCloud2`, `Range`, `Temperature`


### PR DESCRIPTION
Closes #26.

## Summary

`CZenohPico` and `CCycloneDDS` are link-only binary targets — consumed at the C level by `CZenohBridge` / `CDDSBridge` with platform-specific `cSettings` defines applied — and **never `import`ed from Swift directly**.

On Apple, `.xcframework`'s auto-synthesised modulemap means a stray `import CZenohPico` in Swift compiles silently. On the source-build path (Linux / Windows / Android) there is no synthesised modulemap, so the same import would fail there. This PR catches it at lint time across all platforms instead of letting one CI matrix entry fail confusingly later.

## Changes

- New `lint-link-only-imports` CI job greps `Sources/` and `Tests/` for `^import C(ZenohPico|CycloneDDS)\b` and fails loudly on a hit. Currently passes (zero matches across the codebase — invariant already holds).
- `README.md` Module layout section gains a callout block documenting the invariant and pointing readers at `SwiftROS2Zenoh` / `SwiftROS2DDS` as the supported way to reach the C bridges.

## Test plan
- [x] `swift format lint --recursive --strict --configuration .swift-format Package.swift Sources Tests` — clean.
- [x] Local smoke test on the lint script:
  - Against current `Sources/` + `Tests/`: passes (0 matches).
  - Against a synthetic `import CZenohPico` file: correctly flags it and exits 1.
- [ ] CI green on every matrix entry.