### PR TITLE
ci(windows): drop swift-crypto, use pure-Swift SHA-256

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -8,24 +8,6 @@
         "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
         "version" : "1.7.1"
       }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -252,12 +252,14 @@ var targets: [Target] = [
         path: "Tests/SwiftROS2TransportTests"
     ),
 
-    // Code generator library — IDL → Swift ROS2Message conformances
+    // Code generator library — IDL → Swift ROS2Message conformances.
+    // SHA-256 (used by RIHS01) is implemented in pure Swift inside this
+    // target so non-Apple CI matrix entries — Windows in particular —
+    // don't pay the cost of compiling swift-crypto's BoringSSL on every
+    // run. See Sources/SwiftROS2Gen/Hash/SHA256.swift.
     .target(
         name: "SwiftROS2Gen",
-        dependencies: [
-            .product(name: "Crypto", package: "swift-crypto")
-        ],
+        dependencies: [],
         path: "Sources/SwiftROS2Gen"
     ),
 
@@ -493,8 +495,7 @@ if canBuildDDS {
 let isDocsBuild = ProcessInfo.processInfo.environment["SWIFT_ROS2_DOCS_BUILD"] == "1"
 
 var packageDependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0")
 ]
 if isDocsBuild {
     packageDependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"))

--- a/Sources/SwiftROS2Gen/Hash/RIHS01.swift
+++ b/Sources/SwiftROS2Gen/Hash/RIHS01.swift
@@ -1,4 +1,3 @@
-import Crypto
 import Foundation
 
 /// Computes the RIHS01 type-hash for a ROS 2 message IR.

--- a/Sources/SwiftROS2Gen/Hash/SHA256.swift
+++ b/Sources/SwiftROS2Gen/Hash/SHA256.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Pure-Swift SHA-256 (FIPS 180-4).
+///
+/// Used by ``RIHS01`` to digest the canonical type-description JSON. We
+/// inline the algorithm rather than depend on swift-crypto so non-Apple
+/// CI matrix entries — Windows in particular — don't pay the cost of
+/// compiling BoringSSL (≈1,900 C/C++/asm units) every run. The Apple
+/// toolchain's `CryptoKit.SHA256` and swift-crypto's `Crypto.SHA256`
+/// both implement the exact same FIPS spec, so output bytes are
+/// bit-identical to either; the existing `HashGoldenTests` and
+/// `HashOracleCorpusTests` golden corpora are the regression net.
+enum SHA256 {
+
+    /// Hash arbitrary bytes and return the 32-byte digest.
+    static func hash(data: Data) -> [UInt8] {
+        var state: [UInt32] = [
+            0x6a09_e667, 0xbb67_ae85, 0x3c6e_f372, 0xa54f_f53a,
+            0x510e_527f, 0x9b05_688c, 0x1f83_d9ab, 0x5be0_cd19,
+        ]
+
+        // Pre-processing: append 0x80, pad to 56 mod 64, append 64-bit length.
+        let bitLength = UInt64(data.count) &* 8
+        var padded = Array(data)
+        padded.append(0x80)
+        while padded.count % 64 != 56 {
+            padded.append(0x00)
+        }
+        for shift in stride(from: 56, through: 0, by: -8) {
+            padded.append(UInt8((bitLength >> UInt64(shift)) & 0xff))
+        }
+
+        var w = [UInt32](repeating: 0, count: 64)
+        var blockStart = 0
+        while blockStart < padded.count {
+            for i in 0..<16 {
+                let off = blockStart + i * 4
+                w[i] =
+                    (UInt32(padded[off]) << 24)
+                    | (UInt32(padded[off + 1]) << 16)
+                    | (UInt32(padded[off + 2]) << 8)
+                    | UInt32(padded[off + 3])
+            }
+            for i in 16..<64 {
+                let s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >> 3)
+                let s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >> 10)
+                w[i] = w[i - 16] &+ s0 &+ w[i - 7] &+ s1
+            }
+
+            var a = state[0]
+            var b = state[1]
+            var c = state[2]
+            var d = state[3]
+            var e = state[4]
+            var f = state[5]
+            var g = state[6]
+            var h = state[7]
+
+            for i in 0..<64 {
+                let s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25)
+                let ch = (e & f) ^ (~e & g)
+                let temp1 = h &+ s1 &+ ch &+ k[i] &+ w[i]
+                let s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22)
+                let mj = (a & b) ^ (a & c) ^ (b & c)
+                let temp2 = s0 &+ mj
+                h = g
+                g = f
+                f = e
+                e = d &+ temp1
+                d = c
+                c = b
+                b = a
+                a = temp1 &+ temp2
+            }
+
+            state[0] = state[0] &+ a
+            state[1] = state[1] &+ b
+            state[2] = state[2] &+ c
+            state[3] = state[3] &+ d
+            state[4] = state[4] &+ e
+            state[5] = state[5] &+ f
+            state[6] = state[6] &+ g
+            state[7] = state[7] &+ h
+
+            blockStart += 64
+        }
+
+        var out: [UInt8] = []
+        out.reserveCapacity(32)
+        for word in state {
+            out.append(UInt8((word >> 24) & 0xff))
+            out.append(UInt8((word >> 16) & 0xff))
+            out.append(UInt8((word >> 8) & 0xff))
+            out.append(UInt8(word & 0xff))
+        }
+        return out
+    }
+
+    @inline(__always)
+    private static func rotr(_ x: UInt32, _ n: UInt32) -> UInt32 {
+        (x >> n) | (x << (32 - n))
+    }
+
+    private static let k: [UInt32] = [
+        0x428a_2f98, 0x7137_4491, 0xb5c0_fbcf, 0xe9b5_dba5,
+        0x3956_c25b, 0x59f1_11f1, 0x923f_82a4, 0xab1c_5ed5,
+        0xd807_aa98, 0x1283_5b01, 0x2431_85be, 0x550c_7dc3,
+        0x72be_5d74, 0x80de_b1fe, 0x9bdc_06a7, 0xc19b_f174,
+        0xe49b_69c1, 0xefbe_4786, 0x0fc1_9dc6, 0x240c_a1cc,
+        0x2de9_2c6f, 0x4a74_84aa, 0x5cb0_a9dc, 0x76f9_88da,
+        0x983e_5152, 0xa831_c66d, 0xb003_27c8, 0xbf59_7fc7,
+        0xc6e0_0bf3, 0xd5a7_9147, 0x06ca_6351, 0x1429_2967,
+        0x27b7_0a85, 0x2e1b_2138, 0x4d2c_6dfc, 0x5338_0d13,
+        0x650a_7354, 0x766a_0abb, 0x81c2_c92e, 0x9272_2c85,
+        0xa2bf_e8a1, 0xa81a_664b, 0xc24b_8b70, 0xc76c_51a3,
+        0xd192_e819, 0xd699_0624, 0xf40e_3585, 0x106a_a070,
+        0x19a4_c116, 0x1e37_6c08, 0x2748_774c, 0x34b0_bcb5,
+        0x391c_0cb3, 0x4ed8_aa4a, 0x5b9c_ca4f, 0x682e_6ff3,
+        0x748f_82ee, 0x78a5_636f, 0x84c8_7814, 0x8cc7_0208,
+        0x90be_fffa, 0xa450_6ceb, 0xbef9_a3f7, 0xc671_78f2,
+    ]
+}


### PR DESCRIPTION
## Summary

The Windows CI job in [run 25360658814](https://github.com/youtalk/swift-ros2/actions/runs/25360658814) took **30m29s** vs **6–8m** on Linux for the same workload. Build step alone was 16m40s, Test step 10m15s — almost all of which was compilation, not actual test runtime (the 111 tests themselves finished in 0.13s).

Of the 2,348 compile units invoked during a Windows build, **1,943 were BoringSSL** (.cc/.S/.c) pulled in by `swift-crypto`. `swift-crypto` was a dependency of `SwiftROS2Gen` solely so `RIHS01.swift` could call `SHA256.hash(data:)`. windows-latest's NTFS + Defender + 4-core profile turns ≈2k C/C++/asm units into a multi-minute tax that Linux runners absorb without trouble.

This PR replaces `import Crypto` with a self-contained FIPS 180-4 SHA-256 implementation in `Sources/SwiftROS2Gen/Hash/SHA256.swift` (~120 lines) and drops the `swift-crypto` package dependency entirely.

- Output bytes are bit-identical to swift-crypto's `SHA256` by spec.
- The existing 18 RIHS01 golden assertions across 6 suites (`HashGoldenTests`, `HashOracleCorpusTests`, distro/action variants) are the regression net and pass unchanged.
- No public-API impact: `Crypto` was an internal dep of `SwiftROS2Gen`, never re-exported.
- `Package.resolved` loses `swift-crypto` and the transitive `swift-asn1` pin.

## Expected effect on CI wall time

| Job | Before | Expected after |
|-----|--------|----------------|
| Build & Test (Windows x86_64) | ~30m | ~10–12m |
| Build & Test (Ubuntu × 6) | 5m26s–8m | save ~1–2m each |
| Build (Android × 2) | ~5m | save ~1–2m each |

## Test plan

- [x] `swift build` (macOS) clean
- [x] `swift test --parallel` — 111 tests / 28 suites pass (macOS)
- [x] `swift test --filter "Hash|RIHS01"` — 18 hash tests / 6 suites pass
- [x] `swift format lint --strict` clean
- [x] `bash Scripts/diagnose-api-breaking-changes.sh 0.6.1 …` — no new breakages introduced
- [ ] Verify Windows CI job is materially faster on this PR
- [ ] Verify Linux + Android matrices stay green