### PR TITLE
chore(release): pin 1.0.0 xcframework URL + checksums

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,7 +79,7 @@ let windowsCycloneDDSDir: String? = {
 // can only when `CYCLONEDDS_DIR` is set; Android never can.
 let canBuildDDS = !isAndroidBuild && (!isWindowsBuild || windowsCycloneDDSDir != nil)
 
-let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/0.9.0"
+let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/1.0.0"
 
 // Non-unix zenoh-pico platform backends shared between the Linux and
 // Android arms — both use the unix backend inside `src/system/unix`.
@@ -148,7 +148,7 @@ let cZenohPico: Target = {
         return .binaryTarget(
             name: "CZenohPico",
             url: "\(releaseBaseURL)/CZenohPico.xcframework.zip",
-            checksum: "387773222d48b06026b5560f100fc0d82a69e7447e9482fb493af2338c2992a9"
+            checksum: "f528edc8548b1a782d57b09a06fe0949ab070362aed5c6ba187a0f156524afb8"
         )
     }
 }()
@@ -359,7 +359,7 @@ if canBuildDDS {
             return .binaryTarget(
                 name: "CCycloneDDS",
                 url: "\(releaseBaseURL)/CCycloneDDS.xcframework.zip",
-                checksum: "c9f569a9ab0f90e7512410d44f8849015140b9c3c1fe557d89d8a344bd21a94b"
+                checksum: "94d98deb20f84da7c897059b32e4ae6a8002b8d845d566d416a5738c890ee52f"
             )
         }
     }()


### PR DESCRIPTION
## Summary
- Bumps `releaseBaseURL` to the 1.0.0 GitHub Release.
- Bumps `CZenohPico` and `CCycloneDDS` binaryTarget checksums against the freshly-uploaded zips.

## Test plan
- [x] `swift package reset && swift build` resolves 1.0.0 binaryTargets.
- [x] `swift test --parallel` — 111 tests pass.
- [ ] CI green.