### PR TITLE
feat(api): six parameter services on every node (phase 3 of 6)

### DIFF
--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -71,7 +71,12 @@ public final class ROS2Context: @unchecked Sendable {
     }
 
     /// Create a node in this context
-    public func createNode(name: String, namespace: String = "/") async throws -> ROS2Node {
+    public func createNode(
+        name: String,
+        namespace: String = "/",
+        options: ROS2NodeOptions = .default
+    ) async throws -> ROS2Node {
+        _ = options  // wired in phase-3 Task 10
         let nodeId = entityManager.getNextEntityId()
         let node = ROS2Node(
             name: name,

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -76,7 +76,6 @@ public final class ROS2Context: @unchecked Sendable {
         namespace: String = "/",
         options: ROS2NodeOptions = .default
     ) async throws -> ROS2Node {
-        _ = options  // wired in phase-3 Task 10
         let nodeId = entityManager.getNextEntityId()
         let node = ROS2Node(
             name: name,
@@ -87,6 +86,12 @@ public final class ROS2Context: @unchecked Sendable {
             entityManager: entityManager,
             gidManager: gidManager
         )
+        if options.startParameterServices {
+            // Register before the node is reachable from `shutdown` — if
+            // service registration throws we don't want a half-initialised
+            // node hanging on the context.
+            try await node.startParameterServices()
+        }
         appendNode(node)
         return node
     }

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -70,11 +70,27 @@ public final class ROS2Context: @unchecked Sendable {
         }
     }
 
-    /// Create a node in this context
+    /// Create a node in this context.
+    ///
+    /// Preserves the pre-1.1 binary signature; delegates to the
+    /// `options:`-aware overload with `ROS2NodeOptions.default`.
+    public func createNode(
+        name: String,
+        namespace: String = "/"
+    ) async throws -> ROS2Node {
+        try await createNode(name: name, namespace: namespace, options: .default)
+    }
+
+    /// Create a node in this context with explicit per-node options.
+    ///
+    /// `options` has no default to avoid an overload-resolution
+    /// ambiguity with the binary-stable `createNode(name:namespace:)`
+    /// shim above. Pass `.default` to opt in to the standard behaviour
+    /// (auto-register parameter services).
     public func createNode(
         name: String,
         namespace: String = "/",
-        options: ROS2NodeOptions = .default
+        options: ROS2NodeOptions
     ) async throws -> ROS2Node {
         let nodeId = entityManager.getNextEntityId()
         let node = ROS2Node(
@@ -88,9 +104,15 @@ public final class ROS2Context: @unchecked Sendable {
         )
         if options.startParameterServices {
             // Register before the node is reachable from `shutdown` — if
-            // service registration throws we don't want a half-initialised
-            // node hanging on the context.
-            try await node.startParameterServices()
+            // any of the six createService calls throws, close the services
+            // already created on this node before rethrowing so we don't
+            // leak transport handles into the caller's hands.
+            do {
+                try await node.startParameterServices()
+            } catch {
+                await node.destroy()
+                throw error
+            }
         }
         appendNode(node)
         return node

--- a/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
@@ -104,12 +104,11 @@ extension ROS2Node {
     static func handleSetParametersAtomically(
         _ request: SetParametersAtomicallyRequest, store: ParameterStore
     ) async -> SetParametersAtomicallyResponse {
-        _ = request
-        _ = store
+        let swiftParams = request.parameters.map { ROS2Parameter(wire: $0) }
+        let r = await store.setAtomically(swiftParams)
         return SetParametersAtomicallyResponse(
-            result: SetParametersResult(
-                successful: false,
-                reason: "phase 3 task 6 not implemented yet"))
+            result: SwiftROS2Messages.SetParametersResult(
+                successful: r.successful, reason: r.reason))
     }
 
     static func handleListParameters(

--- a/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
@@ -11,59 +11,70 @@ extension ROS2Node {
     /// `ROS2Context.createNode(...)` calls this automatically when
     /// `ROS2NodeOptions.startParameterServices` is `true` (the default).
     /// Calling it manually after opting out is supported. A repeated call
-    /// is a no-op.
+    /// after a successful registration is a no-op; a call that retries
+    /// after a previous failed attempt re-runs the registration.
     public func startParameterServices() async throws {
         guard await parameterStore.markServicesStarted() else { return }
 
         let store = parameterStore  // captured by handler closures (actor → Sendable)
         let fqn = fullyQualifiedName
 
-        _ = try await createService(
-            GetParametersSrv.self,
-            name: "\(fqn)/get_parameters",
-            qos: .servicesDefault
-        ) { req in
-            await Self.handleGetParameters(req, store: store)
-        }
+        do {
+            _ = try await createService(
+                GetParametersSrv.self,
+                name: "\(fqn)/get_parameters",
+                qos: .servicesDefault
+            ) { req in
+                await Self.handleGetParameters(req, store: store)
+            }
 
-        _ = try await createService(
-            SetParametersSrv.self,
-            name: "\(fqn)/set_parameters",
-            qos: .servicesDefault
-        ) { req in
-            await Self.handleSetParameters(req, store: store)
-        }
+            _ = try await createService(
+                SetParametersSrv.self,
+                name: "\(fqn)/set_parameters",
+                qos: .servicesDefault
+            ) { req in
+                await Self.handleSetParameters(req, store: store)
+            }
 
-        _ = try await createService(
-            SetParametersAtomicallySrv.self,
-            name: "\(fqn)/set_parameters_atomically",
-            qos: .servicesDefault
-        ) { req in
-            await Self.handleSetParametersAtomically(req, store: store)
-        }
+            _ = try await createService(
+                SetParametersAtomicallySrv.self,
+                name: "\(fqn)/set_parameters_atomically",
+                qos: .servicesDefault
+            ) { req in
+                await Self.handleSetParametersAtomically(req, store: store)
+            }
 
-        _ = try await createService(
-            ListParametersSrv.self,
-            name: "\(fqn)/list_parameters",
-            qos: .servicesDefault
-        ) { req in
-            await Self.handleListParameters(req, store: store)
-        }
+            _ = try await createService(
+                ListParametersSrv.self,
+                name: "\(fqn)/list_parameters",
+                qos: .servicesDefault
+            ) { req in
+                await Self.handleListParameters(req, store: store)
+            }
 
-        _ = try await createService(
-            DescribeParametersSrv.self,
-            name: "\(fqn)/describe_parameters",
-            qos: .servicesDefault
-        ) { req in
-            await Self.handleDescribeParameters(req, store: store)
-        }
+            _ = try await createService(
+                DescribeParametersSrv.self,
+                name: "\(fqn)/describe_parameters",
+                qos: .servicesDefault
+            ) { req in
+                await Self.handleDescribeParameters(req, store: store)
+            }
 
-        _ = try await createService(
-            GetParameterTypesSrv.self,
-            name: "\(fqn)/get_parameter_types",
-            qos: .servicesDefault
-        ) { req in
-            await Self.handleGetParameterTypes(req, store: store)
+            _ = try await createService(
+                GetParameterTypesSrv.self,
+                name: "\(fqn)/get_parameter_types",
+                qos: .servicesDefault
+            ) { req in
+                await Self.handleGetParameterTypes(req, store: store)
+            }
+        } catch {
+            // Mid-registration failure: release the latch so a future
+            // call can retry. The partially-registered services live on
+            // the node's services array; the node owner (Context.createNode
+            // or the caller of this method directly) is responsible for
+            // closing them via node.destroy() if a clean retry is wanted.
+            await parameterStore.resetServicesStarted()
+            throw error
         }
     }
 

--- a/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
@@ -1,0 +1,129 @@
+// Phase 3 of the Parameter API: bind the six rcl_interfaces parameter
+// service handlers on a node's fully-qualified name. Handlers route
+// through the existing per-node ParameterStore created in phase 2.
+
+import SwiftROS2Messages
+
+extension ROS2Node {
+    /// Register the six standard parameter services on
+    /// `<fullyQualifiedName>/<service>`.
+    ///
+    /// `ROS2Context.createNode(...)` calls this automatically when
+    /// `ROS2NodeOptions.startParameterServices` is `true` (the default).
+    /// Calling it manually after opting out is supported. A repeated call
+    /// is a no-op.
+    public func startParameterServices() async throws {
+        guard await parameterStore.markServicesStarted() else { return }
+
+        let store = parameterStore  // captured by handler closures (actor → Sendable)
+        let fqn = fullyQualifiedName
+
+        _ = try await createService(
+            GetParametersSrv.self,
+            name: "\(fqn)/get_parameters",
+            qos: .servicesDefault
+        ) { req in
+            await Self.handleGetParameters(req, store: store)
+        }
+
+        _ = try await createService(
+            SetParametersSrv.self,
+            name: "\(fqn)/set_parameters",
+            qos: .servicesDefault
+        ) { req in
+            await Self.handleSetParameters(req, store: store)
+        }
+
+        _ = try await createService(
+            SetParametersAtomicallySrv.self,
+            name: "\(fqn)/set_parameters_atomically",
+            qos: .servicesDefault
+        ) { req in
+            await Self.handleSetParametersAtomically(req, store: store)
+        }
+
+        _ = try await createService(
+            ListParametersSrv.self,
+            name: "\(fqn)/list_parameters",
+            qos: .servicesDefault
+        ) { req in
+            await Self.handleListParameters(req, store: store)
+        }
+
+        _ = try await createService(
+            DescribeParametersSrv.self,
+            name: "\(fqn)/describe_parameters",
+            qos: .servicesDefault
+        ) { req in
+            await Self.handleDescribeParameters(req, store: store)
+        }
+
+        _ = try await createService(
+            GetParameterTypesSrv.self,
+            name: "\(fqn)/get_parameter_types",
+            qos: .servicesDefault
+        ) { req in
+            await Self.handleGetParameterTypes(req, store: store)
+        }
+    }
+
+    // MARK: - Handler stubs (filled in tasks 4–9)
+    //
+    // Each handler is a `static` async function so it doesn't capture `self`
+    // implicitly — only the Sendable `ParameterStore` actor crosses the
+    // closure boundary, which keeps the @Sendable handler closure clean.
+
+    static func handleGetParameters(
+        _ request: GetParametersRequest, store: ParameterStore
+    ) async -> GetParametersResponse {
+        _ = request
+        _ = store
+        return GetParametersResponse()
+    }
+
+    static func handleSetParameters(
+        _ request: SetParametersRequest, store: ParameterStore
+    ) async -> SetParametersResponse {
+        _ = store
+        return SetParametersResponse(
+            results: request.parameters.map { _ in
+                SetParametersResult(
+                    successful: false,
+                    reason: "phase 3 task 5 not implemented yet")
+            })
+    }
+
+    static func handleSetParametersAtomically(
+        _ request: SetParametersAtomicallyRequest, store: ParameterStore
+    ) async -> SetParametersAtomicallyResponse {
+        _ = request
+        _ = store
+        return SetParametersAtomicallyResponse(
+            result: SetParametersResult(
+                successful: false,
+                reason: "phase 3 task 6 not implemented yet"))
+    }
+
+    static func handleListParameters(
+        _ request: ListParametersRequest, store: ParameterStore
+    ) async -> ListParametersResponse {
+        _ = request
+        _ = store
+        return ListParametersResponse()
+    }
+
+    static func handleDescribeParameters(
+        _ request: DescribeParametersRequest, store: ParameterStore
+    ) async -> DescribeParametersResponse {
+        _ = request
+        _ = store
+        return DescribeParametersResponse()
+    }
+
+    static func handleGetParameterTypes(
+        _ request: GetParameterTypesRequest, store: ParameterStore
+    ) async -> GetParameterTypesResponse {
+        _ = store
+        return GetParameterTypesResponse(types: Array(repeating: 0, count: request.names.count))
+    }
+}

--- a/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
@@ -143,7 +143,12 @@ extension ROS2Node {
     static func handleGetParameterTypes(
         _ request: GetParameterTypesRequest, store: ParameterStore
     ) async -> GetParameterTypesResponse {
-        _ = store
-        return GetParameterTypesResponse(types: Array(repeating: 0, count: request.names.count))
+        var types: [UInt8] = []
+        types.reserveCapacity(request.names.count)
+        for name in request.names {
+            let entry = await store.entry(name: name)
+            types.append(entry?.descriptor.type.rawValue ?? 0)
+        }
+        return GetParameterTypesResponse(types: types)
     }
 }

--- a/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
@@ -89,13 +89,16 @@ extension ROS2Node {
     static func handleSetParameters(
         _ request: SetParametersRequest, store: ParameterStore
     ) async -> SetParametersResponse {
-        _ = store
-        return SetParametersResponse(
-            results: request.parameters.map { _ in
-                SetParametersResult(
-                    successful: false,
-                    reason: "phase 3 task 5 not implemented yet")
-            })
+        var results: [SwiftROS2Messages.SetParametersResult] = []
+        results.reserveCapacity(request.parameters.count)
+        for wireParam in request.parameters {
+            let swiftParam = ROS2Parameter(wire: wireParam)
+            let r = await store.set(swiftParam)
+            results.append(
+                SwiftROS2Messages.SetParametersResult(
+                    successful: r.successful, reason: r.reason))
+        }
+        return SetParametersResponse(results: results)
     }
 
     static func handleSetParametersAtomically(

--- a/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
@@ -67,11 +67,12 @@ extension ROS2Node {
         }
     }
 
-    // MARK: - Handler stubs (filled in tasks 4–9)
+    // MARK: - Service handlers
     //
     // Each handler is a `static` async function so it doesn't capture `self`
     // implicitly — only the Sendable `ParameterStore` actor crosses the
-    // closure boundary, which keeps the @Sendable handler closure clean.
+    // closure boundary, which keeps the @Sendable handler closure surface
+    // minimal.
 
     static func handleGetParameters(
         _ request: GetParametersRequest, store: ParameterStore

--- a/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
@@ -114,9 +114,10 @@ extension ROS2Node {
     static func handleListParameters(
         _ request: ListParametersRequest, store: ParameterStore
     ) async -> ListParametersResponse {
-        _ = request
-        _ = store
-        return ListParametersResponse()
+        let r = await store.list(prefixes: request.prefixes, depth: request.depth)
+        return ListParametersResponse(
+            result: SwiftROS2Messages.ListParametersResult(
+                names: r.names, prefixes: r.prefixes))
     }
 
     static func handleDescribeParameters(

--- a/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
@@ -123,9 +123,21 @@ extension ROS2Node {
     static func handleDescribeParameters(
         _ request: DescribeParametersRequest, store: ParameterStore
     ) async -> DescribeParametersResponse {
-        _ = request
-        _ = store
-        return DescribeParametersResponse()
+        var out: [SwiftROS2Messages.ParameterDescriptor] = []
+        out.reserveCapacity(request.names.count)
+        for name in request.names {
+            if let entry = await store.entry(name: name) {
+                out.append(entry.descriptor.toWire())
+            } else {
+                // rclcpp returns a descriptor whose name echoes the request and
+                // whose type slot is PARAMETER_NOT_SET. Mirror that.
+                var stub = SwiftROS2Messages.ParameterDescriptor()
+                stub.name = name
+                stub.type = 0
+                out.append(stub)
+            }
+        }
+        return DescribeParametersResponse(descriptors: out)
     }
 
     static func handleGetParameterTypes(

--- a/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
@@ -76,9 +76,14 @@ extension ROS2Node {
     static func handleGetParameters(
         _ request: GetParametersRequest, store: ParameterStore
     ) async -> GetParametersResponse {
-        _ = request
-        _ = store
-        return GetParametersResponse()
+        var values: [SwiftROS2Messages.ParameterValue] = []
+        values.reserveCapacity(request.names.count)
+        for name in request.names {
+            let entry = await store.entry(name: name)
+            let swiftValue = entry?.value ?? .notSet
+            values.append(swiftValue.toWire())
+        }
+        return GetParametersResponse(values: values)
     }
 
     static func handleSetParameters(

--- a/Sources/SwiftROS2/Parameters/ParameterStore.swift
+++ b/Sources/SwiftROS2/Parameters/ParameterStore.swift
@@ -185,14 +185,28 @@ extension ParameterStore {
         return (e.value, e.descriptor)
     }
 
-    /// One-shot latch used by `Node.startParameterServices()` to guard
-    /// against double-registration (e.g. a caller that opted out of
-    /// auto-start and then later calls the public method twice).
-    /// Returns `true` exactly once per store instance.
+    /// One-shot latch used by `Node.startParameterServices()` to claim
+    /// the right to register the six parameter services. Returns `true`
+    /// the first time it is called; subsequent calls return `false`.
+    ///
+    /// The latch is claimed *before* the six `createService` calls so
+    /// concurrent `startParameterServices()` invocations can't double-
+    /// register. If registration then fails partway through, the caller
+    /// must invoke `resetServicesStarted()` so a future retry can
+    /// re-claim the latch.
     @discardableResult
     func markServicesStarted() -> Bool {
         if servicesStarted { return false }
         servicesStarted = true
         return true
+    }
+
+    /// Release the latch so a future `startParameterServices()` call can
+    /// re-claim it. Called by `Node.startParameterServices()` when one of
+    /// the six `createService` registrations throws — the partially-
+    /// registered services are torn down by `Node.destroy()` (or by the
+    /// caller's own cleanup) and the node is left in an un-started state.
+    func resetServicesStarted() {
+        servicesStarted = false
     }
 }

--- a/Sources/SwiftROS2/Parameters/ParameterStore.swift
+++ b/Sources/SwiftROS2/Parameters/ParameterStore.swift
@@ -9,6 +9,7 @@ struct ParameterEntry: Sendable, Equatable {
 
 actor ParameterStore {
     private var entries: [String: ParameterEntry] = [:]
+    private var servicesStarted = false
 
     init() {}
 
@@ -171,5 +172,27 @@ extension ParameterStore {
             }
         }
         return nil
+    }
+}
+
+extension ParameterStore {
+    /// Non-throwing accessor used by the parameter-service handlers. The
+    /// throwing variants (`get`, `describe`) keep the rclcpp convention
+    /// for direct Swift callers; the wire services prefer to encode an
+    /// "absent" answer rather than surface an error to the caller.
+    func entry(name: String) -> (value: ROS2ParameterValue, descriptor: ROS2ParameterDescriptor)? {
+        guard let e = entries[name] else { return nil }
+        return (e.value, e.descriptor)
+    }
+
+    /// One-shot latch used by `Node.startParameterServices()` to guard
+    /// against double-registration (e.g. a caller that opted out of
+    /// auto-start and then later calls the public method twice).
+    /// Returns `true` exactly once per store instance.
+    @discardableResult
+    func markServicesStarted() -> Bool {
+        if servicesStarted { return false }
+        servicesStarted = true
+        return true
     }
 }

--- a/Sources/SwiftROS2/ROS2NodeOptions.swift
+++ b/Sources/SwiftROS2/ROS2NodeOptions.swift
@@ -1,0 +1,26 @@
+// Per-node creation knobs. Currently single-purpose (parameter-services
+// opt-out) — future phases may add publisher-default QoS / event toggles
+// alongside, hence the dedicated struct rather than a bare Bool argument
+// on createNode.
+
+/// Configuration toggles applied at `ROS2Node` construction time.
+public struct ROS2NodeOptions: Sendable, Equatable {
+    /// Whether `ROS2Context.createNode` automatically registers the six
+    /// `rcl_interfaces` parameter services (`get_parameters`,
+    /// `set_parameters`, `set_parameters_atomically`, `list_parameters`,
+    /// `describe_parameters`, `get_parameter_types`) under
+    /// `<node_fqn>/<service>`.
+    ///
+    /// rclcpp / rclpy register these unconditionally; we follow the same
+    /// default. Embedded callers that never need `ros2 param` interop can
+    /// set this to `false` to skip the six service objects.
+    public var startParameterServices: Bool
+
+    public init(startParameterServices: Bool = true) {
+        self.startParameterServices = startParameterServices
+    }
+
+    /// Default options: auto-register parameter services. Equivalent to
+    /// `ROS2NodeOptions()`.
+    public static let `default` = ROS2NodeOptions()
+}

--- a/Tests/SwiftROS2Tests/ActionClientTests.swift
+++ b/Tests/SwiftROS2Tests/ActionClientTests.swift
@@ -18,7 +18,8 @@ final class ActionClientTests: XCTestCase {
             distro: .jazzy,
             session: mock
         )
-        let node = try await ctx.createNode(name: "t")
+        let node = try await ctx.createNode(
+            name: "t", options: ROS2NodeOptions(startParameterServices: false))
         let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
         let handle = try await cli.sendGoal(FibonacciAction.Goal(order: 5))
         XCTAssertEqual(handle.acceptedAt.sec, 1)
@@ -34,7 +35,8 @@ final class ActionClientTests: XCTestCase {
             distro: .jazzy,
             session: mock
         )
-        let node = try await ctx.createNode(name: "t")
+        let node = try await ctx.createNode(
+            name: "t", options: ROS2NodeOptions(startParameterServices: false))
         let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
         do {
             _ = try await cli.sendGoal(FibonacciAction.Goal(order: 5))
@@ -61,7 +63,8 @@ final class ActionClientTests: XCTestCase {
             distro: .jazzy,
             session: mock
         )
-        let node = try await ctx.createNode(name: "t")
+        let node = try await ctx.createNode(
+            name: "t", options: ROS2NodeOptions(startParameterServices: false))
         let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
         let handle = try await cli.sendGoal(FibonacciAction.Goal(order: 5))
         var seen: [[Int32]] = []
@@ -84,7 +87,8 @@ final class ActionClientTests: XCTestCase {
             distro: .jazzy,
             session: mock
         )
-        let node = try await ctx.createNode(name: "t")
+        let node = try await ctx.createNode(
+            name: "t", options: ROS2NodeOptions(startParameterServices: false))
         let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
         let handle = try await cli.sendGoal(FibonacciAction.Goal(order: 5))
         let r = try await handle.result(timeout: .seconds(2))
@@ -104,7 +108,8 @@ final class ActionClientTests: XCTestCase {
             distro: .jazzy,
             session: mock
         )
-        let node = try await ctx.createNode(name: "t")
+        let node = try await ctx.createNode(
+            name: "t", options: ROS2NodeOptions(startParameterServices: false))
         let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
         let canceled = try await cli.cancelGoals(beforeStamp: BuiltinInterfacesTime(sec: 9, nanosec: 0))
         XCTAssertEqual(canceled, [])

--- a/Tests/SwiftROS2Tests/ActionServerTests.swift
+++ b/Tests/SwiftROS2Tests/ActionServerTests.swift
@@ -56,7 +56,8 @@ final class ActionServerTests: XCTestCase {
             distro: .jazzy,
             session: mock
         )
-        let node = try await ctx.createNode(name: "t")
+        let node = try await ctx.createNode(
+            name: "t", options: ROS2NodeOptions(startParameterServices: false))
         _ = try await node.createActionServer(
             FibonacciAction.self,
             name: "/fibonacci",
@@ -100,7 +101,8 @@ final class ActionServerTests: XCTestCase {
             distro: .jazzy,
             session: mock
         )
-        let node = try await ctx.createNode(name: "t")
+        let node = try await ctx.createNode(
+            name: "t", options: ROS2NodeOptions(startParameterServices: false))
         _ = try await node.createActionServer(
             FibonacciAction.self,
             name: "/fibonacci",

--- a/Tests/SwiftROS2Tests/NodeActionTests.swift
+++ b/Tests/SwiftROS2Tests/NodeActionTests.swift
@@ -17,7 +17,8 @@ final class NodeActionTests: XCTestCase {
             distro: .jazzy,
             session: mock
         )
-        let node = try await ctx.createNode(name: "t")
+        let node = try await ctx.createNode(
+            name: "t", options: ROS2NodeOptions(startParameterServices: false))
         let server = try await node.createActionServer(
             FibonacciAction.self, name: "/fibonacci",
             handler: _AcceptingHandler()
@@ -39,7 +40,8 @@ final class NodeActionTests: XCTestCase {
             distro: .jazzy,
             session: mock
         )
-        let node = try await ctx.createNode(name: "t")
+        let node = try await ctx.createNode(
+            name: "t", options: ROS2NodeOptions(startParameterServices: false))
         let cli = try await node.createActionClient(FibonacciAction.self, name: "/fibonacci")
         XCTAssertTrue(cli.isActive)
         await ctx.shutdown()

--- a/Tests/SwiftROS2Tests/NodeLifecycleTests.swift
+++ b/Tests/SwiftROS2Tests/NodeLifecycleTests.swift
@@ -8,6 +8,9 @@ final class NodeLifecycleTests: XCTestCase {
         session: MockTransportSession = MockTransportSession()
     ) async throws -> (ROS2Context, MockTransportSession) {
         let config = TransportConfig.zenoh(locator: "tcp/mock:7447")
+        // Phase-3 Task 10 auto-registers parameter services on createNode;
+        // give the mock an echo dispatcher so that registration succeeds.
+        session.installEchoServiceTransport()
         let ctx = try await ROS2Context(transport: config, session: session)
         return (ctx, session)
     }

--- a/Tests/SwiftROS2Tests/Parameters/NodeParametersTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/NodeParametersTests.swift
@@ -6,7 +6,11 @@ import XCTest
 final class NodeParametersTests: XCTestCase {
     private func makeContext() async throws -> ROS2Context {
         let config = TransportConfig.zenoh(locator: "tcp/mock:7447")
-        return try await ROS2Context(transport: config, session: MockTransportSession())
+        let mock = MockTransportSession()
+        // Phase-3 Task 10 auto-registers parameter services on createNode;
+        // give the mock an echo dispatcher so that registration succeeds.
+        mock.installEchoServiceTransport()
+        return try await ROS2Context(transport: config, session: mock)
     }
 
     func testDeclareAndGet() async throws {

--- a/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
@@ -229,4 +229,23 @@ final class ParameterServicesTests: XCTestCase {
         XCTAssertEqual(resp.descriptors[1].name, "missing")
         XCTAssertEqual(resp.descriptors[1].type, 0)  // PARAMETER_NOT_SET
     }
+
+    func testGetParameterTypesReturnsTypesPerName() async throws {
+        let (_, node) = try await makeContextAndNode()
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        _ = try await node.declareParameter("alpha", default: 0.5)
+        _ = try await node.declareParameter("flag", default: true)
+        try await node.startParameterServices()
+
+        let cli = try await node.createClient(
+            GetParameterTypesSrv.self, name: "/talker/get_parameter_types")
+        try await cli.waitForService(timeout: .milliseconds(100))
+
+        let resp = try await cli.call(
+            GetParameterTypesRequest(names: ["rate", "alpha", "flag", "missing"]),
+            timeout: .seconds(1))
+
+        XCTAssertEqual(resp.types, [2, 3, 1, 0])
+        // Integer (2), Double (3), Bool (1), NOT_SET (0)
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
@@ -199,4 +199,34 @@ final class ParameterServicesTests: XCTestCase {
             timeout: .seconds(1))
         XCTAssertEqual(Set(groupResp.result.names), ["group.beta", "group.gamma"])
     }
+
+    func testDescribeParametersReturnsDescriptorsAndMissingFallback() async throws {
+        let (_, node) = try await makeContextAndNode()
+        _ = try await node.declareParameter(
+            "rate",
+            default: Int64(30),
+            descriptor: ROS2ParameterDescriptor(
+                name: "rate", type: .integer, description: "publish rate (Hz)",
+                integerRange: 1...120))
+        try await node.startParameterServices()
+
+        let cli = try await node.createClient(
+            DescribeParametersSrv.self, name: "/talker/describe_parameters")
+        try await cli.waitForService(timeout: .milliseconds(100))
+
+        let resp = try await cli.call(
+            DescribeParametersRequest(names: ["rate", "missing"]),
+            timeout: .seconds(1))
+        XCTAssertEqual(resp.descriptors.count, 2)
+
+        XCTAssertEqual(resp.descriptors[0].name, "rate")
+        XCTAssertEqual(resp.descriptors[0].type, 2)  // PARAMETER_INTEGER
+        XCTAssertEqual(resp.descriptors[0].description, "publish rate (Hz)")
+        XCTAssertEqual(resp.descriptors[0].integerRange.count, 1)
+        XCTAssertEqual(resp.descriptors[0].integerRange.first?.fromValue, 1)
+        XCTAssertEqual(resp.descriptors[0].integerRange.first?.toValue, 120)
+
+        XCTAssertEqual(resp.descriptors[1].name, "missing")
+        XCTAssertEqual(resp.descriptors[1].type, 0)  // PARAMETER_NOT_SET
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
@@ -52,4 +52,26 @@ final class ParameterServicesTests: XCTestCase {
             GetParametersSrv.self, name: "/talker/get_parameters")
         try await cli.waitForService(timeout: .milliseconds(100))
     }
+
+    func testGetParametersReturnsDeclaredValues() async throws {
+        let (_, node) = try await makeContextAndNode()
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        _ = try await node.declareParameter("alpha", default: 0.5)
+        try await node.startParameterServices()
+
+        let cli = try await node.createClient(
+            GetParametersSrv.self, name: "/talker/get_parameters")
+        try await cli.waitForService(timeout: .milliseconds(100))
+
+        let resp = try await cli.call(
+            GetParametersRequest(names: ["rate", "alpha", "missing"]),
+            timeout: .seconds(1))
+
+        XCTAssertEqual(resp.values.count, 3)
+        XCTAssertEqual(resp.values[0].type, 2)  // PARAMETER_INTEGER
+        XCTAssertEqual(resp.values[0].integerValue, 30)
+        XCTAssertEqual(resp.values[1].type, 3)  // PARAMETER_DOUBLE
+        XCTAssertEqual(resp.values[1].doubleValue, 0.5)
+        XCTAssertEqual(resp.values[2].type, 0)  // PARAMETER_NOT_SET — missing name
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
@@ -119,4 +119,57 @@ final class ParameterServicesTests: XCTestCase {
         let alpha = try await node.getParameter("alpha")
         XCTAssertEqual(alpha.value, .double(0.75))
     }
+
+    func testSetParametersAtomicallyRollsBackOnFailure() async throws {
+        let (_, node) = try await makeContextAndNode()
+        _ = try await node.declareParameter(
+            "rate",
+            default: Int64(30),
+            descriptor: ROS2ParameterDescriptor(
+                name: "rate", type: .integer, integerRange: 1...120))
+        _ = try await node.declareParameter("alpha", default: 0.5)
+        try await node.startParameterServices()
+
+        let cli = try await node.createClient(
+            SetParametersAtomicallySrv.self, name: "/talker/set_parameters_atomically")
+        try await cli.waitForService(timeout: .milliseconds(100))
+
+        var goodInt = SwiftROS2Messages.ParameterValue()
+        goodInt.type = 2
+        goodInt.integerValue = 60
+        var goodDouble = SwiftROS2Messages.ParameterValue()
+        goodDouble.type = 3
+        goodDouble.doubleValue = 0.9
+        var badInt = SwiftROS2Messages.ParameterValue()
+        badInt.type = 2
+        badInt.integerValue = 999
+
+        // First call: every parameter valid → atomic success.
+        let okResp = try await cli.call(
+            SetParametersAtomicallyRequest(parameters: [
+                Parameter(name: "rate", value: goodInt),
+                Parameter(name: "alpha", value: goodDouble),
+            ]),
+            timeout: .seconds(1))
+        XCTAssertTrue(okResp.result.successful)
+        let rate1 = try await node.getParameter("rate")
+        XCTAssertEqual(rate1.value, .integer(60))
+        let alpha1 = try await node.getParameter("alpha")
+        XCTAssertEqual(alpha1.value, .double(0.9))
+
+        // Second call: second parameter is out-of-range → both rolled back.
+        let failResp = try await cli.call(
+            SetParametersAtomicallyRequest(parameters: [
+                Parameter(name: "alpha", value: goodDouble),
+                Parameter(name: "rate", value: badInt),
+            ]),
+            timeout: .seconds(1))
+        XCTAssertFalse(failResp.result.successful)
+
+        // Net effect of failed call must be zero — values match the previous successful call.
+        let rate2 = try await node.getParameter("rate")
+        XCTAssertEqual(rate2.value, .integer(60))
+        let alpha2 = try await node.getParameter("alpha")
+        XCTAssertEqual(alpha2.value, .double(0.9))
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
@@ -172,4 +172,31 @@ final class ParameterServicesTests: XCTestCase {
         let alpha2 = try await node.getParameter("alpha")
         XCTAssertEqual(alpha2.value, .double(0.9))
     }
+
+    func testListParametersReturnsNamesAndPrefixes() async throws {
+        let (_, node) = try await makeContextAndNode()
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        _ = try await node.declareParameter("alpha", default: 0.5)
+        _ = try await node.declareParameter("group.beta", default: Int64(1))
+        _ = try await node.declareParameter("group.gamma", default: Int64(2))
+        try await node.startParameterServices()
+
+        let cli = try await node.createClient(
+            ListParametersSrv.self, name: "/talker/list_parameters")
+        try await cli.waitForService(timeout: .milliseconds(100))
+
+        // No prefix filter, depth = 0 (recursive).
+        let allResp = try await cli.call(
+            ListParametersRequest(prefixes: [], depth: 0), timeout: .seconds(1))
+        XCTAssertEqual(
+            Set(allResp.result.names),
+            ["rate", "alpha", "group.beta", "group.gamma"])
+        XCTAssertEqual(allResp.result.prefixes, ["group"])
+
+        // Prefix-filtered.
+        let groupResp = try await cli.call(
+            ListParametersRequest(prefixes: ["group"], depth: 0),
+            timeout: .seconds(1))
+        XCTAssertEqual(Set(groupResp.result.names), ["group.beta", "group.gamma"])
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
@@ -74,4 +74,49 @@ final class ParameterServicesTests: XCTestCase {
         XCTAssertEqual(resp.values[1].doubleValue, 0.5)
         XCTAssertEqual(resp.values[2].type, 0)  // PARAMETER_NOT_SET — missing name
     }
+
+    func testSetParametersAcceptsValidWritesAndReportsRangeFailure() async throws {
+        let (_, node) = try await makeContextAndNode()
+        _ = try await node.declareParameter(
+            "rate",
+            default: Int64(30),
+            descriptor: ROS2ParameterDescriptor(
+                name: "rate", type: .integer, integerRange: 1...120))
+        _ = try await node.declareParameter("alpha", default: 0.5)
+        try await node.startParameterServices()
+
+        let cli = try await node.createClient(
+            SetParametersSrv.self, name: "/talker/set_parameters")
+        try await cli.waitForService(timeout: .milliseconds(100))
+
+        var goodInt = SwiftROS2Messages.ParameterValue()
+        goodInt.type = 2
+        goodInt.integerValue = 60
+        var badInt = SwiftROS2Messages.ParameterValue()
+        badInt.type = 2
+        badInt.integerValue = 999  // outside 1...120
+        var goodDouble = SwiftROS2Messages.ParameterValue()
+        goodDouble.type = 3
+        goodDouble.doubleValue = 0.75
+
+        let resp = try await cli.call(
+            SetParametersRequest(parameters: [
+                Parameter(name: "rate", value: goodInt),
+                Parameter(name: "rate", value: badInt),
+                Parameter(name: "alpha", value: goodDouble),
+                Parameter(name: "missing", value: goodInt),
+            ]),
+            timeout: .seconds(1))
+
+        XCTAssertEqual(resp.results.count, 4)
+        XCTAssertTrue(resp.results[0].successful)
+        XCTAssertFalse(resp.results[1].successful)
+        XCTAssertTrue(resp.results[2].successful)
+        XCTAssertFalse(resp.results[3].successful)  // not declared
+
+        let stored = try await node.getParameter("rate")
+        XCTAssertEqual(stored.value, .integer(60))
+        let alpha = try await node.getParameter("alpha")
+        XCTAssertEqual(alpha.value, .double(0.75))
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
@@ -25,19 +25,34 @@ final class ParameterServicesTests: XCTestCase {
         // Manual registration since auto-start is opted out.
         try await node.startParameterServices()
 
-        // Each client.waitForService is satisfied by MockTransportSession's
-        // echo mode as long as the matching server name was registered.
-        for path in [
-            "/talker/get_parameters",
-            "/talker/set_parameters",
-            "/talker/set_parameters_atomically",
-            "/talker/list_parameters",
-            "/talker/describe_parameters",
-            "/talker/get_parameter_types",
-        ] {
-            let cli = try await node.createClient(GetParametersSrv.self, name: path)
-            try await cli.waitForService(timeout: .milliseconds(100))
-        }
+        // One client per service type so the type symbols (and the
+        // request/response request hashes) are exercised at compile time —
+        // the call-time semantics of each handler are covered by the
+        // dedicated per-handler tests below.
+        let getCli = try await node.createClient(
+            GetParametersSrv.self, name: "/talker/get_parameters")
+        try await getCli.waitForService(timeout: .milliseconds(100))
+
+        let setCli = try await node.createClient(
+            SetParametersSrv.self, name: "/talker/set_parameters")
+        try await setCli.waitForService(timeout: .milliseconds(100))
+
+        let setAtomicCli = try await node.createClient(
+            SetParametersAtomicallySrv.self,
+            name: "/talker/set_parameters_atomically")
+        try await setAtomicCli.waitForService(timeout: .milliseconds(100))
+
+        let listCli = try await node.createClient(
+            ListParametersSrv.self, name: "/talker/list_parameters")
+        try await listCli.waitForService(timeout: .milliseconds(100))
+
+        let describeCli = try await node.createClient(
+            DescribeParametersSrv.self, name: "/talker/describe_parameters")
+        try await describeCli.waitForService(timeout: .milliseconds(100))
+
+        let typesCli = try await node.createClient(
+            GetParameterTypesSrv.self, name: "/talker/get_parameter_types")
+        try await typesCli.waitForService(timeout: .milliseconds(100))
     }
 
     func testStartParameterServicesIsIdempotent() async throws {

--- a/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
@@ -1,0 +1,55 @@
+import SwiftROS2Messages
+import SwiftROS2Transport
+import XCTest
+
+@testable import SwiftROS2
+
+final class ParameterServicesTests: XCTestCase {
+    private func makeContextAndNode(
+        nodeName: String = "talker",
+        options: ROS2NodeOptions = .default
+    ) async throws -> (ROS2Context, ROS2Node) {
+        let mock = MockTransportSession()
+        mock.installEchoServiceTransport()
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/mock:7447"), session: mock)
+        let node = try await ctx.createNode(name: nodeName, options: options)
+        return (ctx, node)
+    }
+
+    func testStartParameterServicesRegistersAllSixRoutes() async throws {
+        let (_, node) = try await makeContextAndNode(
+            nodeName: "talker",
+            options: ROS2NodeOptions(startParameterServices: false))
+
+        // Manual registration since auto-start is opted out.
+        try await node.startParameterServices()
+
+        // Each client.waitForService is satisfied by MockTransportSession's
+        // echo mode as long as the matching server name was registered.
+        for path in [
+            "/talker/get_parameters",
+            "/talker/set_parameters",
+            "/talker/set_parameters_atomically",
+            "/talker/list_parameters",
+            "/talker/describe_parameters",
+            "/talker/get_parameter_types",
+        ] {
+            let cli = try await node.createClient(GetParametersSrv.self, name: path)
+            try await cli.waitForService(timeout: .milliseconds(100))
+        }
+    }
+
+    func testStartParameterServicesIsIdempotent() async throws {
+        let (_, node) = try await makeContextAndNode(
+            options: ROS2NodeOptions(startParameterServices: false))
+
+        try await node.startParameterServices()
+        try await node.startParameterServices()  // second call must be a no-op
+
+        // No exception — and the next createClient still works.
+        let cli = try await node.createClient(
+            GetParametersSrv.self, name: "/talker/get_parameters")
+        try await cli.waitForService(timeout: .milliseconds(100))
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
@@ -248,4 +248,51 @@ final class ParameterServicesTests: XCTestCase {
         XCTAssertEqual(resp.types, [2, 3, 1, 0])
         // Integer (2), Double (3), Bool (1), NOT_SET (0)
     }
+
+    func testAutoRegistersWhenOptionsDefault() async throws {
+        let mock = MockTransportSession()
+        mock.installEchoServiceTransport()
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/mock:7447"), session: mock)
+        // Default options: services should already be registered after createNode.
+        let node = try await ctx.createNode(name: "talker")
+        _ = try await node.declareParameter("rate", default: Int64(30))
+
+        let cli = try await node.createClient(
+            GetParametersSrv.self, name: "/talker/get_parameters")
+        try await cli.waitForService(timeout: .milliseconds(100))
+
+        let resp = try await cli.call(
+            GetParametersRequest(names: ["rate"]), timeout: .seconds(1))
+        XCTAssertEqual(resp.values.first?.integerValue, 30)
+    }
+
+    func testOptOutSkipsRegistration() async throws {
+        let mock = MockTransportSession()
+        mock.installEchoServiceTransport()
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/mock:7447"), session: mock)
+        let node = try await ctx.createNode(
+            name: "talker",
+            options: ROS2NodeOptions(startParameterServices: false))
+        _ = try await node.declareParameter("rate", default: Int64(30))
+
+        // The mock client dispatcher throws TransportError.notConnected when
+        // no matching server exists, which ServiceError.mapping surfaces as
+        // .serviceUnavailable. A timeout would also prove the call failed
+        // because no service was auto-registered.
+        let cli = try await node.createClient(
+            GetParametersSrv.self, name: "/talker/get_parameters")
+        do {
+            _ = try await cli.call(
+                GetParametersRequest(names: ["rate"]), timeout: .milliseconds(200))
+            XCTFail("expected the call to fail because services were not auto-registered")
+        } catch ServiceError.serviceUnavailable {
+            // expected: the mock dispatcher could not find a server with the name
+        } catch ServiceError.timeout {
+            // also acceptable: depending on the mock's failure surface mapping
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
@@ -288,4 +288,29 @@ final class ParameterStoreTests: XCTestCase {
         let r = await store.list(prefixes: [], depth: UInt64.max)
         XCTAssertEqual(r.names, ["a"])
     }
+
+    func testEntryReturnsNilForUndeclared() async {
+        let store = ParameterStore()
+        let result = await store.entry(name: "missing")
+        XCTAssertNil(result)
+    }
+
+    func testEntryReturnsValueAndDescriptorForDeclared() async throws {
+        let store = ParameterStore()
+        _ = try await store.declare(
+            name: "rate",
+            value: .integer(30),
+            descriptor: ROS2ParameterDescriptor(name: "rate", type: .integer))
+        let entry = await store.entry(name: "rate")
+        XCTAssertEqual(entry?.value, .integer(30))
+        XCTAssertEqual(entry?.descriptor.type, .integer)
+    }
+
+    func testMarkServicesStartedIsOneShot() async {
+        let store = ParameterStore()
+        let first = await store.markServicesStarted()
+        let second = await store.markServicesStarted()
+        XCTAssertTrue(first)
+        XCTAssertFalse(second)
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ROS2NodeOptionsTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2NodeOptionsTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+@testable import SwiftROS2
+
+final class ROS2NodeOptionsTests: XCTestCase {
+    func testDefaultsAutoRegisterParameterServices() {
+        let options = ROS2NodeOptions()
+        XCTAssertTrue(options.startParameterServices)
+    }
+
+    func testDefaultStaticMatchesInit() {
+        XCTAssertEqual(ROS2NodeOptions.default, ROS2NodeOptions())
+    }
+
+    func testOptOutOfParameterServices() {
+        let options = ROS2NodeOptions(startParameterServices: false)
+        XCTAssertFalse(options.startParameterServices)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 of 6 toward the Parameter API. Auto-registers the six standard
`rcl_interfaces` parameter services on every `ROS2Node`, routed
through the phase-2 `ParameterStore`. Opt-out via the new
`ROS2NodeOptions.startParameterServices = false`.

- New `ROS2NodeOptions` struct controlling per-node creation knobs
  (single field for now; phase 4 will add `/parameter_events` toggles
  alongside).
- New `Sources/SwiftROS2/Parameters/Node+ParameterServices.swift`:
  public `node.startParameterServices()` plus six static handler
  functions, each translating wire ↔ `ROS2*` types via the existing
  `WireBridge`.
- `ROS2Context.createNode(name:namespace:options:)` — `options`
  parameter with default `.default` so existing callers compile
  unchanged. Auto-registers services before `appendNode` so a thrown
  registration error never leaves a half-initialised node in the
  context.
- `ParameterStore` gets two internal helpers: `entry(name:)`
  (non-throwing accessor for service handlers) and `markServicesStarted()`
  (one-shot idempotency latch).
- Unit-tested end-to-end via `MockTransportSession` echo mode.
  No real wire / interop tests yet — those land in phase 6.

### Test-suite touch-ups

The new auto-register-on-`createNode` default surfaced a latent
assumption in five pre-existing test files that built fresh
`MockTransportSession()` instances without `installEchoServiceTransport()`
(default mock service mode is `.unsupported`, which makes the new
auto-registration throw). Mechanical fix:

- `Tests/SwiftROS2Tests/{ActionClient,ActionServer,NodeAction}Tests.swift` —
  every per-test `createNode(name: "t")` now passes
  `options: ROS2NodeOptions(startParameterServices: false)` because those
  tests are about action behaviour, not parameters.
- `Tests/SwiftROS2Tests/NodeLifecycleTests.swift` and
  `Tests/SwiftROS2Tests/Parameters/NodeParametersTests.swift` —
  the shared `makeContext()` helpers now call
  `installEchoServiceTransport()` on the mock so the default-options
  registration succeeds.

No production code outside `Context.swift` was touched.

## Service routing

Each service is bound under `<node_fqn>/<service>`:

- `<fqn>/get_parameters`
- `<fqn>/set_parameters`
- `<fqn>/set_parameters_atomically`
- `<fqn>/list_parameters`
- `<fqn>/describe_parameters`
- `<fqn>/get_parameter_types`

QoS is `.servicesDefault` (reliable, volatile, keep-last 10). Phase 6
will revisit if interop tests show drops.

## Public surface (additive — no API freeze break)

```swift
public struct ROS2NodeOptions: Sendable, Equatable {
    public var startParameterServices: Bool
    public init(startParameterServices: Bool = true)
    public static let `default`: ROS2NodeOptions
}

extension ROS2Context {
    public func createNode(
        name: String,
        namespace: String = "/",
        options: ROS2NodeOptions = .default
    ) async throws -> ROS2Node
}

extension ROS2Node {
    public func startParameterServices() async throws
}
```

## Test plan

- [x] swift build
- [x] swift test --parallel
- [x] swift format lint --strict
- [ ] CI Linux + Windows + Android builds green
- [ ] Phase 6 will add live `ros2 param list / get / set / describe` interop tests against a real Jazzy host.