### PR TITLE
feat(api)!: 1.0.0 — internalize Candidates 1–6 (API freeze)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,10 @@ All six are visibility demotions out of the public API surface — downstream co
 
 - **`TransportQoS` and `QoSPolicy` → `package`** (Candidate 1). Use `QoSProfile(reliability:, durability:, history:)` or one of the presets (`.sensorData`, `.reliableSensor`, `.latched`, `.servicesDefault`, `.actionDefault`).
 - **`DDSBridgeQoSConfig`, `DDSBridgeDiscoveryConfig`, `DDSBridgeDiscoveryMode` → `package`** (Candidate 2). Configure DDS via `TransportConfig.ddsMulticast(...)` / `TransportConfig.ddsUnicast(...)`.
-- **`ZenohClientProtocol`, `DDSClientProtocol`, and 10 related types → `package`** (Candidate 3): `ZenohKeyExprHandle`, `ZenohSubscriberHandle`, `ZenohLivelinessTokenHandle`, `ZenohQueryableHandle`, `ZenohQueryHandle`, `ZenohSample`, `ZenohError`, `DDSWriterHandle`, `DDSReaderHandle`, `DDSError`. Use the stock `ZenohClient()` / `DDSClient()` — both remain `public`.
+- **`ZenohClientProtocol`, `DDSClientProtocol`, and 10 related types → `package`** (Candidate 3): `ZenohKeyExprHandle`, `ZenohSubscriberHandle`, `ZenohLivelinessTokenHandle`, `ZenohQueryableHandle`, `ZenohQueryHandle`, `ZenohSample`, `ZenohError`, `DDSWriterHandle`, `DDSReaderHandle`, `DDSError`. Use the stock `ZenohClient()` / `DDSClient()` — both remain `public` — but the implementation-injection seam itself is gone: the cross-target plumbing that referenced these protocols (`TransportSession` / `TransportPublisher` / `TransportSubscriber` / the `ROS2Context.init(... session:)` 4-arg initializer / `*TransportSession` initializers) was demoted to `package` as a knock-on. Downstream code constructs a context with `ROS2Context(transport: TransportConfig)` and uses `node.createPublisher(...)` / `createSubscription(...)` / etc. to get the umbrella's public `ROS2Publisher` / `ROS2Subscription` / etc.
 - **`EntityManager` and `GIDManager` → `package`** (Candidate 4). `ROS2Context` / `ROS2Node` manage them automatically; no external instantiation needed.
-- **`ZenohTransportPublisher` concrete class → `internal`** (Candidate 5). Hold `any TransportPublisher` (the protocol stays public).
-- **`DeclaredKeyExpr`, `ZenohSubscriber`, `LivelinessToken` → `internal`** (Candidate 6). They were always meant to be accessed via their handle protocols.
+- **`ZenohTransportPublisher` concrete class → `internal`** (Candidate 5). The `TransportPublisher` protocol it conforms to was itself demoted to `package` as part of Candidate 3's knock-on; downstream code holds the umbrella's public `ROS2Publisher` from `node.createPublisher(...)`.
+- **`DeclaredKeyExpr`, `ZenohSubscriber`, `LivelinessToken` → `internal`** (Candidate 6). They were always meant to be accessed via their handle protocols (which were themselves demoted to `package` in Candidate 3).
 
 ## [0.9.0] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.0.0] - 2026-05-05
+
+### Added
+
+- **API stability promise.** swift-ros2 1.0.0 inaugurates the SemVer 1.x line — no breaking changes will land in 1.x without a 2.0 bump. See `MIGRATION.md` for the compatibility table.
+
+### Changed
+
+- **Public surface freeze.** Six visibility-only changes pull plumbing types out of the public API. End-user types (`ROS2Context`, `ROS2Node`, `ROS2Publisher`, `ROS2Subscription`, `ROS2Service`, `ROS2Client`, `ROS2ActionServer`, `ROS2ActionClient`, `QoSProfile`, `TransportConfig`, all message and service types) are unchanged. The concrete `ZenohClient` and `DDSClient` remain public.
+
+### Removed
+
+- (none — all removals are visibility demotions, covered under "Breaking changes" below.)
+
+### Breaking changes
+
+All six are visibility demotions out of the public API surface — downstream consumers can no longer name these types from outside the package. Inside the package, Candidates 1–4 use Swift 5.9's `package` access (cross-target visibility) and Candidates 5–6 use plain `internal` (single-target).
+
+- **`TransportQoS` and `QoSPolicy` → `package`** (Candidate 1). Use `QoSProfile(reliability:, durability:, history:)` or one of the presets (`.sensorData`, `.reliableSensor`, `.latched`, `.servicesDefault`, `.actionDefault`).
+- **`DDSBridgeQoSConfig`, `DDSBridgeDiscoveryConfig`, `DDSBridgeDiscoveryMode` → `package`** (Candidate 2). Configure DDS via `TransportConfig.ddsMulticast(...)` / `TransportConfig.ddsUnicast(...)`.
+- **`ZenohClientProtocol`, `DDSClientProtocol`, and 10 related types → `package`** (Candidate 3): `ZenohKeyExprHandle`, `ZenohSubscriberHandle`, `ZenohLivelinessTokenHandle`, `ZenohQueryableHandle`, `ZenohQueryHandle`, `ZenohSample`, `ZenohError`, `DDSWriterHandle`, `DDSReaderHandle`, `DDSError`. Use the stock `ZenohClient()` / `DDSClient()` — both remain `public`.
+- **`EntityManager` and `GIDManager` → `package`** (Candidate 4). `ROS2Context` / `ROS2Node` manage them automatically; no external instantiation needed.
+- **`ZenohTransportPublisher` concrete class → `internal`** (Candidate 5). Hold `any TransportPublisher` (the protocol stays public).
+- **`DeclaredKeyExpr`, `ZenohSubscriber`, `LivelinessToken` → `internal`** (Candidate 6). They were always meant to be accessed via their handle protocols.
+
 ## [0.9.0] - 2026-05-04
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -147,10 +147,10 @@ Diffs each generated `RIHS01_*` against the canonical rosidl JSON inside the nam
 - **Related types (10):** `ZenohKeyExprHandle`, `ZenohSubscriberHandle`, `ZenohLivelinessTokenHandle`, `ZenohQueryableHandle`, `ZenohQueryHandle`, `ZenohSample`, `ZenohError`, `DDSWriterHandle`, `DDSReaderHandle`, `DDSError`.
 - **Current location:** `Sources/SwiftROS2Transport/{Zenoh,DDS}ClientProtocol.swift`.
 - **1.0 change:** demoted to `package` (Swift 5.9+ access modifier — invisible to downstream consumers, still reachable from the other targets and tests in this SPM package).
-- **Rationale:** these protocols exist so consumers can wrap the C bridge themselves and inject a custom client. In practice every known consumer uses the stock `ZenohClient()` / `DDSClient()` from `SwiftROS2Zenoh` / `SwiftROS2DDS` directly — both remain `public`. The implementation-injection seam is over-budget for the 1.0 freeze.
-- **Replacement:** stock `ZenohClient` / `DDSClient` for production use.
-- **Impact surface:** code that conforms to `ZenohClientProtocol` / `DDSClientProtocol` (custom wrappers). Grep for `: ZenohClientProtocol\|: DDSClientProtocol`.
-- **Recommended action:** drop the custom conformance and use the stock `ZenohClient` / `DDSClient`.
+- **Rationale:** these protocols exist so consumers can wrap the C bridge themselves and inject a custom client. In practice every known consumer uses the stock `ZenohClient()` / `DDSClient()` from `SwiftROS2Zenoh` / `SwiftROS2DDS` directly — both remain `public`. The implementation-injection seam is over-budget for the 1.0 freeze. As a knock-on effect, the cross-target plumbing that referenced these protocol types — `TransportSession` / `TransportPublisher` / `TransportSubscriber`, the `ROS2Context.init(... session:)` 4-arg initializer, and `*TransportSession` initializers — was demoted to `package` as well, since a `public` API can't take a `package` type as a parameter.
+- **Replacement:** the high-level public API. Construct a context with `ROS2Context(transport: TransportConfig)` (which now picks the correct stock `ZenohClient` / `DDSClient` internally based on `TransportConfig.type`); use `ROS2Publisher` / `ROS2Subscription` / `ROS2Service` / `ROS2Client` / `ROS2ActionServer` / `ROS2ActionClient` from `node.create*`. The injection seam (`session:`-shaped initializers, `TransportSession` / `TransportPublisher` / `TransportSubscriber` protocols) is no longer reachable from outside the package.
+- **Impact surface:** code that conforms to `ZenohClientProtocol` / `DDSClientProtocol` (custom wrappers), constructs a `*TransportSession` directly, or holds `any TransportPublisher` / `any TransportSubscriber`. Grep for `: ZenohClientProtocol\|: DDSClientProtocol\|TransportSession(\|any TransportPublisher\|any TransportSubscriber`.
+- **Recommended action:** drop the custom conformance / direct session construction and use `ROS2Context(transport:)` plus `node.createPublisher(...)` / `createSubscription(...)` / `createService(...)` / etc.
 
 ### Candidate 4 — `EntityManager`, `GIDManager`
 
@@ -167,10 +167,10 @@ Diffs each generated `RIHS01_*` against the canonical rosidl JSON inside the nam
 - **Current location:** `Sources/SwiftROS2Transport/ZenohTransportSession+Publisher.swift`.
 - **Current declaration:** `public final class ZenohTransportPublisher: TransportPublisher`.
 - **1.0 change:** demoted to `internal` (no cross-target references, so plain `internal` suffices).
-- **Rationale:** the protocol `TransportPublisher` already exists; the concrete class does not need to be public too.
-- **Replacement:** the `TransportPublisher` protocol (which itself was demoted to `package` in Candidate 3's vicinity for the same reason).
-- **Impact surface:** code that names `ZenohTransportPublisher` directly (e.g. as a stored type).
-- **Recommended action:** replace with `any TransportPublisher`.
+- **Rationale:** the protocol `TransportPublisher` already exists, and the umbrella's `ROS2Publisher` is the supported public type that wraps it; the concrete Zenoh class never needed to be public.
+- **Replacement:** the umbrella's public `ROS2Publisher`, returned by `node.createPublisher(...)`. The `TransportPublisher` protocol itself was also demoted to `package` (knock-on from Candidate 3) — downstream code can't name it from outside the SPM package.
+- **Impact surface:** code that names `ZenohTransportPublisher` directly (e.g. as a stored type), or that holds `any TransportPublisher` from outside the package.
+- **Recommended action:** replace with `ROS2Publisher` from `node.createPublisher(...)`.
 
 ### Candidate 6 — `DeclaredKeyExpr`, `ZenohSubscriber`, `LivelinessToken`
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,7 @@
 | 0.6.x | 0.7.x | **One** if upgrading from 0.6.0 directly: the rename above. From 0.6.1 → 0.7.x there are no breaking changes — the Services API is purely additive. |
 | 0.7.x | 0.8.0 | **None.** Actions are purely additive — `ROS2Action`, `ROS2ActionServer`, `ROS2ActionClient`, `ActionGoalHandle`, `ActionResult`, `ActionGoalStatus`, `ActionError` are new. `ROS2ActionTypeInfo` gained five optional hash fields with source-compatible defaults (Phase 1). |
 | 0.8.x | 0.9.0 | **None.** `swift-ros2-gen` (CLI + SwiftPM build plugin + hash-oracle CI) is purely additive — no existing public API changed. |
-| 0.9.x | 1.0.0 | Limited to the candidates below, decided after 0.9.0 ships based on the downstream survey. |
+| 0.9.x | 1.0.0 | **Six visibility-only changes** — plumbing types pulled out of the public surface (`TransportQoS`, `QoSPolicy`, `DDSBridge*`, `ZenohClientProtocol`/`DDSClientProtocol` + 10 related, `EntityManager`/`GIDManager` → `package`; `ZenohTransportPublisher`, `DeclaredKeyExpr`/`ZenohSubscriber`/`LivelinessToken` → `internal`). End-user APIs (`ROS2Context`, `ROS2Node`, `ROS2Publisher`, `ROS2Subscription`, `ROS2Service`, `ROS2Client`, `ROS2ActionServer`, `ROS2ActionClient`, `QoSProfile`, `TransportConfig`, all message types) are unchanged. |
 | 1.0.x | 1.x   | **None guaranteed.** Minor releases on the 1.x line will not break public API. |
 
 SwiftROS2 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once 1.0.0 is cut. Breaking changes after 1.0 require a major bump.
@@ -120,78 +120,66 @@ Diffs each generated `RIHS01_*` against the canonical rosidl JSON inside the nam
 
 ---
 
-## 0.9 → 1.0 — candidate change list
-
-> **Status:** the actual 1.0 break list is decided **after 0.9.0 ships**, based on a downstream-consumer survey (Conduit and any other known users). Each candidate below describes what *might* change, why it is being considered, and the recommended action you can take during 0.9.x to avoid surprise.
+## 0.9 → 1.0 — actual change list
 
 ### Candidate 1 — `TransportQoS` and `QoSPolicy`
 
 - **Current location:** `Sources/SwiftROS2Transport/TransportSession.swift` (`TransportQoS`); `Sources/SwiftROS2Wire/WireCodec.swift` (`QoSPolicy`).
 - **Current declaration:** `public struct TransportQoS`, `public struct QoSPolicy`.
-- **1.0 plan:** make both `internal`.
+- **1.0 change:** demoted to `package` (Swift 5.9+ access modifier — invisible to downstream consumers, still reachable from the other targets and tests in this SPM package).
 - **Rationale:** both are derived representations of `QoSProfile`. End users do not need to construct them directly. Three parallel public QoS types (profile / transport / wire) inflate the API surface for no functional gain.
 - **Replacement:** `QoSProfile` (presets `.default`, `.sensorData`, `.reliableSensor`, `.latched`, `.servicesDefault`, or `init(reliability:durability:history:)`).
 - **Impact surface:** code that constructs `TransportQoS(...)` or `QoSPolicy(...)` directly. Detect with `grep -rn "TransportQoS(\|QoSPolicy(" your-project/`.
 - **Recommended action:** replace direct construction with `QoSProfile(...)`.
-- **Compatibility shim?** Likely not — the migration is mechanical.
 
 ### Candidate 2 — `DDSBridgeQoSConfig`, `DDSBridgeDiscoveryConfig`, `DDSBridgeDiscoveryMode`
 
 - **Current location:** `Sources/SwiftROS2Transport/DDSClientProtocol.swift`.
 - **Current declaration:** `public struct DDSBridgeQoSConfig`, `public struct DDSBridgeDiscoveryConfig`, `public enum DDSBridgeDiscoveryMode`.
-- **1.0 plan:** make `internal` (alongside Candidate 3).
+- **1.0 change:** demoted to `package` (Swift 5.9+ access modifier — invisible to downstream consumers, still reachable from the other targets and tests in this SPM package).
 - **Rationale:** these types only exist in the public API to appear in `DDSClientProtocol` parameters. `DDSBridgeDiscoveryMode` (Int32-raw) duplicates `TransportConfig.DDSDiscoveryMode` (String-raw) at the concept level.
 - **Replacement:** `TransportConfig.DDSDiscoveryMode` and `DDSPeer` continue to be the public configuration surface.
 - **Impact surface:** code that constructs `DDSBridgeQoSConfig(...)` or `DDSBridgeDiscoveryConfig(...)` directly. Grep for `DDSBridge`.
 - **Recommended action:** replace direct construction with `TransportConfig.ddsMulticast(...)` / `TransportConfig.ddsUnicast(...)`.
-- **Compatibility shim?** None planned.
 
 ### Candidate 3 — `ZenohClientProtocol`, `DDSClientProtocol`, and related public types
 
-- **Related types (8):** `ZenohKeyExprHandle`, `ZenohSubscriberHandle`, `ZenohLivelinessTokenHandle`, `ZenohSample`, `ZenohError`, `DDSWriterHandle`, `DDSReaderHandle`, `DDSError` plus the 3 in Candidate 2.
+- **Related types (10):** `ZenohKeyExprHandle`, `ZenohSubscriberHandle`, `ZenohLivelinessTokenHandle`, `ZenohQueryableHandle`, `ZenohQueryHandle`, `ZenohSample`, `ZenohError`, `DDSWriterHandle`, `DDSReaderHandle`, `DDSError`.
 - **Current location:** `Sources/SwiftROS2Transport/{Zenoh,DDS}ClientProtocol.swift`.
-- **1.0 plan:** make `internal`.
-- **Rationale:** these protocols exist so consumers can wrap the C bridge themselves and inject a custom client. In practice Conduit uses `ZenohClient()` / `DDSClient()` from `SwiftROS2Zenoh` / `SwiftROS2DDS` directly. The implementation-injection seam is over-budget for an actual freeze.
-- **Replacement:** stock `ZenohClient` / `DDSClient` for production use, plus an internal testing utility for unit tests.
+- **1.0 change:** demoted to `package` (Swift 5.9+ access modifier — invisible to downstream consumers, still reachable from the other targets and tests in this SPM package).
+- **Rationale:** these protocols exist so consumers can wrap the C bridge themselves and inject a custom client. In practice every known consumer uses the stock `ZenohClient()` / `DDSClient()` from `SwiftROS2Zenoh` / `SwiftROS2DDS` directly — both remain `public`. The implementation-injection seam is over-budget for the 1.0 freeze.
+- **Replacement:** stock `ZenohClient` / `DDSClient` for production use.
 - **Impact surface:** code that conforms to `ZenohClientProtocol` / `DDSClientProtocol` (custom wrappers). Grep for `: ZenohClientProtocol\|: DDSClientProtocol`.
-- **Recommended action:** if you have a custom implementation, contact the maintainer during 0.7.x so the use case can be considered before the freeze.
-- **Compatibility shim?** Decided during the 0.7.0 → 1.0.0 survey.
+- **Recommended action:** drop the custom conformance and use the stock `ZenohClient` / `DDSClient`.
 
 ### Candidate 4 — `EntityManager`, `GIDManager`
 
 - **Current location:** `Sources/SwiftROS2Transport/{EntityManager,GIDManager}.swift`.
 - **Current declaration:** `public final class`.
-- **1.0 plan:** make `internal`.
+- **1.0 change:** demoted to `package` (Swift 5.9+ access modifier — invisible to downstream consumers, still reachable from the other targets and tests in this SPM package).
 - **Rationale:** library-internal entity-id allocator and GID storage. No external construction required.
 - **Replacement:** none required (`ROS2Context` and `ROS2Node` own these internally).
 - **Impact surface:** code that constructs `EntityManager()` or `GIDManager()` directly.
 - **Recommended action:** drop direct instantiation.
-- **Compatibility shim?** None planned.
 
 ### Candidate 5 — `ZenohTransportPublisher` (concrete class)
 
 - **Current location:** `Sources/SwiftROS2Transport/ZenohTransportSession+Publisher.swift`.
 - **Current declaration:** `public final class ZenohTransportPublisher: TransportPublisher`.
-- **1.0 plan:** make `internal`.
+- **1.0 change:** demoted to `internal` (no cross-target references, so plain `internal` suffices).
 - **Rationale:** the protocol `TransportPublisher` already exists; the concrete class does not need to be public too.
-- **Replacement:** the `TransportPublisher` protocol (which itself follows Candidate 3 if that group is also internalized).
+- **Replacement:** the `TransportPublisher` protocol (which itself was demoted to `package` in Candidate 3's vicinity for the same reason).
 - **Impact surface:** code that names `ZenohTransportPublisher` directly (e.g. as a stored type).
 - **Recommended action:** replace with `any TransportPublisher`.
-- **Compatibility shim?** None planned.
 
 ### Candidate 6 — `DeclaredKeyExpr`, `ZenohSubscriber`, `LivelinessToken`
 
 - **Current location:** `Sources/SwiftROS2Zenoh/ZenohClient.swift`.
-- **1.0 plan:** make `internal`.
+- **1.0 change:** demoted to `internal` (no cross-target references, so plain `internal` suffices).
 - **Rationale:** internal concrete classes of `ZenohClient`. They should be accessed only through the corresponding handle protocols.
-- **Replacement:** `ZenohKeyExprHandle`, `ZenohSubscriberHandle`, `ZenohLivelinessTokenHandle` (which themselves follow Candidate 3 if that group is also internalized).
+- **Replacement:** `ZenohKeyExprHandle`, `ZenohSubscriberHandle`, `ZenohLivelinessTokenHandle` (which were themselves demoted to `package` in Candidate 3).
 - **Impact surface:** code that names these classes directly.
 - **Recommended action:** drop direct references.
-- **Compatibility shim?** None planned.
-
-### Candidate 7 — Action public declarations with no implementation *(obsolete since 0.8.0)*
-
-The 0.7.0 plan had assumed `ROS2ActionTypeInfo` and `ROS2Action` in `SwiftROS2Messages` would either be removed or made `internal` for 1.0. Both are now real, fully-implemented protocols backing the `ROS2ActionServer<H>` / `ROS2ActionClient<A>` umbrella that shipped in 0.8.0 (#77–#82). They will remain `public` in 1.0.0 — no action required from downstream code.
 
 > **Note:** the analogous Service placeholders (`ROS2ServiceTypeInfo`, `ROS2ServiceType`) were retained in 0.7.0 once the typed `ROS2Service<S>` / `ROS2Client<S>` umbrella landed — they are now real, implemented protocols, not placeholders.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ Native Swift client library for ROS 2. Publish and subscribe to ROS 2 topics ove
 
 > The four CI badges above all reflect the same `ci.yml` workflow status (GitHub Actions does not expose per-matrix-job badges). Each label is the OS family that workflow exercises — when the badges are green, every Apple / Linux / Windows / Android matrix entry passed.
 
-Shipping as **0.9.0** — Apple xcframeworks (iOS / iPadOS / macOS / Mac Catalyst / visionOS), `zenoh-pico` source build on Linux / Windows / Android, `swift-ros2-gen` IDL → Swift code generator + SwiftPM build plugin.
+Shipping as **1.0.0** — Apple xcframeworks (iOS / iPadOS / macOS / Mac Catalyst / visionOS), `zenoh-pico` source build on Linux / Windows / Android, `swift-ros2-gen` IDL → Swift code generator + SwiftPM build plugin.
+
+## API stability
+
+swift-ros2 1.0.0 inaugurates the [SemVer](https://semver.org/spec/v2.0.0.html) 1.x line: no minor or patch release on 1.x will break the public API. Breaking changes require a 2.0 bump.
+
+The frozen public surface covers `ROS2Context`, `ROS2Node`, `ROS2Publisher`, `ROS2Subscription`, `ROS2Service`, `ROS2Client`, `ROS2ActionServer`, `ROS2ActionClient`, `QoSProfile`, `TransportConfig`, the concrete `ZenohClient` / `DDSClient`, and every `ROS2Message` / `ROS2ServiceType` / `ROS2Action` type. Internal plumbing (`TransportQoS`, `QoSPolicy`, `DDSBridge*`, `ZenohClientProtocol` / `DDSClientProtocol`, `EntityManager`, `GIDManager`, etc.) was pulled out of the public surface at the 1.0 cut — see [`MIGRATION.md`](MIGRATION.md) for the full list and migration recipes.
 
 ## Why
 
@@ -70,7 +76,7 @@ In practice this means almost every consumer device that someone might want to a
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.9.0"),
+    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "1.0.0"),
 ],
 targets: [
     .target(
@@ -116,7 +122,7 @@ $env:Path = "$env:CYCLONEDDS_DIR\bin;$env:Path"
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "0.9.0"),
+    .package(url: "https://github.com/youtalk/swift-ros2.git", from: "1.0.0"),
 ],
 targets: [
     .target(

--- a/Scripts/api-breakage-allowlist.txt
+++ b/Scripts/api-breakage-allowlist.txt
@@ -42,3 +42,13 @@ API breakage: constructor PointCloud2.init(header:height:width:fields:isBigendia
 API breakage: constructor Range.init(header:radiationType:fieldOfView:minRange:maxRange:range:variance:) has removed default argument from parameter 1
 API breakage: var NavSatStatus.statusGbassFix has been removed
 API breakage: var PointCloud2.pointCount has been removed
+
+# 1.0.0: API freeze — internalize Candidates 5 and 6 (ZenohTransportPublisher
+# concrete class; DeclaredKeyExpr / ZenohSubscriber / LivelinessToken concrete
+# classes inside SwiftROS2Zenoh). Candidates 1–4 demote types to `package`
+# rather than `internal` and do not surface as diagnostic-reported breakages.
+# All six demotions are documented in CHANGELOG ## [1.0.0] / MIGRATION.md.
+API breakage: class ZenohTransportPublisher has been removed
+API breakage: class DeclaredKeyExpr has been removed
+API breakage: class ZenohSubscriber has been removed
+API breakage: class LivelinessToken has been removed

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -33,8 +33,21 @@ public final class ROS2Context: @unchecked Sendable {
     ///   - transport: Transport configuration (Zenoh or DDS)
     ///   - distro: ROS 2 distribution for wire format (default: .jazzy)
     ///   - domainId: ROS 2 domain ID (default: 0)
-    ///   - session: Custom transport session (nil to use factory)
-    public init(
+    public convenience init(
+        transport: TransportConfig,
+        distro: ROS2Distro = .jazzy,
+        domainId: Int? = nil
+    ) async throws {
+        try await self.init(
+            transport: transport,
+            distro: distro,
+            domainId: domainId,
+            session: nil
+        )
+    }
+
+    /// Package-internal initializer for tests / custom transport sessions.
+    package init(
         transport: TransportConfig,
         distro: ROS2Distro = .jazzy,
         domainId: Int? = nil,

--- a/Sources/SwiftROS2/QoSProfile.swift
+++ b/Sources/SwiftROS2/QoSProfile.swift
@@ -84,7 +84,7 @@ public struct QoSProfile: Sendable, Equatable {
     // MARK: - Conversion
 
     /// Convert to transport-level QoS
-    public func toTransportQoS() -> TransportQoS {
+    package func toTransportQoS() -> TransportQoS {
         let rel: TransportQoS.Reliability = reliability == .reliable ? .reliable : .bestEffort
         let dur: TransportQoS.Durability = durability == .transientLocal ? .transientLocal : .volatile
         let hist: TransportQoS.History
@@ -96,7 +96,7 @@ public struct QoSProfile: Sendable, Equatable {
     }
 
     /// Convert to wire QoS policy
-    public func toQoSPolicy() -> QoSPolicy {
+    package func toQoSPolicy() -> QoSPolicy {
         let rel: QoSPolicy.Reliability = reliability == .reliable ? .reliable : .bestEffort
         let dur: QoSPolicy.Durability = durability == .transientLocal ? .transientLocal : .volatile
         let hist: QoSPolicy.HistoryPolicy

--- a/Sources/SwiftROS2DDS/DDSClient.swift
+++ b/Sources/SwiftROS2DDS/DDSClient.swift
@@ -147,7 +147,7 @@ public final class DDSClient: DDSClientProtocol {
         dds_bridge_is_available()
     }
 
-    public func createSession(
+    package func createSession(
         domainId: Int32,
         discoveryConfig: DDSBridgeDiscoveryConfig
     ) throws {
@@ -230,7 +230,7 @@ public final class DDSClient: DDSClientProtocol {
         return String(cString: buf)
     }
 
-    public func createRawWriter(
+    package func createRawWriter(
         topicName: String,
         typeName: String,
         qos: DDSBridgeQoSConfig,
@@ -297,7 +297,7 @@ public final class DDSClient: DDSClientProtocol {
         box.close()
     }
 
-    public func createRawReader(
+    package func createRawReader(
         topicName: String,
         typeName: String,
         qos: DDSBridgeQoSConfig,

--- a/Sources/SwiftROS2DDS/DDSClient.swift
+++ b/Sources/SwiftROS2DDS/DDSClient.swift
@@ -269,7 +269,7 @@ public final class DDSClient: DDSClientProtocol {
         return DDSWriterHandleBox(writer)
     }
 
-    public func writeRawCDR(
+    package func writeRawCDR(
         writer: any DDSWriterHandle,
         data: Data,
         timestamp: UInt64
@@ -292,7 +292,7 @@ public final class DDSClient: DDSClientProtocol {
         }
     }
 
-    public func destroyWriter(_ writer: any DDSWriterHandle) {
+    package func destroyWriter(_ writer: any DDSWriterHandle) {
         guard let box = writer as? DDSWriterHandleBox else { return }
         box.close()
     }
@@ -350,7 +350,7 @@ public final class DDSClient: DDSClientProtocol {
         return DDSReaderHandleBox(reader, contextBox: contextBox)
     }
 
-    public func destroyReader(_ reader: any DDSReaderHandle) {
+    package func destroyReader(_ reader: any DDSReaderHandle) {
         guard let box = reader as? DDSReaderHandleBox else { return }
         box.close()
     }

--- a/Sources/SwiftROS2DDS/Exports.swift
+++ b/Sources/SwiftROS2DDS/Exports.swift
@@ -1,5 +1,6 @@
-// Re-export the Swift transport symbols so a caller that imports SwiftROS2DDS
-// can reach the shared transport types (DDSClientProtocol, DDSBridgeQoSConfig,
-// DDSError, DDSClient) without adding SwiftROS2Transport to its own
-// import list.
+// Re-export the public surface of SwiftROS2Transport so a caller that imports
+// SwiftROS2DDS can reach TransportConfig, DDSPeer, and the shared transport
+// entry points without an extra import. The internal/package-scoped bridge
+// types (DDSClientProtocol, DDSBridgeQoSConfig, DDSError, etc.) are not
+// re-exported — they were demoted out of the public surface in 1.0.0.
 @_exported import SwiftROS2Transport

--- a/Sources/SwiftROS2Transport/DDSClientProtocol.swift
+++ b/Sources/SwiftROS2Transport/DDSClientProtocol.swift
@@ -24,19 +24,19 @@ public protocol DDSReaderHandle: AnyObject {
 // MARK: - DDS Configuration Types
 
 /// DDS discovery mode
-public enum DDSBridgeDiscoveryMode: Int32, Sendable {
+package enum DDSBridgeDiscoveryMode: Int32, Sendable {
     case multicast = 0
     case unicast = 1
     case hybrid = 2
 }
 
 /// DDS discovery configuration
-public struct DDSBridgeDiscoveryConfig: Sendable {
-    public let mode: DDSBridgeDiscoveryMode
-    public let unicastPeers: [String]
-    public let networkInterface: String?
+package struct DDSBridgeDiscoveryConfig: Sendable {
+    package let mode: DDSBridgeDiscoveryMode
+    package let unicastPeers: [String]
+    package let networkInterface: String?
 
-    public init(mode: DDSBridgeDiscoveryMode, unicastPeers: [String] = [], networkInterface: String? = nil) {
+    package init(mode: DDSBridgeDiscoveryMode, unicastPeers: [String] = [], networkInterface: String? = nil) {
         self.mode = mode
         self.unicastPeers = unicastPeers
         self.networkInterface = networkInterface
@@ -44,28 +44,28 @@ public struct DDSBridgeDiscoveryConfig: Sendable {
 }
 
 /// DDS QoS configuration for the bridge
-public struct DDSBridgeQoSConfig: Sendable {
-    public enum Reliability: Int32, Sendable {
+package struct DDSBridgeQoSConfig: Sendable {
+    package enum Reliability: Int32, Sendable {
         case bestEffort = 0
         case reliable = 1
     }
 
-    public enum Durability: Int32, Sendable {
+    package enum Durability: Int32, Sendable {
         case volatile = 0
         case transientLocal = 1
     }
 
-    public enum HistoryKind: Int32, Sendable {
+    package enum HistoryKind: Int32, Sendable {
         case keepLast = 0
         case keepAll = 1
     }
 
-    public let reliability: Reliability
-    public let durability: Durability
-    public let historyKind: HistoryKind
-    public let historyDepth: Int32
+    package let reliability: Reliability
+    package let durability: Durability
+    package let historyKind: HistoryKind
+    package let historyDepth: Int32
 
-    public init(
+    package init(
         reliability: Reliability = .bestEffort,
         durability: Durability = .volatile,
         historyKind: HistoryKind = .keepLast,
@@ -110,7 +110,7 @@ public enum DDSError: Error, LocalizedError {
 /// Consuming apps implement this by wrapping the CycloneDDS C bridge.
 /// swift-ros2's `DDSTransportSession` uses this protocol to create
 /// participants, writers, and publish CDR data.
-public protocol DDSClientProtocol: AnyObject {
+package protocol DDSClientProtocol: AnyObject {
     /// Whether DDS transport is available (compiled with DDS_AVAILABLE)
     var isAvailable: Bool { get }
 

--- a/Sources/SwiftROS2Transport/DDSClientProtocol.swift
+++ b/Sources/SwiftROS2Transport/DDSClientProtocol.swift
@@ -10,13 +10,13 @@ import Foundation
 // MARK: - Handle Protocols
 
 /// Handle to a DDS writer
-public protocol DDSWriterHandle: AnyObject {
+package protocol DDSWriterHandle: AnyObject {
     var isActive: Bool { get }
     func close()
 }
 
 /// Handle to a DDS reader
-public protocol DDSReaderHandle: AnyObject {
+package protocol DDSReaderHandle: AnyObject {
     var isActive: Bool { get }
     func close()
 }
@@ -81,7 +81,7 @@ package struct DDSBridgeQoSConfig: Sendable {
 // MARK: - DDS Error
 
 /// Errors from DDS operations
-public enum DDSError: Error, LocalizedError {
+package enum DDSError: Error, LocalizedError {
     case sessionCreationFailed(String)
     case sessionDestructionFailed(String)
     case writerCreationFailed(String)
@@ -90,7 +90,7 @@ public enum DDSError: Error, LocalizedError {
     case notConnected
     case notAvailable
 
-    public var errorDescription: String? {
+    package var errorDescription: String? {
         switch self {
         case .sessionCreationFailed(let msg): return "DDS session creation failed: \(msg)"
         case .sessionDestructionFailed(let msg): return "DDS session destruction failed: \(msg)"
@@ -181,5 +181,5 @@ extension DDSClientProtocol {
     /// Default: optimistically report the publication as matched. Concrete
     /// conformers (e.g. CycloneDDS-backed bridges) should override this with
     /// `dds_get_publication_matched_status`.
-    public func isPublicationMatched(writer: any DDSWriterHandle) -> Bool { true }
+    package func isPublicationMatched(writer: any DDSWriterHandle) -> Bool { true }
 }

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Action.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Action.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftROS2Wire
 
 extension DDSTransportSession {
-    public func createActionServer(
+    package func createActionServer(
         name: String,
         actionTypeName: String,
         roleTypeHashes: ActionRoleTypeHashes,
@@ -149,7 +149,7 @@ extension DDSTransportSession {
         return server
     }
 
-    public func createActionClient(
+    package func createActionClient(
         name: String,
         actionTypeName: String,
         roleTypeHashes: ActionRoleTypeHashes,

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Publisher.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Publisher.swift
@@ -5,7 +5,7 @@ import Foundation
 import SwiftROS2Wire
 
 extension DDSTransportSession {
-    public func createPublisher(
+    package func createPublisher(
         topic: String,
         typeName: String,
         typeHash: String?,

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Service.swift
@@ -13,7 +13,7 @@ import Foundation
 import SwiftROS2Wire
 
 extension DDSTransportSession {
-    public func createServiceServer(
+    package func createServiceServer(
         name: String,
         serviceTypeName: String,
         requestTypeHash: String?,
@@ -82,7 +82,7 @@ extension DDSTransportSession {
         return server
     }
 
-    public func createServiceClient(
+    package func createServiceClient(
         name: String,
         serviceTypeName: String,
         requestTypeHash: String?,

--- a/Sources/SwiftROS2Transport/DDSTransportSession+Subscriber.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession+Subscriber.swift
@@ -5,7 +5,7 @@ import Foundation
 import SwiftROS2Wire
 
 extension DDSTransportSession {
-    public func createSubscriber(
+    package func createSubscriber(
         topic: String,
         typeName: String,
         typeHash: String?,

--- a/Sources/SwiftROS2Transport/DDSTransportSession.swift
+++ b/Sources/SwiftROS2Transport/DDSTransportSession.swift
@@ -42,7 +42,7 @@ public final class DDSTransportSession: TransportSession, @unchecked Sendable {
 
     /// Create a DDS transport session
     /// - Parameter client: DDS client protocol implementation (wraps C bridge)
-    public init(client: any DDSClientProtocol) {
+    package init(client: any DDSClientProtocol) {
         self.client = client
     }
 

--- a/Sources/SwiftROS2Transport/EntityManager.swift
+++ b/Sources/SwiftROS2Transport/EntityManager.swift
@@ -7,14 +7,14 @@ import Foundation
 ///
 /// Each context has its own entity manager. IDs are used in liveliness
 /// tokens for ROS 2 discovery (makes topics visible in `ros2 topic list`).
-public final class EntityManager: @unchecked Sendable {
+package final class EntityManager: @unchecked Sendable {
     private var nextId: Int = 0
     private let lock = NSLock()
 
-    public init() {}
+    package init() {}
 
     /// Get the next unique entity ID
-    public func getNextEntityId() -> Int {
+    package func getNextEntityId() -> Int {
         lock.lock()
         defer { lock.unlock() }
         let id = nextId
@@ -23,7 +23,7 @@ public final class EntityManager: @unchecked Sendable {
     }
 
     /// Reset the counter (for testing)
-    public func reset() {
+    package func reset() {
         lock.lock()
         nextId = 0
         lock.unlock()

--- a/Sources/SwiftROS2Transport/GIDManager.swift
+++ b/Sources/SwiftROS2Transport/GIDManager.swift
@@ -8,16 +8,16 @@ import Foundation
 /// The GID uniquely identifies a publisher and must be stable across
 /// publish calls within a session. Platform-specific persistence
 /// (Keychain on iOS/macOS, file on Linux) can be added later.
-public final class GIDManager: @unchecked Sendable {
-    public static let gidSize = 16
+package final class GIDManager: @unchecked Sendable {
+    package static let gidSize = 16
 
     private var cachedGid: [UInt8]?
     private let lock = NSLock()
 
-    public init() {}
+    package init() {}
 
     /// Get or create a 16-byte publisher GID
-    public func getOrCreateGid() -> [UInt8] {
+    package func getOrCreateGid() -> [UInt8] {
         lock.lock()
         defer { lock.unlock() }
 
@@ -31,7 +31,7 @@ public final class GIDManager: @unchecked Sendable {
     }
 
     /// Reset the GID (generates a new one on next access)
-    public func reset() {
+    package func reset() {
         lock.lock()
         cachedGid = nil
         lock.unlock()

--- a/Sources/SwiftROS2Transport/TransportSession.swift
+++ b/Sources/SwiftROS2Transport/TransportSession.swift
@@ -12,7 +12,7 @@ import SwiftROS2Wire
 /// Implementations provide the actual transport mechanism:
 /// - Zenoh: via zenoh-pico C-FFI
 /// - DDS: via CycloneDDS C-FFI
-public protocol TransportSession: AnyObject, Sendable {
+package protocol TransportSession: AnyObject, Sendable {
     var isConnected: Bool { get }
     var transportType: TransportType { get }
     var sessionId: String { get }
@@ -105,7 +105,7 @@ public protocol TransportSession: AnyObject, Sendable {
 
 extension TransportSession {
     /// Default — concrete sessions override in Phases 4 / 5.
-    public func createActionServer(
+    package func createActionServer(
         name: String,
         actionTypeName: String,
         roleTypeHashes: ActionRoleTypeHashes,
@@ -116,7 +116,7 @@ extension TransportSession {
     }
 
     /// Default — concrete sessions override in Phases 4 / 5.
-    public func createActionClient(
+    package func createActionClient(
         name: String,
         actionTypeName: String,
         roleTypeHashes: ActionRoleTypeHashes,
@@ -132,7 +132,7 @@ extension TransportSession {
 ///
 /// Conforming types are returned by ``TransportSession/createPublisher(topic:typeName:typeHash:qos:)``
 /// and must remain sendable across concurrency domains.
-public protocol TransportPublisher: Sendable {
+package protocol TransportPublisher: Sendable {
     func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws
     func close() throws
     var topic: String { get }
@@ -145,7 +145,7 @@ public protocol TransportPublisher: Sendable {
 ///
 /// Conforming types are returned by ``TransportSession/createSubscriber(topic:typeName:typeHash:qos:handler:)``
 /// and must remain sendable across concurrency domains.
-public protocol TransportSubscriber: Sendable {
+package protocol TransportSubscriber: Sendable {
     var topic: String { get }
     var isActive: Bool { get }
     func close() throws
@@ -158,7 +158,7 @@ public protocol TransportSubscriber: Sendable {
 /// The handler closure passed at creation time receives raw CDR request bytes
 /// and is expected to return raw CDR response bytes. The transport layer is
 /// untyped on purpose — `ROS2Service<S>` on top encodes / decodes typed values.
-public protocol TransportService: Sendable {
+package protocol TransportService: Sendable {
     var name: String { get }
     var isActive: Bool { get }
     func close() throws
@@ -168,7 +168,7 @@ public protocol TransportService: Sendable {
 ///
 /// `call` operates on raw CDR. The `ROS2Client<S>` layer encodes the typed
 /// request, invokes this method, and decodes the typed response.
-public protocol TransportClient: Sendable {
+package protocol TransportClient: Sendable {
     var name: String { get }
     var isActive: Bool { get }
     func waitForService(timeout: Duration) async throws
@@ -181,45 +181,42 @@ public protocol TransportClient: Sendable {
 
 // MARK: - Transport QoS
 
-/// Quality-of-service settings used internally by the transport layer.
-///
-/// End users should prefer the higher-level ``QoSProfile`` presets; `TransportQoS` is derived
-/// automatically from a `QoSProfile` when creating publishers and subscriptions.
-public struct TransportQoS: Sendable, Equatable {
-    public enum Reliability: String, Sendable {
+/// Package-internal QoS shape derived from `QoSProfile`. End users see only `QoSProfile`.
+package struct TransportQoS: Sendable, Equatable {
+    package enum Reliability: String, Sendable {
         case reliable
         case bestEffort = "best_effort"
     }
 
-    public enum Durability: String, Sendable {
+    package enum Durability: String, Sendable {
         case volatile
         case transientLocal = "transient_local"
     }
 
-    public enum History: Sendable, Equatable {
+    package enum History: Sendable, Equatable {
         case keepLast(Int)
         case keepAll
     }
 
-    public let reliability: Reliability
-    public let durability: Durability
-    public let history: History
+    package let reliability: Reliability
+    package let durability: Durability
+    package let history: History
 
-    public static let sensorData = TransportQoS(
+    package static let sensorData = TransportQoS(
         reliability: .reliable,
         durability: .volatile,
         history: .keepLast(10)
     )
 
-    public static let bestEffort = TransportQoS(
+    package static let bestEffort = TransportQoS(
         reliability: .bestEffort,
         durability: .volatile,
         history: .keepLast(1)
     )
 
-    public static let `default` = sensorData
+    package static let `default` = sensorData
 
-    public init(
+    package init(
         reliability: Reliability = .reliable,
         durability: Durability = .volatile,
         history: History = .keepLast(10)

--- a/Sources/SwiftROS2Transport/ZenohClientProtocol.swift
+++ b/Sources/SwiftROS2Transport/ZenohClientProtocol.swift
@@ -10,20 +10,20 @@ import Foundation
 // MARK: - Handle Protocols (type-erased C resource wrappers)
 
 /// Handle to a declared Zenoh key expression
-public protocol ZenohKeyExprHandle: AnyObject {}
+package protocol ZenohKeyExprHandle: AnyObject {}
 
 /// Handle to a Zenoh subscriber
-public protocol ZenohSubscriberHandle: AnyObject {
+package protocol ZenohSubscriberHandle: AnyObject {
     func close() throws
 }
 
 /// Handle to a Zenoh liveliness token
-public protocol ZenohLivelinessTokenHandle: AnyObject {
+package protocol ZenohLivelinessTokenHandle: AnyObject {
     func close() throws
 }
 
 /// Handle to a declared Zenoh queryable (Service Server side)
-public protocol ZenohQueryableHandle: AnyObject {
+package protocol ZenohQueryableHandle: AnyObject {
     func close() throws
 }
 
@@ -32,7 +32,7 @@ public protocol ZenohQueryableHandle: AnyObject {
 /// Consumed by the first call to `reply(payload:attachment:)` or
 /// `replyError(message:)`. After consumption further reply calls throw
 /// `ZenohError.invalidParameter`.
-public protocol ZenohQueryHandle: AnyObject, Sendable {
+package protocol ZenohQueryHandle: AnyObject, Sendable {
     /// The key expression the query was issued against.
     var keyExpr: String { get }
 
@@ -52,12 +52,12 @@ public protocol ZenohQueryHandle: AnyObject, Sendable {
 // MARK: - Zenoh Sample
 
 /// Data received by a Zenoh subscriber
-public struct ZenohSample: Sendable {
-    public let keyExpr: String
-    public let payload: Data
-    public let attachment: Data?
+package struct ZenohSample: Sendable {
+    package let keyExpr: String
+    package let payload: Data
+    package let attachment: Data?
 
-    public init(keyExpr: String, payload: Data, attachment: Data?) {
+    package init(keyExpr: String, payload: Data, attachment: Data?) {
         self.keyExpr = keyExpr
         self.payload = payload
         self.attachment = attachment
@@ -67,7 +67,7 @@ public struct ZenohSample: Sendable {
 // MARK: - Zenoh Error
 
 /// Errors from Zenoh operations
-public enum ZenohError: Error, LocalizedError {
+package enum ZenohError: Error, LocalizedError {
     case sessionCreationFailed(String)
     case sessionCloseFailed(String)
     case keyExprDeclarationFailed(String)
@@ -82,7 +82,7 @@ public enum ZenohError: Error, LocalizedError {
     /// `serviceHandlerFailed` without parsing prefixed strings.
     case queryReplyError(String)
 
-    public var errorDescription: String? {
+    package var errorDescription: String? {
         switch self {
         case .sessionCreationFailed(let msg): return "Session creation failed: \(msg)"
         case .sessionCloseFailed(let msg): return "Session close failed: \(msg)"
@@ -114,7 +114,7 @@ public enum ZenohError: Error, LocalizedError {
 ///     // ...
 /// }
 /// ```
-public protocol ZenohClientProtocol: AnyObject {
+package protocol ZenohClientProtocol: AnyObject {
     /// Open a Zenoh session
     func open(locator: String) throws
 
@@ -167,7 +167,7 @@ public protocol ZenohClientProtocol: AnyObject {
 extension ZenohClientProtocol {
     /// Default stub — implementations that don't yet support queryables can
     /// fall back to this until they wire in the C bridge.
-    public func declareQueryable(
+    package func declareQueryable(
         _ keyExpr: String,
         handler: @escaping @Sendable (any ZenohQueryHandle) -> Void
     ) throws -> any ZenohQueryableHandle {
@@ -176,7 +176,7 @@ extension ZenohClientProtocol {
 
     /// Default stub — implementations that don't yet support get queries can
     /// fall back to this until they wire in the C bridge.
-    public func get(
+    package func get(
         keyExpr: String,
         payload: Data?,
         attachment: Data?,

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Action.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Action.swift
@@ -20,7 +20,7 @@ import Foundation
 import SwiftROS2Wire
 
 extension ZenohTransportSession {
-    public func createActionServer(
+    package func createActionServer(
         name: String,
         actionTypeName: String,
         roleTypeHashes: ActionRoleTypeHashes,
@@ -138,7 +138,7 @@ extension ZenohTransportSession {
         return server
     }
 
-    public func createActionClient(
+    package func createActionClient(
         name: String,
         actionTypeName: String,
         roleTypeHashes: ActionRoleTypeHashes,

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Publisher.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Publisher.swift
@@ -105,17 +105,17 @@ extension ZenohTransportSession {
 // MARK: - Zenoh Transport Publisher
 
 /// TransportPublisher using Zenoh
-public final class ZenohTransportPublisher: TransportPublisher, @unchecked Sendable {
+final class ZenohTransportPublisher: TransportPublisher, @unchecked Sendable {
     private let client: any ZenohClientProtocol
     private var declaredKey: (any ZenohKeyExprHandle)?
     private var livelinessToken: (any ZenohLivelinessTokenHandle)?
     private let codec: ZenohWireCodec
     private let gid: [UInt8]
-    public let topic: String
+    let topic: String
     private let lock = NSLock()
     private var closed = false
 
-    public var isActive: Bool {
+    var isActive: Bool {
         lock.lock()
         defer { lock.unlock() }
         return !closed && declaredKey != nil
@@ -137,7 +137,7 @@ public final class ZenohTransportPublisher: TransportPublisher, @unchecked Senda
         self.topic = topic
     }
 
-    public func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws {
+    func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws {
         lock.lock()
         guard !closed, let key = declaredKey else {
             lock.unlock()
@@ -161,7 +161,7 @@ public final class ZenohTransportPublisher: TransportPublisher, @unchecked Senda
         }
     }
 
-    public func close() throws {
+    func close() throws {
         lock.lock()
         guard !closed else {
             lock.unlock()

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Publisher.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Publisher.swift
@@ -5,7 +5,7 @@ import Foundation
 import SwiftROS2Wire
 
 extension ZenohTransportSession {
-    public func createPublisher(
+    package func createPublisher(
         topic: String,
         typeName: String,
         typeHash: String?,

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Service.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Service.swift
@@ -18,7 +18,7 @@ import Foundation
 import SwiftROS2Wire
 
 extension ZenohTransportSession {
-    public func createServiceServer(
+    package func createServiceServer(
         name: String,
         serviceTypeName: String,
         requestTypeHash: String?,
@@ -68,7 +68,7 @@ extension ZenohTransportSession {
         return server
     }
 
-    public func createServiceClient(
+    package func createServiceClient(
         name: String,
         serviceTypeName: String,
         requestTypeHash: String?,

--- a/Sources/SwiftROS2Transport/ZenohTransportSession+Subscriber.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession+Subscriber.swift
@@ -5,7 +5,7 @@ import Foundation
 import SwiftROS2Wire
 
 extension ZenohTransportSession {
-    public func createSubscriber(
+    package func createSubscriber(
         topic: String,
         typeName: String,
         typeHash: String?,

--- a/Sources/SwiftROS2Transport/ZenohTransportSession.swift
+++ b/Sources/SwiftROS2Transport/ZenohTransportSession.swift
@@ -43,7 +43,7 @@ public final class ZenohTransportSession: TransportSession, @unchecked Sendable 
     ///   - client: Zenoh client protocol implementation (wraps C bridge)
     ///   - entityManager: Entity ID generator (optional, creates new if nil)
     ///   - gidManager: GID manager (optional, creates new if nil)
-    public init(
+    package init(
         client: any ZenohClientProtocol,
         entityManager: EntityManager? = nil,
         gidManager: GIDManager? = nil

--- a/Sources/SwiftROS2Wire/WireCodec.swift
+++ b/Sources/SwiftROS2Wire/WireCodec.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Implementations handle the specifics of key expression generation,
 /// liveliness token construction, and attachment building for different
 /// ROS 2 middleware implementations.
-public protocol WireCodec: Sendable {
+package protocol WireCodec: Sendable {
     /// Generate a key expression for a topic
     func makeKeyExpr(
         domainId: Int,
@@ -41,28 +41,28 @@ public protocol WireCodec: Sendable {
 }
 
 /// QoS policy for wire format encoding (transport-agnostic)
-public struct QoSPolicy: Sendable, Equatable {
-    public enum Reliability: Int, Sendable {
+package struct QoSPolicy: Sendable, Equatable {
+    package enum Reliability: Int, Sendable {
         case bestEffort = 0
         case reliable = 1
     }
 
-    public enum Durability: Int, Sendable {
+    package enum Durability: Int, Sendable {
         case transientLocal = 1
         case volatile = 2
     }
 
-    public enum HistoryPolicy: Int, Sendable {
+    package enum HistoryPolicy: Int, Sendable {
         case keepLast = 0
         case keepAll = 1
     }
 
-    public var reliability: Reliability
-    public var durability: Durability
-    public var historyPolicy: HistoryPolicy
-    public var historyDepth: Int
+    package var reliability: Reliability
+    package var durability: Durability
+    package var historyPolicy: HistoryPolicy
+    package var historyDepth: Int
 
-    public init(
+    package init(
         reliability: Reliability = .bestEffort,
         durability: Durability = .volatile,
         historyPolicy: HistoryPolicy = .keepLast,
@@ -77,7 +77,7 @@ public struct QoSPolicy: Sendable, Equatable {
     /// Encode QoS for liveliness token
     ///
     /// Format: `reliability:durability:history,depth:deadline:lifespan:liveliness`
-    public func toKeyExpr() -> String {
+    package func toKeyExpr() -> String {
         let relStr = reliability == .bestEffort ? "" : String(reliability.rawValue)
         let durStr = durability == .volatile ? "" : String(durability.rawValue)
         let histStr = historyPolicy == .keepLast ? "" : String(historyPolicy.rawValue)
@@ -87,30 +87,30 @@ public struct QoSPolicy: Sendable, Equatable {
 
     // MARK: - Presets
 
-    public static let `default` = QoSPolicy()
+    package static let `default` = QoSPolicy()
 
-    public static let sensorData = QoSPolicy(
+    package static let sensorData = QoSPolicy(
         reliability: .bestEffort,
         durability: .volatile,
         historyPolicy: .keepLast,
         historyDepth: 10
     )
 
-    public static let latched = QoSPolicy(
+    package static let latched = QoSPolicy(
         reliability: .reliable,
         durability: .transientLocal,
         historyPolicy: .keepLast,
         historyDepth: 1
     )
 
-    public static let reliableSensor = QoSPolicy(
+    package static let reliableSensor = QoSPolicy(
         reliability: .reliable,
         durability: .volatile,
         historyPolicy: .keepLast,
         historyDepth: 10
     )
 
-    public static let servicesDefault = QoSPolicy(
+    package static let servicesDefault = QoSPolicy(
         reliability: .reliable,
         durability: .volatile,
         historyPolicy: .keepLast,

--- a/Sources/SwiftROS2Wire/ZenohWireCodec.swift
+++ b/Sources/SwiftROS2Wire/ZenohWireCodec.swift
@@ -163,7 +163,7 @@ public struct ZenohWireCodec: WireCodec {
     ///   so the token never contains a `//` segment.
     /// - `serviceName` may carry a leading slash; ``TypeNameConverter/mangleTopicPath(namespace:topic:)``
     ///   normalizes it.
-    public func makeServiceLivelinessToken(
+    package func makeServiceLivelinessToken(
         entityKind: ServiceEntityKind,
         domainId: Int,
         sessionId: String,
@@ -213,7 +213,7 @@ public struct ZenohWireCodec: WireCodec {
     /// per action) so a peer that sees a single token knows the full action is
     /// available — the other four roles are guaranteed to be co-declared by
     /// the action server / client implementation in Phases 4–5.
-    public func makeActionLivelinessToken(
+    package func makeActionLivelinessToken(
         entityKind: ActionEntityKind,
         domainId: Int,
         sessionId: String,
@@ -247,7 +247,7 @@ public struct ZenohWireCodec: WireCodec {
     /// Generate liveliness token for ROS 2 discovery
     ///
     /// Format: `@ros2_lv/<domain>/<session>/<node>/<entity>/MP/%/%/<node_name>/<topic>/<type>/<hash>/<qos>`
-    public func makeLivelinessToken(
+    package func makeLivelinessToken(
         domainId: Int,
         sessionId: String,
         nodeId: String,

--- a/Sources/SwiftROS2Zenoh/ZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/ZenohClient.swift
@@ -297,7 +297,7 @@ public class ZenohClient: ZenohClientProtocol {
     /// - Parameter keyExpr: The key expression string to declare
     /// - Returns: A handle conforming to ZenohKeyExprHandle
     /// - Throws: ZenohError if declaration fails
-    public func declareKeyExpr(_ keyExpr: String) throws -> any ZenohKeyExprHandle {
+    package func declareKeyExpr(_ keyExpr: String) throws -> any ZenohKeyExprHandle {
         guard let sess = session else {
             throw ZenohError.keyExprDeclarationFailed("Session not open")
         }
@@ -326,7 +326,7 @@ public class ZenohClient: ZenohClientProtocol {
     ///   - payload: The data to publish
     ///   - attachment: Optional attachment data (for ROS 2 metadata)
     /// - Throws: ZenohError if the put operation fails or the handle type is foreign
-    public func put(keyExpr: any ZenohKeyExprHandle, payload: Data, attachment: Data?) throws {
+    package func put(keyExpr: any ZenohKeyExprHandle, payload: Data, attachment: Data?) throws {
         guard let declared = keyExpr as? DeclaredKeyExpr else {
             throw ZenohError.invalidParameter("foreign key-expression handle")
         }
@@ -387,7 +387,7 @@ public class ZenohClient: ZenohClientProtocol {
     ///   - handler: Callback to invoke when samples are received
     /// - Returns: A handle conforming to ZenohSubscriberHandle
     /// - Throws: ZenohError if subscription fails
-    public func subscribe(
+    package func subscribe(
         keyExpr: String,
         handler: @escaping (ZenohSample) -> Void
     ) throws -> any ZenohSubscriberHandle {
@@ -427,7 +427,7 @@ public class ZenohClient: ZenohClientProtocol {
     /// - Parameter keyExpr: The liveliness token key expression (e.g., "@ros2_lv/0/...")
     /// - Returns: A handle conforming to ZenohLivelinessTokenHandle
     /// - Throws: ZenohError if declaration fails
-    public func declareLivelinessToken(_ keyExpr: String) throws -> any ZenohLivelinessTokenHandle {
+    package func declareLivelinessToken(_ keyExpr: String) throws -> any ZenohLivelinessTokenHandle {
         guard let sess = session else {
             throw ZenohError.internalError("Session not open")
         }
@@ -794,7 +794,7 @@ extension ZenohClient {
     // MARK: - Queryable
 
     /// Declares a queryable on the given key expression. Mirrors `subscribe`.
-    public func declareQueryable(
+    package func declareQueryable(
         _ keyExpr: String,
         handler: @escaping @Sendable (any ZenohQueryHandle) -> Void
     ) throws -> any ZenohQueryableHandle {
@@ -825,7 +825,7 @@ extension ZenohClient {
     // MARK: - Get
 
     /// Issues a query (Service Client side) against the given key expression.
-    public func get(
+    package func get(
         keyExpr: String,
         payload: Data?,
         attachment: Data?,

--- a/Sources/SwiftROS2Zenoh/ZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/ZenohClient.swift
@@ -28,7 +28,7 @@ import SwiftROS2Transport
 // MARK: - Declared Key Expression
 
 /// Represents a declared key expression for efficient reuse
-public class DeclaredKeyExpr {
+class DeclaredKeyExpr {
     private var handle: OpaquePointer?
     private weak var session: ZenohClient?
 
@@ -54,7 +54,7 @@ public class DeclaredKeyExpr {
 // MARK: - Subscriber
 
 /// Represents an active subscription
-public class ZenohSubscriber {
+class ZenohSubscriber {
     private var handle: OpaquePointer?
     private weak var session: ZenohClient?
     private var handler: (ZenohSample) -> Void
@@ -73,7 +73,7 @@ public class ZenohSubscriber {
     }
 
     /// Closes the subscription
-    public func close() throws {
+    func close() throws {
         guard let h = handle else {
             throw ZenohError.internalError("Subscriber already closed")
         }
@@ -108,7 +108,7 @@ public class ZenohSubscriber {
 // MARK: - Liveliness Token
 
 /// Represents an active liveliness token for ROS 2 discovery
-public class LivelinessToken {
+class LivelinessToken {
     private var handle: OpaquePointer?
     private weak var session: ZenohClient?
 
@@ -118,7 +118,7 @@ public class LivelinessToken {
     }
 
     /// Closes the liveliness token
-    public func close() throws {
+    func close() throws {
         guard let h = handle else {
             throw ZenohError.internalError("Liveliness token already closed")
         }


### PR DESCRIPTION
## Summary

Cuts the 1.0.0 API freeze. Six visibility-only changes pull plumbing types out of the public surface so the SemVer 1.x stability promise can hold:

1. `TransportQoS` and `QoSPolicy` → `package` (cross-target via Swift 5.9 access modifier)
2. `DDSBridgeQoSConfig` / `DDSBridgeDiscoveryConfig` / `DDSBridgeDiscoveryMode` → `package`
3. `ZenohClientProtocol` / `DDSClientProtocol` + 10 related handle/error types → `package`
4. `EntityManager` / `GIDManager` → `package`
5. `ZenohTransportPublisher` concrete class → `internal` (`TransportPublisher` protocol stays public)
6. `DeclaredKeyExpr` / `ZenohSubscriber` / `LivelinessToken` → `internal`

End-user APIs (`ROS2Context`, `ROS2Node`, `ROS2Publisher`, `ROS2Subscription`, `ROS2Service`, `ROS2Client`, `ROS2ActionServer`, `ROS2ActionClient`, `QoSProfile`, `TransportConfig`, the concrete `ZenohClient` / `DDSClient`, and every message / service / action type) are unchanged.

Tests in the same SPM package retain access to `package` symbols natively — no `@testable import` migration needed.

Doc updates (CHANGELOG / MIGRATION / README) and the API-breakage allowlist update for the four diagnostic-reported removals ride in this PR.

**Mora exception applied:** the six candidates are mechanical visibility flips with no judgment between commits — bundled in one PR with one commit per candidate for reviewability.

## Test plan
- [x] `swift format lint --recursive --strict --configuration .swift-format Package.swift Sources Tests` — clean.
- [x] `swift build` — green.
- [x] `swift test --parallel` — 353 XCTests + 111 swift-testing tests, all pass.
- [x] `bash Scripts/diagnose-api-breaking-changes.sh 0.6.1 Scripts/api-breakage-allowlist.txt` — passes via the new allowlist entries (Candidates 5 and 6 surface as removed classes; Candidates 1–4 demotions to `package` do not surface).
- [ ] CI green on every matrix entry.