### PR TITLE
feat(api): node-side parameter storage + declare/get/set (phase 2 of 6)

### DIFF
--- a/Sources/SwiftROS2/Node.swift
+++ b/Sources/SwiftROS2/Node.swift
@@ -33,6 +33,8 @@ public final class ROS2Node: @unchecked Sendable {
     private var actionClients: [AnyObject] = []
     private let lock = NSLock()
 
+    let parameterStore: ParameterStore = ParameterStore()
+
     init(
         name: String,
         namespace: String,

--- a/Sources/SwiftROS2/Parameters/Node+Parameters.swift
+++ b/Sources/SwiftROS2/Parameters/Node+Parameters.swift
@@ -10,7 +10,11 @@ extension ROS2Node {
         ignoreOverride: Bool = false  // reserved for phase 6 YAML override layer
     ) async throws -> T {
         var d = descriptor
-        if d.name.isEmpty { d.name = name }
+        // Always pin the descriptor's name to the declared name. If the caller
+        // supplied a non-empty name that differs, we silently override rather
+        // than throwing — the parameter's storage key is the canonical name
+        // and a divergent descriptor.name would later confuse describeParameter.
+        d.name = name
         if d.type == .notSet { d.type = T.parameterType }
         let stored = try await parameterStore.declare(
             name: name, value: value.parameterValue, descriptor: d)

--- a/Sources/SwiftROS2/Parameters/Node+Parameters.swift
+++ b/Sources/SwiftROS2/Parameters/Node+Parameters.swift
@@ -49,21 +49,21 @@ extension ROS2Node {
     @discardableResult
     public func setParameter(
         _ p: ROS2Parameter
-    ) async throws -> ROS2SetParametersResult {
+    ) async -> ROS2SetParametersResult {
         await parameterStore.set(p)
     }
 
     @discardableResult
     public func setParameters(
         _ ps: [ROS2Parameter]
-    ) async throws -> [ROS2SetParametersResult] {
+    ) async -> [ROS2SetParametersResult] {
         await parameterStore.setMany(ps)
     }
 
     @discardableResult
     public func setParametersAtomically(
         _ ps: [ROS2Parameter]
-    ) async throws -> ROS2SetParametersResult {
+    ) async -> ROS2SetParametersResult {
         await parameterStore.setAtomically(ps)
     }
 

--- a/Sources/SwiftROS2/Parameters/Node+Parameters.swift
+++ b/Sources/SwiftROS2/Parameters/Node+Parameters.swift
@@ -1,0 +1,75 @@
+// Public Parameter API on ROS2Node. Phase 2: storage only — no
+// services, no /parameter_events. Callbacks are deferred to phase 4.
+
+extension ROS2Node {
+    @discardableResult
+    public func declareParameter<T: ROS2ParameterConvertible>(
+        _ name: String,
+        default value: T,
+        descriptor: ROS2ParameterDescriptor = ROS2ParameterDescriptor(),
+        ignoreOverride: Bool = false  // reserved for phase 6 YAML override layer
+    ) async throws -> T {
+        var d = descriptor
+        if d.name.isEmpty { d.name = name }
+        if d.type == .notSet { d.type = T.parameterType }
+        let stored = try await parameterStore.declare(
+            name: name, value: value.parameterValue, descriptor: d)
+        return try T(parameterValue: stored)
+    }
+
+    public func undeclareParameter(_ name: String) async throws {
+        try await parameterStore.undeclare(name: name)
+    }
+
+    public func hasParameter(_ name: String) async -> Bool {
+        await parameterStore.has(name: name)
+    }
+
+    public func listParameters(
+        prefixes: [String] = [], depth: UInt64 = 0
+    ) async -> ROS2ListParametersResult {
+        await parameterStore.list(prefixes: prefixes, depth: depth)
+    }
+
+    public func getParameter(_ name: String) async throws -> ROS2Parameter {
+        try await parameterStore.get(name: name)
+    }
+
+    public func getParameterOrDefault<T: ROS2ParameterConvertible>(
+        _ name: String, default value: T
+    ) async -> T {
+        do {
+            let p = try await parameterStore.get(name: name)
+            return try T(parameterValue: p.value)
+        } catch {
+            return value
+        }
+    }
+
+    @discardableResult
+    public func setParameter(
+        _ p: ROS2Parameter
+    ) async throws -> ROS2SetParametersResult {
+        await parameterStore.set(p)
+    }
+
+    @discardableResult
+    public func setParameters(
+        _ ps: [ROS2Parameter]
+    ) async throws -> [ROS2SetParametersResult] {
+        await parameterStore.setMany(ps)
+    }
+
+    @discardableResult
+    public func setParametersAtomically(
+        _ ps: [ROS2Parameter]
+    ) async throws -> ROS2SetParametersResult {
+        await parameterStore.setAtomically(ps)
+    }
+
+    public func describeParameter(
+        _ name: String
+    ) async throws -> ROS2ParameterDescriptor {
+        try await parameterStore.describe(name: name)
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ParameterStore.swift
+++ b/Sources/SwiftROS2/Parameters/ParameterStore.swift
@@ -35,3 +35,63 @@ actor ParameterStore {
         entries[name] != nil
     }
 }
+
+extension ParameterStore {
+    func get(name: String) throws -> ROS2Parameter {
+        guard let e = entries[name] else {
+            throw ROS2ParameterError.notDeclared(name: name)
+        }
+        return ROS2Parameter(name: name, value: e.value)
+    }
+
+    func describe(name: String) throws -> ROS2ParameterDescriptor {
+        guard let e = entries[name] else {
+            throw ROS2ParameterError.notDeclared(name: name)
+        }
+        return e.descriptor
+    }
+
+    func list(prefixes: [String], depth: UInt64) -> ROS2ListParametersResult {
+        let allNames = entries.keys.sorted()
+        let matched: [String]
+        if prefixes.isEmpty {
+            matched = allNames.filter { passesDepth($0, prefix: "", depth: depth) }
+        } else {
+            matched = allNames.filter { name in
+                prefixes.contains { p in
+                    (name == p || name.hasPrefix(p + "."))
+                        && passesDepth(name, prefix: p, depth: depth)
+                }
+            }
+        }
+        let derivedPrefixes = collectPrefixes(matched)
+        return ROS2ListParametersResult(names: matched, prefixes: derivedPrefixes)
+    }
+
+    private func passesDepth(_ name: String, prefix: String, depth: UInt64) -> Bool {
+        if depth == 0 { return true }
+        let suffix: Substring
+        if prefix.isEmpty {
+            suffix = name[...]
+        } else if name == prefix {
+            return true
+        } else {
+            suffix = name.dropFirst(prefix.count + 1)  // skip "<prefix>."
+        }
+        let separators = suffix.filter { $0 == "." }.count
+        return separators < Int(depth)
+    }
+
+    private func collectPrefixes(_ names: [String]) -> [String] {
+        var seen = Set<String>()
+        for name in names {
+            var parts = name.split(separator: ".", omittingEmptySubsequences: false)
+            // every proper ancestor (drop the last segment, then the next, ...)
+            while parts.count > 1 {
+                parts.removeLast()
+                seen.insert(parts.joined(separator: "."))
+            }
+        }
+        return seen.sorted()
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ParameterStore.swift
+++ b/Sources/SwiftROS2/Parameters/ParameterStore.swift
@@ -95,3 +95,64 @@ extension ParameterStore {
         return seen.sorted()
     }
 }
+
+extension ParameterStore {
+    @discardableResult
+    func set(_ p: ROS2Parameter) -> ROS2SetParametersResult {
+        guard var entry = entries[p.name] else {
+            return .failure(reason: "parameter '\(p.name)' is not declared")
+        }
+        if let reason = validate(name: p.name, value: p.value, descriptor: entry.descriptor) {
+            return .failure(reason: reason)
+        }
+        entry.value = p.value
+        entries[p.name] = entry
+        return .success()
+    }
+
+    func setMany(_ ps: [ROS2Parameter]) -> [ROS2SetParametersResult] {
+        ps.map { set($0) }
+    }
+
+    func setAtomically(_ ps: [ROS2Parameter]) -> ROS2SetParametersResult {
+        let snapshot = entries
+        for p in ps {
+            let r = set(p)
+            if !r.successful {
+                entries = snapshot
+                return r
+            }
+        }
+        return .success()
+    }
+
+    /// Returns nil if the value is acceptable, otherwise a human-readable reason.
+    private func validate(
+        name: String,
+        value: ROS2ParameterValue,
+        descriptor: ROS2ParameterDescriptor
+    ) -> String? {
+        if descriptor.readOnly {
+            return "parameter '\(name)' is read-only"
+        }
+        let valueType = value.parameterType
+        if !descriptor.dynamicTyping
+            && descriptor.type != .notSet
+            && valueType != descriptor.type
+            && valueType != .notSet
+        {
+            return "parameter '\(name)' expects \(descriptor.type), got \(valueType)"
+        }
+        if case let .integer(v) = value, let r = descriptor.integerRange {
+            if v < r.lowerBound || v > r.upperBound {
+                return "parameter '\(name)' value \(v) out of range \(r)"
+            }
+        }
+        if case let .double(v) = value, let r = descriptor.floatingPointRange {
+            if v < r.lowerBound || v > r.upperBound {
+                return "parameter '\(name)' value \(v) out of range \(r)"
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ParameterStore.swift
+++ b/Sources/SwiftROS2/Parameters/ParameterStore.swift
@@ -21,6 +21,14 @@ actor ParameterStore {
         guard entries[name] == nil else {
             throw ROS2ParameterError.alreadyDeclared(name: name)
         }
+        // Validate the initial value against the descriptor — the same rules
+        // that gate set(_:) apply at declare time. readOnly is intentionally
+        // skipped here: declare IS the one legal write to a read-only param.
+        if let reason = validate(
+            name: name, value: value, descriptor: descriptor, allowWriteToReadOnly: true)
+        {
+            throw ROS2ParameterError.invalidValue(name: name, reason: reason)
+        }
         entries[name] = ParameterEntry(value: value, descriptor: descriptor)
         return value
     }
@@ -78,8 +86,9 @@ extension ParameterStore {
         } else {
             suffix = name.dropFirst(prefix.count + 1)  // skip "<prefix>."
         }
-        let separators = suffix.filter { $0 == "." }.count
-        return separators < Int(depth)
+        // Stay in UInt64-land so a depth > Int.max can't trap on the cast.
+        let separators = UInt64(suffix.filter { $0 == "." }.count)
+        return separators < depth
     }
 
     private func collectPrefixes(_ names: [String]) -> [String] {
@@ -102,7 +111,10 @@ extension ParameterStore {
         guard var entry = entries[p.name] else {
             return .failure(reason: "parameter '\(p.name)' is not declared")
         }
-        if let reason = validate(name: p.name, value: p.value, descriptor: entry.descriptor) {
+        if let reason = validate(
+            name: p.name, value: p.value, descriptor: entry.descriptor,
+            allowWriteToReadOnly: false)
+        {
             return .failure(reason: reason)
         }
         entry.value = p.value
@@ -127,12 +139,17 @@ extension ParameterStore {
     }
 
     /// Returns nil if the value is acceptable, otherwise a human-readable reason.
+    ///
+    /// `floatingPointStep` and `integerStep` from the descriptor are NOT
+    /// enforced here — they are advisory metadata for tools (rqt_param,
+    /// `ros2 param describe`). rclcpp follows the same convention.
     private func validate(
         name: String,
         value: ROS2ParameterValue,
-        descriptor: ROS2ParameterDescriptor
+        descriptor: ROS2ParameterDescriptor,
+        allowWriteToReadOnly: Bool
     ) -> String? {
-        if descriptor.readOnly {
+        if descriptor.readOnly && !allowWriteToReadOnly {
             return "parameter '\(name)' is read-only"
         }
         let valueType = value.parameterType

--- a/Sources/SwiftROS2/Parameters/ParameterStore.swift
+++ b/Sources/SwiftROS2/Parameters/ParameterStore.swift
@@ -1,0 +1,37 @@
+// Per-node parameter storage. Phase 2 covers declare / get / set / list /
+// describe with validation. Service registration and ParameterEvent
+// publishing land in phases 3 and 4 respectively.
+
+struct ParameterEntry: Sendable, Equatable {
+    var value: ROS2ParameterValue
+    var descriptor: ROS2ParameterDescriptor
+}
+
+actor ParameterStore {
+    private var entries: [String: ParameterEntry] = [:]
+
+    init() {}
+
+    @discardableResult
+    func declare(
+        name: String,
+        value: ROS2ParameterValue,
+        descriptor: ROS2ParameterDescriptor
+    ) throws -> ROS2ParameterValue {
+        guard entries[name] == nil else {
+            throw ROS2ParameterError.alreadyDeclared(name: name)
+        }
+        entries[name] = ParameterEntry(value: value, descriptor: descriptor)
+        return value
+    }
+
+    func undeclare(name: String) throws {
+        guard entries.removeValue(forKey: name) != nil else {
+            throw ROS2ParameterError.notDeclared(name: name)
+        }
+    }
+
+    func has(name: String) -> Bool {
+        entries[name] != nil
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ParameterStore.swift
+++ b/Sources/SwiftROS2/Parameters/ParameterStore.swift
@@ -143,12 +143,12 @@ extension ParameterStore {
         {
             return "parameter '\(name)' expects \(descriptor.type), got \(valueType)"
         }
-        if case let .integer(v) = value, let r = descriptor.integerRange {
+        if case .integer(let v) = value, let r = descriptor.integerRange {
             if v < r.lowerBound || v > r.upperBound {
                 return "parameter '\(name)' value \(v) out of range \(r)"
             }
         }
-        if case let .double(v) = value, let r = descriptor.floatingPointRange {
+        if case .double(let v) = value, let r = descriptor.floatingPointRange {
             if v < r.lowerBound || v > r.upperBound {
                 return "parameter '\(name)' value \(v) out of range \(r)"
             }

--- a/Sources/SwiftROS2/Parameters/ROS2Parameter.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2Parameter.swift
@@ -1,0 +1,9 @@
+public struct ROS2Parameter: Sendable, Equatable {
+    public let name: String
+    public let value: ROS2ParameterValue
+
+    public init(name: String, value: ROS2ParameterValue) {
+        self.name = name
+        self.value = value
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ROS2Parameter.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2Parameter.swift
@@ -1,3 +1,7 @@
+/// A name + value pair representing one ROS 2 parameter assignment.
+///
+/// Distinct from the wire-level `rcl_interfaces/msg/Parameter`, which uses
+/// the discriminator-based `ParameterValue` struct in every typed slot.
 public struct ROS2Parameter: Sendable, Equatable {
     public let name: String
     public let value: ROS2ParameterValue

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterConvertible.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterConvertible.swift
@@ -1,0 +1,144 @@
+public protocol ROS2ParameterConvertible {
+    init(parameterValue: ROS2ParameterValue) throws
+    var parameterValue: ROS2ParameterValue { get }
+    static var parameterType: ROS2ParameterType { get }
+}
+
+extension ROS2ParameterValue {
+    public var parameterType: ROS2ParameterType {
+        switch self {
+        case .notSet: return .notSet
+        case .bool: return .bool
+        case .integer: return .integer
+        case .double: return .double
+        case .string: return .string
+        case .byteArray: return .byteArray
+        case .boolArray: return .boolArray
+        case .integerArray: return .integerArray
+        case .doubleArray: return .doubleArray
+        case .stringArray: return .stringArray
+        }
+    }
+}
+
+private func mismatch(
+    _ value: ROS2ParameterValue,
+    expected: ROS2ParameterType
+) -> ROS2ParameterError {
+    .invalidType(name: "", expected: expected, got: value.parameterType)
+}
+
+extension Bool: ROS2ParameterConvertible {
+    public static var parameterType: ROS2ParameterType { .bool }
+    public init(parameterValue: ROS2ParameterValue) throws {
+        guard case let .bool(v) = parameterValue else {
+            throw mismatch(parameterValue, expected: .bool)
+        }
+        self = v
+    }
+    public var parameterValue: ROS2ParameterValue { .bool(self) }
+}
+
+extension Int64: ROS2ParameterConvertible {
+    public static var parameterType: ROS2ParameterType { .integer }
+    public init(parameterValue: ROS2ParameterValue) throws {
+        guard case let .integer(v) = parameterValue else {
+            throw mismatch(parameterValue, expected: .integer)
+        }
+        self = v
+    }
+    public var parameterValue: ROS2ParameterValue { .integer(self) }
+}
+
+extension Int: ROS2ParameterConvertible {
+    public static var parameterType: ROS2ParameterType { .integer }
+    public init(parameterValue: ROS2ParameterValue) throws {
+        guard case let .integer(v) = parameterValue else {
+            throw mismatch(parameterValue, expected: .integer)
+        }
+        self = Int(v)
+    }
+    public var parameterValue: ROS2ParameterValue { .integer(Int64(self)) }
+}
+
+extension Double: ROS2ParameterConvertible {
+    public static var parameterType: ROS2ParameterType { .double }
+    public init(parameterValue: ROS2ParameterValue) throws {
+        guard case let .double(v) = parameterValue else {
+            throw mismatch(parameterValue, expected: .double)
+        }
+        self = v
+    }
+    public var parameterValue: ROS2ParameterValue { .double(self) }
+}
+
+extension String: ROS2ParameterConvertible {
+    public static var parameterType: ROS2ParameterType { .string }
+    public init(parameterValue: ROS2ParameterValue) throws {
+        guard case let .string(v) = parameterValue else {
+            throw mismatch(parameterValue, expected: .string)
+        }
+        self = v
+    }
+    public var parameterValue: ROS2ParameterValue { .string(self) }
+}
+
+extension Array: ROS2ParameterConvertible where Element == UInt8 {
+    public static var parameterType: ROS2ParameterType { .byteArray }
+    public init(parameterValue: ROS2ParameterValue) throws {
+        guard case let .byteArray(v) = parameterValue else {
+            throw mismatch(parameterValue, expected: .byteArray)
+        }
+        self = v
+    }
+    public var parameterValue: ROS2ParameterValue { .byteArray(self) }
+}
+
+// The four below are NOT protocol conformances — Swift forbids multiple
+// conditional conformances of Array to the same protocol. They expose the
+// same shape (parameterValue getter, throwing init from ROS2ParameterValue)
+// so caller code reads the same.
+
+extension Array where Element == Bool {
+    public var parameterValue: ROS2ParameterValue { .boolArray(self) }
+    public init(parameterValue: ROS2ParameterValue) throws {
+        guard case let .boolArray(v) = parameterValue else {
+            throw ROS2ParameterError.invalidType(
+                name: "", expected: .boolArray, got: parameterValue.parameterType)
+        }
+        self = v
+    }
+}
+
+extension Array where Element == Int64 {
+    public var parameterValue: ROS2ParameterValue { .integerArray(self) }
+    public init(parameterValue: ROS2ParameterValue) throws {
+        guard case let .integerArray(v) = parameterValue else {
+            throw ROS2ParameterError.invalidType(
+                name: "", expected: .integerArray, got: parameterValue.parameterType)
+        }
+        self = v
+    }
+}
+
+extension Array where Element == Double {
+    public var parameterValue: ROS2ParameterValue { .doubleArray(self) }
+    public init(parameterValue: ROS2ParameterValue) throws {
+        guard case let .doubleArray(v) = parameterValue else {
+            throw ROS2ParameterError.invalidType(
+                name: "", expected: .doubleArray, got: parameterValue.parameterType)
+        }
+        self = v
+    }
+}
+
+extension Array where Element == String {
+    public var parameterValue: ROS2ParameterValue { .stringArray(self) }
+    public init(parameterValue: ROS2ParameterValue) throws {
+        guard case let .stringArray(v) = parameterValue else {
+            throw ROS2ParameterError.invalidType(
+                name: "", expected: .stringArray, got: parameterValue.parameterType)
+        }
+        self = v
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterConvertible.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterConvertible.swift
@@ -1,3 +1,12 @@
+/// Protocol that lets a Swift native type be used wherever a
+/// `ROS2ParameterValue` is expected (e.g. `declareParameter("rate", default: 30)`
+/// without wrapping in `.integer(30)`).
+///
+/// Conformances ship for `Bool`, `Int`, `Int64`, `Double`, `String`, and
+/// `[UInt8]`. The other array element types (`[Bool]`, `[Int64]`,
+/// `[Double]`, `[String]`) get the same `parameterValue` getter and
+/// throwing init via plain extensions because Swift does not allow
+/// multiple conditional conformances of `Array` to the same protocol.
 public protocol ROS2ParameterConvertible {
     init(parameterValue: ROS2ParameterValue) throws
     var parameterValue: ROS2ParameterValue { get }
@@ -56,7 +65,13 @@ extension Int: ROS2ParameterConvertible {
         guard case .integer(let v) = parameterValue else {
             throw mismatch(parameterValue, expected: .integer)
         }
-        self = Int(v)
+        // On 32-bit platforms `Int(v)` traps for out-of-range values; use
+        // Int(exactly:) so overflow surfaces as a typed error.
+        guard let narrowed = Int(exactly: v) else {
+            throw ROS2ParameterError.invalidValue(
+                name: "", reason: "integer \(v) does not fit in Int on this platform")
+        }
+        self = narrowed
     }
     public var parameterValue: ROS2ParameterValue { .integer(Int64(self)) }
 }

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterConvertible.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterConvertible.swift
@@ -31,7 +31,7 @@ private func mismatch(
 extension Bool: ROS2ParameterConvertible {
     public static var parameterType: ROS2ParameterType { .bool }
     public init(parameterValue: ROS2ParameterValue) throws {
-        guard case let .bool(v) = parameterValue else {
+        guard case .bool(let v) = parameterValue else {
             throw mismatch(parameterValue, expected: .bool)
         }
         self = v
@@ -42,7 +42,7 @@ extension Bool: ROS2ParameterConvertible {
 extension Int64: ROS2ParameterConvertible {
     public static var parameterType: ROS2ParameterType { .integer }
     public init(parameterValue: ROS2ParameterValue) throws {
-        guard case let .integer(v) = parameterValue else {
+        guard case .integer(let v) = parameterValue else {
             throw mismatch(parameterValue, expected: .integer)
         }
         self = v
@@ -53,7 +53,7 @@ extension Int64: ROS2ParameterConvertible {
 extension Int: ROS2ParameterConvertible {
     public static var parameterType: ROS2ParameterType { .integer }
     public init(parameterValue: ROS2ParameterValue) throws {
-        guard case let .integer(v) = parameterValue else {
+        guard case .integer(let v) = parameterValue else {
             throw mismatch(parameterValue, expected: .integer)
         }
         self = Int(v)
@@ -64,7 +64,7 @@ extension Int: ROS2ParameterConvertible {
 extension Double: ROS2ParameterConvertible {
     public static var parameterType: ROS2ParameterType { .double }
     public init(parameterValue: ROS2ParameterValue) throws {
-        guard case let .double(v) = parameterValue else {
+        guard case .double(let v) = parameterValue else {
             throw mismatch(parameterValue, expected: .double)
         }
         self = v
@@ -75,7 +75,7 @@ extension Double: ROS2ParameterConvertible {
 extension String: ROS2ParameterConvertible {
     public static var parameterType: ROS2ParameterType { .string }
     public init(parameterValue: ROS2ParameterValue) throws {
-        guard case let .string(v) = parameterValue else {
+        guard case .string(let v) = parameterValue else {
             throw mismatch(parameterValue, expected: .string)
         }
         self = v
@@ -86,7 +86,7 @@ extension String: ROS2ParameterConvertible {
 extension Array: ROS2ParameterConvertible where Element == UInt8 {
     public static var parameterType: ROS2ParameterType { .byteArray }
     public init(parameterValue: ROS2ParameterValue) throws {
-        guard case let .byteArray(v) = parameterValue else {
+        guard case .byteArray(let v) = parameterValue else {
             throw mismatch(parameterValue, expected: .byteArray)
         }
         self = v
@@ -102,7 +102,7 @@ extension Array: ROS2ParameterConvertible where Element == UInt8 {
 extension Array where Element == Bool {
     public var parameterValue: ROS2ParameterValue { .boolArray(self) }
     public init(parameterValue: ROS2ParameterValue) throws {
-        guard case let .boolArray(v) = parameterValue else {
+        guard case .boolArray(let v) = parameterValue else {
             throw ROS2ParameterError.invalidType(
                 name: "", expected: .boolArray, got: parameterValue.parameterType)
         }
@@ -113,7 +113,7 @@ extension Array where Element == Bool {
 extension Array where Element == Int64 {
     public var parameterValue: ROS2ParameterValue { .integerArray(self) }
     public init(parameterValue: ROS2ParameterValue) throws {
-        guard case let .integerArray(v) = parameterValue else {
+        guard case .integerArray(let v) = parameterValue else {
             throw ROS2ParameterError.invalidType(
                 name: "", expected: .integerArray, got: parameterValue.parameterType)
         }
@@ -124,7 +124,7 @@ extension Array where Element == Int64 {
 extension Array where Element == Double {
     public var parameterValue: ROS2ParameterValue { .doubleArray(self) }
     public init(parameterValue: ROS2ParameterValue) throws {
-        guard case let .doubleArray(v) = parameterValue else {
+        guard case .doubleArray(let v) = parameterValue else {
             throw ROS2ParameterError.invalidType(
                 name: "", expected: .doubleArray, got: parameterValue.parameterType)
         }
@@ -135,7 +135,7 @@ extension Array where Element == Double {
 extension Array where Element == String {
     public var parameterValue: ROS2ParameterValue { .stringArray(self) }
     public init(parameterValue: ROS2ParameterValue) throws {
-        guard case let .stringArray(v) = parameterValue else {
+        guard case .stringArray(let v) = parameterValue else {
             throw ROS2ParameterError.invalidType(
                 name: "", expected: .stringArray, got: parameterValue.parameterType)
         }

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterDescriptor.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterDescriptor.swift
@@ -1,3 +1,10 @@
+/// Descriptor metadata that travels with a declared parameter.
+///
+/// Mirrors `rcl_interfaces/msg/ParameterDescriptor` but uses Swift-idiomatic
+/// `ClosedRange` plus optional `step` instead of the wire's bounded ≤ 1
+/// `[FloatingPointRange]` / `[IntegerRange]` sequences. The `step` fields
+/// are advisory — they cross the wire for tools to consume but are not
+/// enforced by `ParameterStore` (matching rclcpp behavior).
 public struct ROS2ParameterDescriptor: Sendable, Equatable {
     public var name: String
     public var type: ROS2ParameterType

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterDescriptor.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterDescriptor.swift
@@ -1,0 +1,36 @@
+public struct ROS2ParameterDescriptor: Sendable, Equatable {
+    public var name: String
+    public var type: ROS2ParameterType
+    public var description: String
+    public var additionalConstraints: String
+    public var readOnly: Bool
+    public var dynamicTyping: Bool
+    public var floatingPointRange: ClosedRange<Double>?
+    public var floatingPointStep: Double?
+    public var integerRange: ClosedRange<Int64>?
+    public var integerStep: Int64?
+
+    public init(
+        name: String = "",
+        type: ROS2ParameterType = .notSet,
+        description: String = "",
+        additionalConstraints: String = "",
+        readOnly: Bool = false,
+        dynamicTyping: Bool = false,
+        floatingPointRange: ClosedRange<Double>? = nil,
+        floatingPointStep: Double? = nil,
+        integerRange: ClosedRange<Int64>? = nil,
+        integerStep: Int64? = nil
+    ) {
+        self.name = name
+        self.type = type
+        self.description = description
+        self.additionalConstraints = additionalConstraints
+        self.readOnly = readOnly
+        self.dynamicTyping = dynamicTyping
+        self.floatingPointRange = floatingPointRange
+        self.floatingPointStep = floatingPointStep
+        self.integerRange = integerRange
+        self.integerStep = integerStep
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterError.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterError.swift
@@ -1,0 +1,10 @@
+public enum ROS2ParameterError: Error, Sendable, Equatable {
+    case alreadyDeclared(name: String)
+    case notDeclared(name: String)
+    case invalidType(
+        name: String, expected: ROS2ParameterType, got: ROS2ParameterType)
+    case invalidValue(name: String, reason: String)
+    case immutableTypeChange(name: String)
+    case outOfRange(name: String, reason: String)
+    case readOnly(name: String)
+}

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterError.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterError.swift
@@ -1,3 +1,9 @@
+/// Typed errors thrown by the throwing parameter APIs (`declareParameter`,
+/// `undeclareParameter`, `getParameter`, `describeParameter`).
+///
+/// Non-throwing APIs such as `setParameter` surface failures via
+/// `ROS2SetParametersResult` instead; the `reason` string there is built
+/// from the same vocabulary as these cases.
 public enum ROS2ParameterError: Error, Sendable, Equatable {
     case alreadyDeclared(name: String)
     case notDeclared(name: String)

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterResults.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterResults.swift
@@ -1,0 +1,27 @@
+public struct ROS2SetParametersResult: Sendable, Equatable {
+    public var successful: Bool
+    public var reason: String
+
+    public init(successful: Bool, reason: String = "") {
+        self.successful = successful
+        self.reason = reason
+    }
+
+    public static func success() -> ROS2SetParametersResult {
+        ROS2SetParametersResult(successful: true)
+    }
+
+    public static func failure(reason: String) -> ROS2SetParametersResult {
+        ROS2SetParametersResult(successful: false, reason: reason)
+    }
+}
+
+public struct ROS2ListParametersResult: Sendable, Equatable {
+    public var names: [String]
+    public var prefixes: [String]
+
+    public init(names: [String] = [], prefixes: [String] = []) {
+        self.names = names
+        self.prefixes = prefixes
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterResults.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterResults.swift
@@ -1,3 +1,9 @@
+/// Outcome of a single attempted parameter set.
+///
+/// Mirrors `rcl_interfaces/msg/SetParametersResult` — failures are reported
+/// via `successful = false` plus a human-readable `reason`, never via thrown
+/// errors. This matches what crosses the wire from the parameter services
+/// added in phase 3.
 public struct ROS2SetParametersResult: Sendable, Equatable {
     public var successful: Bool
     public var reason: String
@@ -16,6 +22,11 @@ public struct ROS2SetParametersResult: Sendable, Equatable {
     }
 }
 
+/// Result of a `listParameters` query.
+///
+/// `names` is the matched flat parameter names; `prefixes` is every distinct
+/// dotted ancestor seen across those names (sorted, deduplicated). Mirrors
+/// `rcl_interfaces/msg/ListParametersResult`.
 public struct ROS2ListParametersResult: Sendable, Equatable {
     public var names: [String]
     public var prefixes: [String]

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterType.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterType.swift
@@ -1,0 +1,12 @@
+public enum ROS2ParameterType: UInt8, Sendable, CaseIterable {
+    case notSet = 0
+    case bool = 1
+    case integer = 2
+    case double = 3
+    case string = 4
+    case byteArray = 5
+    case boolArray = 6
+    case integerArray = 7
+    case doubleArray = 8
+    case stringArray = 9
+}

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterType.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterType.swift
@@ -1,3 +1,7 @@
+/// Discriminator for the ten ROS 2 parameter value categories.
+///
+/// Raw values match the `rcl_interfaces/msg/ParameterType` constants used
+/// over the wire (`PARAMETER_NOT_SET = 0` … `PARAMETER_STRING_ARRAY = 9`).
 public enum ROS2ParameterType: UInt8, Sendable, CaseIterable {
     case notSet = 0
     case bool = 1

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterValue.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterValue.swift
@@ -1,8 +1,11 @@
-// Public Swift-side parameter value enum.
 // The wire-level rcl_interfaces.ParameterValue uses a uint8 discriminator
 // + nine fixed-name typed slots; we hide that in WireBridge.swift and
 // give callers a Swift-shaped sum type.
 
+/// Type-erased value of a ROS 2 parameter.
+///
+/// Mirrors the nine typed slots of `rcl_interfaces/msg/ParameterValue` plus
+/// a `notSet` case for absent or default-constructed values.
 public enum ROS2ParameterValue: Sendable, Equatable {
     case notSet
     case bool(Bool)

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterValue.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterValue.swift
@@ -1,0 +1,17 @@
+// Public Swift-side parameter value enum.
+// The wire-level rcl_interfaces.ParameterValue uses a uint8 discriminator
+// + nine fixed-name typed slots; we hide that in WireBridge.swift and
+// give callers a Swift-shaped sum type.
+
+public enum ROS2ParameterValue: Sendable, Equatable {
+    case notSet
+    case bool(Bool)
+    case integer(Int64)
+    case double(Double)
+    case string(String)
+    case byteArray([UInt8])
+    case boolArray([Bool])
+    case integerArray([Int64])
+    case doubleArray([Double])
+    case stringArray([String])
+}

--- a/Sources/SwiftROS2/Parameters/WireBridge.swift
+++ b/Sources/SwiftROS2/Parameters/WireBridge.swift
@@ -79,6 +79,11 @@ extension ROS2ParameterDescriptor {
         )
     }
 
+    // Step is meaningful only paired with a range. The wire's `IntegerRange` /
+    // `FloatingPointRange` carries from/to/step together — there is no slot
+    // for a free-standing step. If the caller sets a step but no range,
+    // the step is intentionally not encoded; document via the type rather
+    // than asserting at runtime.
     func toWire() -> SwiftROS2Messages.ParameterDescriptor {
         var w = SwiftROS2Messages.ParameterDescriptor()
         w.name = name

--- a/Sources/SwiftROS2/Parameters/WireBridge.swift
+++ b/Sources/SwiftROS2/Parameters/WireBridge.swift
@@ -104,3 +104,13 @@ extension ROS2ParameterDescriptor {
         return w
     }
 }
+
+extension ROS2Parameter {
+    init(wire: SwiftROS2Messages.Parameter) {
+        self.init(name: wire.name, value: ROS2ParameterValue(wire: wire.value))
+    }
+
+    func toWire() -> SwiftROS2Messages.Parameter {
+        SwiftROS2Messages.Parameter(name: name, value: value.toWire())
+    }
+}

--- a/Sources/SwiftROS2/Parameters/WireBridge.swift
+++ b/Sources/SwiftROS2/Parameters/WireBridge.swift
@@ -58,6 +58,10 @@ extension ROS2ParameterValue {
 }
 
 extension ROS2ParameterDescriptor {
+    // The wire `IntegerRange.step` is `uint64`; our `integerStep` is
+    // `Int64?` to match Swift convention. We round-trip through the bit
+    // pattern so the encode/decode pair is lossless even for negative
+    // step values (which are nonsensical but valid on the wire).
     init(wire: SwiftROS2Messages.ParameterDescriptor) {
         let floating = wire.floatingPointRange.first
         let integer = wire.integerRange.first

--- a/Sources/SwiftROS2/Parameters/WireBridge.swift
+++ b/Sources/SwiftROS2/Parameters/WireBridge.swift
@@ -1,0 +1,58 @@
+// Translation between the Swift-public ROS2* types and the
+// SwiftROS2Messages.rcl_interfaces wire types. The wire types use
+// uint8 discriminators + fixed-name typed slots; we hide that here.
+
+import SwiftROS2Messages
+
+extension ROS2ParameterValue {
+    init(wire: SwiftROS2Messages.ParameterValue) {
+        switch wire.type {
+        case 1: self = .bool(wire.boolValue)
+        case 2: self = .integer(wire.integerValue)
+        case 3: self = .double(wire.doubleValue)
+        case 4: self = .string(wire.stringValue)
+        case 5: self = .byteArray(wire.byteArrayValue)
+        case 6: self = .boolArray(wire.boolArrayValue)
+        case 7: self = .integerArray(wire.integerArrayValue)
+        case 8: self = .doubleArray(wire.doubleArrayValue)
+        case 9: self = .stringArray(wire.stringArrayValue)
+        default: self = .notSet
+        }
+    }
+
+    func toWire() -> SwiftROS2Messages.ParameterValue {
+        var w = SwiftROS2Messages.ParameterValue()
+        switch self {
+        case .notSet:
+            w.type = 0
+        case .bool(let v):
+            w.type = 1
+            w.boolValue = v
+        case .integer(let v):
+            w.type = 2
+            w.integerValue = v
+        case .double(let v):
+            w.type = 3
+            w.doubleValue = v
+        case .string(let v):
+            w.type = 4
+            w.stringValue = v
+        case .byteArray(let v):
+            w.type = 5
+            w.byteArrayValue = v
+        case .boolArray(let v):
+            w.type = 6
+            w.boolArrayValue = v
+        case .integerArray(let v):
+            w.type = 7
+            w.integerArrayValue = v
+        case .doubleArray(let v):
+            w.type = 8
+            w.doubleArrayValue = v
+        case .stringArray(let v):
+            w.type = 9
+            w.stringArrayValue = v
+        }
+        return w
+    }
+}

--- a/Sources/SwiftROS2/Parameters/WireBridge.swift
+++ b/Sources/SwiftROS2/Parameters/WireBridge.swift
@@ -56,3 +56,51 @@ extension ROS2ParameterValue {
         return w
     }
 }
+
+extension ROS2ParameterDescriptor {
+    init(wire: SwiftROS2Messages.ParameterDescriptor) {
+        let floating = wire.floatingPointRange.first
+        let integer = wire.integerRange.first
+        self.init(
+            name: wire.name,
+            type: ROS2ParameterType(rawValue: wire.type) ?? .notSet,
+            description: wire.description,
+            additionalConstraints: wire.additionalConstraints,
+            readOnly: wire.readOnly,
+            dynamicTyping: wire.dynamicTyping,
+            floatingPointRange: floating.map { $0.fromValue...$0.toValue },
+            floatingPointStep: floating.map { $0.step },
+            integerRange: integer.map { $0.fromValue...$0.toValue },
+            integerStep: integer.map { Int64(bitPattern: $0.step) }
+        )
+    }
+
+    func toWire() -> SwiftROS2Messages.ParameterDescriptor {
+        var w = SwiftROS2Messages.ParameterDescriptor()
+        w.name = name
+        w.type = type.rawValue
+        w.description = description
+        w.additionalConstraints = additionalConstraints
+        w.readOnly = readOnly
+        w.dynamicTyping = dynamicTyping
+        if let r = floatingPointRange {
+            w.floatingPointRange = [
+                SwiftROS2Messages.FloatingPointRange(
+                    fromValue: r.lowerBound,
+                    toValue: r.upperBound,
+                    step: floatingPointStep ?? 0.0
+                )
+            ]
+        }
+        if let r = integerRange {
+            w.integerRange = [
+                SwiftROS2Messages.IntegerRange(
+                    fromValue: r.lowerBound,
+                    toValue: r.upperBound,
+                    step: integerStep.map { UInt64(bitPattern: $0) } ?? 0
+                )
+            ]
+        }
+        return w
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/NodeParametersTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/NodeParametersTests.swift
@@ -1,0 +1,74 @@
+import SwiftROS2Transport
+import XCTest
+
+@testable import SwiftROS2
+
+final class NodeParametersTests: XCTestCase {
+    private func makeContext() async throws -> ROS2Context {
+        let config = TransportConfig.zenoh(locator: "tcp/mock:7447")
+        return try await ROS2Context(transport: config, session: MockTransportSession())
+    }
+
+    func testDeclareAndGet() async throws {
+        let ctx = try await makeContext()
+        let node = try await ctx.createNode(name: "node_params_test")
+
+        let stored = try await node.declareParameter(
+            "rate", default: Int64(30))
+        XCTAssertEqual(stored, 30)
+
+        let p = try await node.getParameter("rate")
+        XCTAssertEqual(p, ROS2Parameter(name: "rate", value: .integer(30)))
+    }
+
+    func testHasParameter() async throws {
+        let ctx = try await makeContext()
+        let node = try await ctx.createNode(name: "node_params_has")
+        let before = await node.hasParameter("nope")
+        XCTAssertFalse(before)
+        _ = try await node.declareParameter("rate", default: Int64(1))
+        let after = await node.hasParameter("rate")
+        XCTAssertTrue(after)
+    }
+
+    func testSetWithRange() async throws {
+        let ctx = try await makeContext()
+        let node = try await ctx.createNode(name: "node_params_range")
+        _ = try await node.declareParameter(
+            "rate",
+            default: Int64(30),
+            descriptor: ROS2ParameterDescriptor(
+                name: "rate", type: .integer, integerRange: 1...120))
+
+        let ok = try await node.setParameter(
+            ROS2Parameter(name: "rate", value: .integer(60)))
+        XCTAssertTrue(ok.successful)
+
+        let bad = try await node.setParameter(
+            ROS2Parameter(name: "rate", value: .integer(999)))
+        XCTAssertFalse(bad.successful)
+    }
+
+    func testListAndDescribe() async throws {
+        let ctx = try await makeContext()
+        let node = try await ctx.createNode(name: "node_params_list")
+        _ = try await node.declareParameter(
+            "rate",
+            default: Int64(30),
+            descriptor: ROS2ParameterDescriptor(name: "rate", type: .integer))
+        _ = try await node.declareParameter("alpha", default: 0.5)
+
+        let list = await node.listParameters()
+        XCTAssertEqual(Set(list.names), ["alpha", "rate"])
+
+        let d = try await node.describeParameter("rate")
+        XCTAssertEqual(d.type, .integer)
+    }
+
+    func testGetParameterOrDefaultFallback() async throws {
+        let ctx = try await makeContext()
+        let node = try await ctx.createNode(name: "node_params_default")
+        let v = await node.getParameterOrDefault("missing", default: Int64(7))
+        XCTAssertEqual(v, 7)
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/NodeParametersTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/NodeParametersTests.swift
@@ -40,11 +40,11 @@ final class NodeParametersTests: XCTestCase {
             descriptor: ROS2ParameterDescriptor(
                 name: "rate", type: .integer, integerRange: 1...120))
 
-        let ok = try await node.setParameter(
+        let ok = await node.setParameter(
             ROS2Parameter(name: "rate", value: .integer(60)))
         XCTAssertTrue(ok.successful)
 
-        let bad = try await node.setParameter(
+        let bad = await node.setParameter(
             ROS2Parameter(name: "rate", value: .integer(999)))
         XCTAssertFalse(bad.successful)
     }

--- a/Tests/SwiftROS2Tests/Parameters/NodeParametersTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/NodeParametersTests.swift
@@ -71,4 +71,18 @@ final class NodeParametersTests: XCTestCase {
         let v = await node.getParameterOrDefault("missing", default: Int64(7))
         XCTAssertEqual(v, 7)
     }
+
+    func testDeclareOverridesNonEmptyDescriptorName() async throws {
+        // If the caller passes a descriptor whose .name disagrees with the
+        // declared key, the key wins — describeParameter must then report
+        // the same name we declared under.
+        let ctx = try await makeContext()
+        let node = try await ctx.createNode(name: "node_params_name_override")
+        _ = try await node.declareParameter(
+            "rate",
+            default: Int64(30),
+            descriptor: ROS2ParameterDescriptor(name: "fps", type: .integer))
+        let d = try await node.describeParameter("rate")
+        XCTAssertEqual(d.name, "rate")
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
@@ -231,4 +231,61 @@ final class ParameterStoreTests: XCTestCase {
         XCTAssertEqual(a.value, .integer(0), "a must have rolled back")
         XCTAssertEqual(b.value, .integer(0))
     }
+
+    // MARK: - declare-time validation (added in PR #103 review)
+
+    func testDeclareRejectsTypeMismatch() async {
+        let store = ParameterStore()
+        do {
+            _ = try await store.declare(
+                name: "rate", value: .string("30"),
+                descriptor: ROS2ParameterDescriptor(name: "rate", type: .integer))
+            XCTFail("expected invalidValue")
+        } catch let e as ROS2ParameterError {
+            guard case .invalidValue = e else {
+                XCTFail("wrong case: \(e)")
+                return
+            }
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testDeclareRejectsOutOfRangeDefault() async {
+        let store = ParameterStore()
+        do {
+            _ = try await store.declare(
+                name: "rate", value: .integer(999),
+                descriptor: ROS2ParameterDescriptor(
+                    name: "rate", type: .integer, integerRange: 1...120))
+            XCTFail("expected invalidValue")
+        } catch let e as ROS2ParameterError {
+            guard case .invalidValue = e else {
+                XCTFail("wrong case: \(e)")
+                return
+            }
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testDeclareAllowsReadOnlyInitialValue() async throws {
+        // declare IS the one legal write to a read-only parameter.
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "k", value: .string("v"),
+            descriptor: ROS2ParameterDescriptor(
+                name: "k", type: .string, readOnly: true))
+        let p = try await store.get(name: "k")
+        XCTAssertEqual(p.value, .string("v"))
+    }
+
+    func testListWithDepthGreaterThanIntMaxDoesNotTrap() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "a", value: .integer(0),
+            descriptor: ROS2ParameterDescriptor(name: "a", type: .integer))
+        let r = await store.list(prefixes: [], depth: UInt64.max)
+        XCTAssertEqual(r.names, ["a"])
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
@@ -52,4 +52,64 @@ final class ParameterStoreTests: XCTestCase {
             XCTFail("wrong error: \(error)")
         }
     }
+
+    func testGetReturnsValue() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "rate", value: .integer(30),
+            descriptor: ROS2ParameterDescriptor(name: "rate", type: .integer))
+        let p = try await store.get(name: "rate")
+        XCTAssertEqual(p, ROS2Parameter(name: "rate", value: .integer(30)))
+    }
+
+    func testGetUnknownThrows() async {
+        let store = ParameterStore()
+        do {
+            _ = try await store.get(name: "rate")
+            XCTFail("expected notDeclared")
+        } catch let e as ROS2ParameterError {
+            XCTAssertEqual(e, .notDeclared(name: "rate"))
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testDescribeReturnsDescriptor() async throws {
+        let store = ParameterStore()
+        let d = ROS2ParameterDescriptor(
+            name: "rate", type: .integer, integerRange: 1...120)
+        _ = try await store.declare(
+            name: "rate", value: .integer(30), descriptor: d)
+        let got = try await store.describe(name: "rate")
+        XCTAssertEqual(got, d)
+    }
+
+    func testListAllNoPrefix() async throws {
+        let store = try await populated()
+        let r = await store.list(prefixes: [], depth: 0)
+        XCTAssertEqual(Set(r.names), ["a", "b.c", "b.d.e"])
+    }
+
+    func testListByPrefix() async throws {
+        let store = try await populated()
+        let r = await store.list(prefixes: ["b"], depth: 0)
+        XCTAssertEqual(Set(r.names), ["b.c", "b.d.e"])
+    }
+
+    func testListByPrefixWithDepth() async throws {
+        let store = try await populated()
+        // depth=1 means "no further . separators after the prefix"
+        // so "b.c" matches but "b.d.e" does not.
+        let r = await store.list(prefixes: ["b"], depth: 1)
+        XCTAssertEqual(Set(r.names), ["b.c"])
+    }
+
+    private func populated() async throws -> ParameterStore {
+        let s = ParameterStore()
+        let d = ROS2ParameterDescriptor()
+        _ = try await s.declare(name: "a", value: .integer(1), descriptor: d)
+        _ = try await s.declare(name: "b.c", value: .integer(2), descriptor: d)
+        _ = try await s.declare(name: "b.d.e", value: .integer(3), descriptor: d)
+        return s
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
@@ -112,4 +112,123 @@ final class ParameterStoreTests: XCTestCase {
         _ = try await s.declare(name: "b.d.e", value: .integer(3), descriptor: d)
         return s
     }
+
+    func testSetExistingValue() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "rate", value: .integer(30),
+            descriptor: ROS2ParameterDescriptor(name: "rate", type: .integer))
+        let r = await store.set(
+            ROS2Parameter(name: "rate", value: .integer(60)))
+        XCTAssertTrue(r.successful)
+        let p = try await store.get(name: "rate")
+        XCTAssertEqual(p.value, .integer(60))
+    }
+
+    func testSetUnknownFails() async {
+        let store = ParameterStore()
+        let r = await store.set(
+            ROS2Parameter(name: "rate", value: .integer(30)))
+        XCTAssertFalse(r.successful)
+        XCTAssertTrue(r.reason.contains("rate"))
+    }
+
+    func testSetReadOnlyFails() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "k", value: .string("v"),
+            descriptor: ROS2ParameterDescriptor(
+                name: "k", type: .string, readOnly: true))
+        let r = await store.set(
+            ROS2Parameter(name: "k", value: .string("w")))
+        XCTAssertFalse(r.successful)
+        XCTAssertTrue(r.reason.contains("read"))
+    }
+
+    func testSetWrongTypeFailsWhenNotDynamic() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "rate", value: .integer(30),
+            descriptor: ROS2ParameterDescriptor(name: "rate", type: .integer))
+        let r = await store.set(
+            ROS2Parameter(name: "rate", value: .string("nope")))
+        XCTAssertFalse(r.successful)
+    }
+
+    func testSetWrongTypeAllowedWhenDynamic() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "k", value: .integer(0),
+            descriptor: ROS2ParameterDescriptor(
+                name: "k", type: .integer, dynamicTyping: true))
+        let r = await store.set(
+            ROS2Parameter(name: "k", value: .string("hi")))
+        XCTAssertTrue(r.successful)
+    }
+
+    func testSetIntegerOutOfRange() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "rate", value: .integer(30),
+            descriptor: ROS2ParameterDescriptor(
+                name: "rate", type: .integer, integerRange: 1...120))
+        let r = await store.set(
+            ROS2Parameter(name: "rate", value: .integer(999)))
+        XCTAssertFalse(r.successful)
+        XCTAssertTrue(r.reason.contains("range"))
+    }
+
+    func testSetDoubleOutOfRange() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "g", value: .double(0.5),
+            descriptor: ROS2ParameterDescriptor(
+                name: "g", type: .double, floatingPointRange: 0.0...1.0))
+        let r = await store.set(
+            ROS2Parameter(name: "g", value: .double(2.0)))
+        XCTAssertFalse(r.successful)
+    }
+
+    func testSetManyReportsPerEntry() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "a", value: .integer(0),
+            descriptor: ROS2ParameterDescriptor(name: "a", type: .integer))
+        _ = try await store.declare(
+            name: "b", value: .integer(0),
+            descriptor: ROS2ParameterDescriptor(
+                name: "b", type: .integer, integerRange: 0...10))
+        let rs = await store.setMany([
+            ROS2Parameter(name: "a", value: .integer(5)),
+            ROS2Parameter(name: "b", value: .integer(999)),
+        ])
+        XCTAssertEqual(rs.count, 2)
+        XCTAssertTrue(rs[0].successful)
+        XCTAssertFalse(rs[1].successful)
+        // a should be applied even though b failed
+        let a = try await store.get(name: "a")
+        let b = try await store.get(name: "b")
+        XCTAssertEqual(a.value, .integer(5))
+        XCTAssertEqual(b.value, .integer(0))
+    }
+
+    func testSetAtomicallyRollsBack() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "a", value: .integer(0),
+            descriptor: ROS2ParameterDescriptor(name: "a", type: .integer))
+        _ = try await store.declare(
+            name: "b", value: .integer(0),
+            descriptor: ROS2ParameterDescriptor(
+                name: "b", type: .integer, integerRange: 0...10))
+        let r = await store.setAtomically([
+            ROS2Parameter(name: "a", value: .integer(5)),
+            ROS2Parameter(name: "b", value: .integer(999)),
+        ])
+        XCTAssertFalse(r.successful)
+        let a = try await store.get(name: "a")
+        let b = try await store.get(name: "b")
+        XCTAssertEqual(a.value, .integer(0), "a must have rolled back")
+        XCTAssertEqual(b.value, .integer(0))
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+
+@testable import SwiftROS2
+
+final class ParameterStoreTests: XCTestCase {
+    func testDeclareThenHas() async throws {
+        let store = ParameterStore()
+        let stored = try await store.declare(
+            name: "rate",
+            value: .integer(30),
+            descriptor: ROS2ParameterDescriptor(name: "rate", type: .integer))
+        XCTAssertEqual(stored, .integer(30))
+        let hit = await store.has(name: "rate")
+        XCTAssertTrue(hit)
+        let miss = await store.has(name: "fps")
+        XCTAssertFalse(miss)
+    }
+
+    func testDeclareTwiceThrows() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "rate", value: .integer(30),
+            descriptor: ROS2ParameterDescriptor(name: "rate", type: .integer))
+        do {
+            _ = try await store.declare(
+                name: "rate", value: .integer(40),
+                descriptor: ROS2ParameterDescriptor(name: "rate", type: .integer))
+            XCTFail("expected alreadyDeclared")
+        } catch let e as ROS2ParameterError {
+            XCTAssertEqual(e, .alreadyDeclared(name: "rate"))
+        }
+    }
+
+    func testUndeclareRemoves() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "rate", value: .integer(30),
+            descriptor: ROS2ParameterDescriptor(name: "rate", type: .integer))
+        try await store.undeclare(name: "rate")
+        let hit = await store.has(name: "rate")
+        XCTAssertFalse(hit)
+    }
+
+    func testUndeclareUnknownThrows() async {
+        let store = ParameterStore()
+        do {
+            try await store.undeclare(name: "rate")
+            XCTFail("expected notDeclared")
+        } catch let e as ROS2ParameterError {
+            XCTAssertEqual(e, .notDeclared(name: "rate"))
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterConvertibleTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterConvertibleTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+@testable import SwiftROS2
+
+final class ROS2ParameterConvertibleTests: XCTestCase {
+    func testBool() throws {
+        XCTAssertEqual(true.parameterValue, .bool(true))
+        XCTAssertEqual(try Bool(parameterValue: .bool(false)), false)
+    }
+
+    func testInt64() throws {
+        XCTAssertEqual(Int64(42).parameterValue, .integer(42))
+        XCTAssertEqual(try Int64(parameterValue: .integer(-7)), -7)
+    }
+
+    func testIntCoercesToInt64() throws {
+        XCTAssertEqual(Int(42).parameterValue, .integer(42))
+        XCTAssertEqual(try Int(parameterValue: .integer(-7)), -7)
+    }
+
+    func testDouble() throws {
+        XCTAssertEqual(3.14.parameterValue, .double(3.14))
+        XCTAssertEqual(try Double(parameterValue: .double(-1.5)), -1.5)
+    }
+
+    func testString() throws {
+        XCTAssertEqual("hi".parameterValue, .string("hi"))
+        XCTAssertEqual(try String(parameterValue: .string("hi")), "hi")
+    }
+
+    func testByteArray() throws {
+        let bs: [UInt8] = [1, 2, 3]
+        XCTAssertEqual(bs.parameterValue, .byteArray([1, 2, 3]))
+        XCTAssertEqual(try [UInt8](parameterValue: .byteArray([1, 2, 3])), [1, 2, 3])
+    }
+
+    func testBoolArray() throws {
+        XCTAssertEqual([true, false].parameterValue, .boolArray([true, false]))
+        XCTAssertEqual(try [Bool](parameterValue: .boolArray([true])), [true])
+    }
+
+    func testInt64Array() throws {
+        let xs: [Int64] = [1, 2]
+        XCTAssertEqual(xs.parameterValue, .integerArray([1, 2]))
+        XCTAssertEqual(try [Int64](parameterValue: .integerArray([3])), [3])
+    }
+
+    func testDoubleArray() throws {
+        XCTAssertEqual([1.0, 2.0].parameterValue, .doubleArray([1.0, 2.0]))
+        XCTAssertEqual(try [Double](parameterValue: .doubleArray([3.5])), [3.5])
+    }
+
+    func testStringArray() throws {
+        XCTAssertEqual(["a", "b"].parameterValue, .stringArray(["a", "b"]))
+        XCTAssertEqual(try [String](parameterValue: .stringArray(["x"])), ["x"])
+    }
+
+    func testTypeMismatchThrows() {
+        XCTAssertThrowsError(try Int64(parameterValue: .string("seven"))) { e in
+            guard case ROS2ParameterError.invalidType(_, let expected, let got) = e else {
+                XCTFail("wrong error: \(e)")
+                return
+            }
+            XCTAssertEqual(expected, .integer)
+            XCTAssertEqual(got, .string)
+        }
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterDescriptorTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterDescriptorTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+@testable import SwiftROS2
+
+final class ROS2ParameterDescriptorTests: XCTestCase {
+    func testDefaultsAreEmpty() {
+        let d = ROS2ParameterDescriptor()
+        XCTAssertEqual(d.name, "")
+        XCTAssertEqual(d.type, .notSet)
+        XCTAssertEqual(d.description, "")
+        XCTAssertEqual(d.additionalConstraints, "")
+        XCTAssertFalse(d.readOnly)
+        XCTAssertFalse(d.dynamicTyping)
+        XCTAssertNil(d.floatingPointRange)
+        XCTAssertNil(d.floatingPointStep)
+        XCTAssertNil(d.integerRange)
+        XCTAssertNil(d.integerStep)
+    }
+
+    func testCustomDescriptor() {
+        let d = ROS2ParameterDescriptor(
+            name: "rate",
+            type: .integer,
+            description: "publish rate (Hz)",
+            integerRange: 1...120,
+            integerStep: 1
+        )
+        XCTAssertEqual(d.name, "rate")
+        XCTAssertEqual(d.type, .integer)
+        XCTAssertEqual(d.description, "publish rate (Hz)")
+        XCTAssertEqual(d.integerRange?.lowerBound, 1)
+        XCTAssertEqual(d.integerRange?.upperBound, 120)
+        XCTAssertEqual(d.integerStep, 1)
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterErrorTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterErrorTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+@testable import SwiftROS2
+
+final class ROS2ParameterErrorTests: XCTestCase {
+    func testCasesAreDistinct() {
+        let a: ROS2ParameterError = .alreadyDeclared(name: "rate")
+        let b: ROS2ParameterError = .notDeclared(name: "rate")
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testInvalidTypeCarriesExpectedAndGot() {
+        let e: ROS2ParameterError = .invalidType(
+            name: "rate", expected: .integer, got: .string)
+        guard case let .invalidType(name, expected, got) = e else {
+            XCTFail("wrong case")
+            return
+        }
+        XCTAssertEqual(name, "rate")
+        XCTAssertEqual(expected, .integer)
+        XCTAssertEqual(got, .string)
+    }
+
+    func testIsErrorType() {
+        let e: any Error = ROS2ParameterError.notDeclared(name: "x")
+        XCTAssertTrue(e is ROS2ParameterError)
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterErrorTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterErrorTests.swift
@@ -12,7 +12,7 @@ final class ROS2ParameterErrorTests: XCTestCase {
     func testInvalidTypeCarriesExpectedAndGot() {
         let e: ROS2ParameterError = .invalidType(
             name: "rate", expected: .integer, got: .string)
-        guard case let .invalidType(name, expected, got) = e else {
+        guard case .invalidType(let name, let expected, let got) = e else {
             XCTFail("wrong case")
             return
         }

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterResultsTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterResultsTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+@testable import SwiftROS2
+
+final class ROS2ParameterResultsTests: XCTestCase {
+    func testSetParametersResultDefaults() {
+        let ok = ROS2SetParametersResult.success()
+        XCTAssertTrue(ok.successful)
+        XCTAssertEqual(ok.reason, "")
+
+        let bad = ROS2SetParametersResult.failure(reason: "out of range")
+        XCTAssertFalse(bad.successful)
+        XCTAssertEqual(bad.reason, "out of range")
+    }
+
+    func testListParametersResultDefaults() {
+        let r = ROS2ListParametersResult(names: ["a"], prefixes: ["p"])
+        XCTAssertEqual(r.names, ["a"])
+        XCTAssertEqual(r.prefixes, ["p"])
+
+        let empty = ROS2ListParametersResult()
+        XCTAssertTrue(empty.names.isEmpty)
+        XCTAssertTrue(empty.prefixes.isEmpty)
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+@testable import SwiftROS2
+
+final class ROS2ParameterTests: XCTestCase {
+    func testInitAndAccessors() {
+        let p = ROS2Parameter(name: "rate", value: .integer(30))
+        XCTAssertEqual(p.name, "rate")
+        XCTAssertEqual(p.value, .integer(30))
+    }
+
+    func testEquality() {
+        let a = ROS2Parameter(name: "rate", value: .integer(30))
+        let b = ROS2Parameter(name: "rate", value: .integer(30))
+        let c = ROS2Parameter(name: "rate", value: .integer(31))
+        let d = ROS2Parameter(name: "fps", value: .integer(30))
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+        XCTAssertNotEqual(a, d)
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterTypeTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterTypeTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+@testable import SwiftROS2
+
+final class ROS2ParameterTypeTests: XCTestCase {
+    func testRawValuesMatchRclInterfacesConstants() {
+        XCTAssertEqual(ROS2ParameterType.notSet.rawValue, 0)
+        XCTAssertEqual(ROS2ParameterType.bool.rawValue, 1)
+        XCTAssertEqual(ROS2ParameterType.integer.rawValue, 2)
+        XCTAssertEqual(ROS2ParameterType.double.rawValue, 3)
+        XCTAssertEqual(ROS2ParameterType.string.rawValue, 4)
+        XCTAssertEqual(ROS2ParameterType.byteArray.rawValue, 5)
+        XCTAssertEqual(ROS2ParameterType.boolArray.rawValue, 6)
+        XCTAssertEqual(ROS2ParameterType.integerArray.rawValue, 7)
+        XCTAssertEqual(ROS2ParameterType.doubleArray.rawValue, 8)
+        XCTAssertEqual(ROS2ParameterType.stringArray.rawValue, 9)
+    }
+
+    func testRoundTripFromRawValue() {
+        for raw: UInt8 in 0...9 {
+            let t = ROS2ParameterType(rawValue: raw)
+            XCTAssertNotNil(t, "unexpected nil for raw \(raw)")
+            XCTAssertEqual(t?.rawValue, raw)
+        }
+        XCTAssertNil(ROS2ParameterType(rawValue: 10))
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterValueTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterValueTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+@testable import SwiftROS2
+
+final class ROS2ParameterValueTests: XCTestCase {
+    func testEqualityForSameValues() {
+        XCTAssertEqual(ROS2ParameterValue.integer(7), ROS2ParameterValue.integer(7))
+        XCTAssertEqual(ROS2ParameterValue.string("a"), ROS2ParameterValue.string("a"))
+        XCTAssertEqual(ROS2ParameterValue.notSet, ROS2ParameterValue.notSet)
+    }
+
+    func testInequalityAcrossCases() {
+        XCTAssertNotEqual(ROS2ParameterValue.integer(7), ROS2ParameterValue.double(7.0))
+        XCTAssertNotEqual(ROS2ParameterValue.bool(true), ROS2ParameterValue.notSet)
+    }
+
+    func testArrayCases() {
+        let a: ROS2ParameterValue = .integerArray([1, 2, 3])
+        let b: ROS2ParameterValue = .integerArray([1, 2, 3])
+        let c: ROS2ParameterValue = .integerArray([1, 2])
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/WireBridgeTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/WireBridgeTests.swift
@@ -135,4 +135,13 @@ final class WireBridgeTests: XCTestCase {
         XCTAssertEqual(wire.integerRange.count, 0)
         XCTAssertEqual(ROS2ParameterDescriptor(wire: wire), swift)
     }
+
+    func testParameterRoundTrip() {
+        let swift = ROS2Parameter(name: "rate", value: .integer(30))
+        let wire = swift.toWire()
+        XCTAssertEqual(wire.name, "rate")
+        XCTAssertEqual(wire.value.type, 2)
+        XCTAssertEqual(wire.value.integerValue, 30)
+        XCTAssertEqual(ROS2Parameter(wire: wire), swift)
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/WireBridgeTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/WireBridgeTests.swift
@@ -1,0 +1,82 @@
+import SwiftROS2Messages
+import XCTest
+
+@testable import SwiftROS2
+
+final class WireBridgeTests: XCTestCase {
+    func testNotSetRoundTrip() {
+        let swift: ROS2ParameterValue = .notSet
+        let wire = swift.toWire()
+        XCTAssertEqual(wire.type, 0)
+        XCTAssertEqual(ROS2ParameterValue(wire: wire), .notSet)
+    }
+
+    func testBoolRoundTrip() {
+        let wire = ROS2ParameterValue.bool(true).toWire()
+        XCTAssertEqual(wire.type, 1)
+        XCTAssertEqual(wire.boolValue, true)
+        XCTAssertEqual(ROS2ParameterValue(wire: wire), .bool(true))
+    }
+
+    func testIntegerRoundTrip() {
+        let wire = ROS2ParameterValue.integer(-42).toWire()
+        XCTAssertEqual(wire.type, 2)
+        XCTAssertEqual(wire.integerValue, -42)
+        XCTAssertEqual(ROS2ParameterValue(wire: wire), .integer(-42))
+    }
+
+    func testDoubleRoundTrip() {
+        let wire = ROS2ParameterValue.double(3.14).toWire()
+        XCTAssertEqual(wire.type, 3)
+        XCTAssertEqual(wire.doubleValue, 3.14)
+        XCTAssertEqual(ROS2ParameterValue(wire: wire), .double(3.14))
+    }
+
+    func testStringRoundTrip() {
+        let wire = ROS2ParameterValue.string("hello").toWire()
+        XCTAssertEqual(wire.type, 4)
+        XCTAssertEqual(wire.stringValue, "hello")
+        XCTAssertEqual(ROS2ParameterValue(wire: wire), .string("hello"))
+    }
+
+    func testByteArrayRoundTrip() {
+        let wire = ROS2ParameterValue.byteArray([1, 2, 3]).toWire()
+        XCTAssertEqual(wire.type, 5)
+        XCTAssertEqual(wire.byteArrayValue, [1, 2, 3])
+        XCTAssertEqual(ROS2ParameterValue(wire: wire), .byteArray([1, 2, 3]))
+    }
+
+    func testBoolArrayRoundTrip() {
+        let wire = ROS2ParameterValue.boolArray([true, false]).toWire()
+        XCTAssertEqual(wire.type, 6)
+        XCTAssertEqual(wire.boolArrayValue, [true, false])
+        XCTAssertEqual(ROS2ParameterValue(wire: wire), .boolArray([true, false]))
+    }
+
+    func testIntegerArrayRoundTrip() {
+        let wire = ROS2ParameterValue.integerArray([1, -2]).toWire()
+        XCTAssertEqual(wire.type, 7)
+        XCTAssertEqual(wire.integerArrayValue, [1, -2])
+        XCTAssertEqual(ROS2ParameterValue(wire: wire), .integerArray([1, -2]))
+    }
+
+    func testDoubleArrayRoundTrip() {
+        let wire = ROS2ParameterValue.doubleArray([1.5, -2.5]).toWire()
+        XCTAssertEqual(wire.type, 8)
+        XCTAssertEqual(wire.doubleArrayValue, [1.5, -2.5])
+        XCTAssertEqual(ROS2ParameterValue(wire: wire), .doubleArray([1.5, -2.5]))
+    }
+
+    func testStringArrayRoundTrip() {
+        let wire = ROS2ParameterValue.stringArray(["a", "b"]).toWire()
+        XCTAssertEqual(wire.type, 9)
+        XCTAssertEqual(wire.stringArrayValue, ["a", "b"])
+        XCTAssertEqual(ROS2ParameterValue(wire: wire), .stringArray(["a", "b"]))
+    }
+
+    func testWireDecodeUnknownTypeFallsBackToNotSet() {
+        var wire = SwiftROS2Messages.ParameterValue()
+        wire.type = 99
+        XCTAssertEqual(ROS2ParameterValue(wire: wire), .notSet)
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/WireBridgeTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/WireBridgeTests.swift
@@ -79,4 +79,60 @@ final class WireBridgeTests: XCTestCase {
         wire.type = 99
         XCTAssertEqual(ROS2ParameterValue(wire: wire), .notSet)
     }
+
+    func testDescriptorRoundTripWithIntegerRange() {
+        let swift = ROS2ParameterDescriptor(
+            name: "rate",
+            type: .integer,
+            description: "publish rate",
+            additionalConstraints: "Hz only",
+            readOnly: false,
+            dynamicTyping: false,
+            integerRange: 1...120,
+            integerStep: 2
+        )
+        let wire = swift.toWire()
+        XCTAssertEqual(wire.name, "rate")
+        XCTAssertEqual(wire.type, 2)
+        XCTAssertEqual(wire.description, "publish rate")
+        XCTAssertEqual(wire.additionalConstraints, "Hz only")
+        XCTAssertFalse(wire.readOnly)
+        XCTAssertFalse(wire.dynamicTyping)
+        XCTAssertEqual(wire.floatingPointRange.count, 0)
+        XCTAssertEqual(wire.integerRange.count, 1)
+        XCTAssertEqual(wire.integerRange[0].fromValue, 1)
+        XCTAssertEqual(wire.integerRange[0].toValue, 120)
+        XCTAssertEqual(wire.integerRange[0].step, 2)
+
+        let back = ROS2ParameterDescriptor(wire: wire)
+        XCTAssertEqual(back, swift)
+    }
+
+    func testDescriptorRoundTripWithFloatingPointRange() {
+        let swift = ROS2ParameterDescriptor(
+            name: "gain",
+            type: .double,
+            floatingPointRange: 0.0...1.0,
+            floatingPointStep: 0.1
+        )
+        let wire = swift.toWire()
+        XCTAssertEqual(wire.floatingPointRange.count, 1)
+        XCTAssertEqual(wire.floatingPointRange[0].fromValue, 0.0)
+        XCTAssertEqual(wire.floatingPointRange[0].toValue, 1.0)
+        XCTAssertEqual(wire.floatingPointRange[0].step, 0.1)
+        XCTAssertEqual(wire.integerRange.count, 0)
+
+        let back = ROS2ParameterDescriptor(wire: wire)
+        XCTAssertEqual(back, swift)
+    }
+
+    func testDescriptorRoundTripEmpty() {
+        let swift = ROS2ParameterDescriptor()
+        let wire = swift.toWire()
+        XCTAssertEqual(wire.name, "")
+        XCTAssertEqual(wire.type, 0)
+        XCTAssertEqual(wire.floatingPointRange.count, 0)
+        XCTAssertEqual(wire.integerRange.count, 0)
+        XCTAssertEqual(ROS2ParameterDescriptor(wire: wire), swift)
+    }
 }


### PR DESCRIPTION
## Summary

Phase 2 of 6 toward the Parameter API. Adds Swift-public Parameter types plus an actor-backed per-node store. **No services, no `/parameter_events`** yet — those land in phases 3 and 4.

- New folder `Sources/SwiftROS2/Parameters/` with 10 production files.
- New folder `Tests/SwiftROS2Tests/Parameters/` with 10 test files (~64 XCTest cases, all green).
- Public types use the `ROS2*` prefix (`ROS2Parameter`, `ROS2ParameterValue`, `ROS2ParameterDescriptor`, `ROS2ParameterType`, `ROS2SetParametersResult`, `ROS2ListParametersResult`, `ROS2ParameterError`, `ROS2ParameterConvertible`) to avoid colliding with the wire types re-exported from `SwiftROS2Messages` (`Parameter`, `ParameterValue`, `ParameterDescriptor`, `ParameterType`, `SetParametersResult`, `ListParametersResult`).
- Validation matrix (read-only / immutable type / range) lives in `ParameterStore` so phases 3 (services) and 4 (events) reuse it without duplication.
- `setParametersAtomically` snapshots `entries` before iterating and restores on first failure.
- `listParameters` implements rclcpp prefix + depth semantics: empty prefixes ⇒ all, `depth == 0` ⇒ no limit, `depth > 0` ⇒ at most `depth - 1` `.` separators in the suffix after the matched prefix.
- The 1.0.0 API freeze is not broken — every change is additive.

## Public surface

```swift
extension ROS2Node {
    @discardableResult
    func declareParameter<T: ROS2ParameterConvertible>(
        _ name: String, default value: T,
        descriptor: ROS2ParameterDescriptor = .init(),
        ignoreOverride: Bool = false
    ) async throws -> T

    func undeclareParameter(_ name: String) async throws
    func hasParameter(_ name: String) async -> Bool
    func listParameters(prefixes: [String], depth: UInt64) async -> ROS2ListParametersResult
    func getParameter(_ name: String) async throws -> ROS2Parameter
    func getParameterOrDefault<T: ROS2ParameterConvertible>(_ name: String, default: T) async -> T

    // Set methods are non-throwing — failures are reported via the result's
    // `successful: Bool + reason: String` payload, matching what crosses the
    // wire from the parameter services in phase 3.
    @discardableResult
    func setParameter(_ p: ROS2Parameter) async -> ROS2SetParametersResult
    @discardableResult
    func setParameters(_ ps: [ROS2Parameter]) async -> [ROS2SetParametersResult]
    @discardableResult
    func setParametersAtomically(_ ps: [ROS2Parameter]) async -> ROS2SetParametersResult

    func describeParameter(_ name: String) async throws -> ROS2ParameterDescriptor
}
```

The three callback registration methods (`setOnSetParametersCallback` etc.) and the auto-registered six standard parameter services are deferred to phases 4 and 3 respectively.

## Out of scope for this PR

- The six `rcl_interfaces/srv/*` parameter services (phase 3).
- `/parameter_events` publisher and on-set / pre-set / post-set callbacks (phase 4).
- `ROS2ParameterClient` for talking to remote nodes' parameters (phase 5).
- `ros2 param` CLI integration tests against a real ROS 2 host (phase 6).
- YAML param-file loading via `--params-file` (deferred indefinitely; not part of the 6-phase rollout).

## Test plan

- [x] `swift build`
- [x] `swift test --parallel` — 111 prior tests + 64 new XCTest cases all pass
- [x] `swift format lint --strict --configuration .swift-format Package.swift Sources Tests` — clean
- [ ] CI macOS / Linux / Windows / Android builds green