### PR TITLE
ci: align verify-plugin-arms job name with other CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
           grep -q "BoolMsg.typeInfo.typeName" plugin-smoke.out
 
   verify-plugin-arms:
-    name: Plugin manifest resolves on all arms
+    name: Check (Plugin manifest on all arms)
     needs: [lint-swift-format]
     runs-on: macos-26
     steps:


### PR DESCRIPTION
## Summary
- Rename the `verify-plugin-arms` job from `Plugin manifest resolves on all arms` to `Check (Plugin manifest on all arms)` so it matches the `<Action> (<scope>)` shape used by every other job in `ci.yml` (`Lint (...)`, `Build (...)`, `Build & Test (...)`, `Check (API stability vs 0.6.1)`).
- No behavior change — only the display name.

## Test plan
- [ ] CI runs and the renamed job appears as `Check (Plugin manifest on all arms)` in the checks list.