### PR TITLE
feat(api): /parameter_events + on/pre/post-set callbacks (phase 4 of 6)

### DIFF
--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -109,6 +109,7 @@ public final class ROS2Context: @unchecked Sendable {
             // leak transport handles into the caller's hands.
             do {
                 try await node.startParameterServices()
+                await node.installParameterEventEmitter()
             } catch {
                 await node.destroy()
                 throw error

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -107,9 +107,12 @@ public final class ROS2Context: @unchecked Sendable {
             // any of the six createService calls throws, close the services
             // already created on this node before rethrowing so we don't
             // leak transport handles into the caller's hands.
+            //
+            // `startParameterServices()` also installs the /parameter_events
+            // emitter, so the auto-start and manual-start paths leave the
+            // node in the same observable state.
             do {
                 try await node.startParameterServices()
-                await node.installParameterEventEmitter()
             } catch {
                 await node.destroy()
                 throw error

--- a/Sources/SwiftROS2/Node.swift
+++ b/Sources/SwiftROS2/Node.swift
@@ -34,6 +34,7 @@ public final class ROS2Node: @unchecked Sendable {
     private let lock = NSLock()
 
     let parameterStore: ParameterStore = ParameterStore()
+    private var parameterEventPublisher: ROS2Publisher<ParameterEvent>?
 
     init(
         name: String,
@@ -391,6 +392,59 @@ public final class ROS2Node: @unchecked Sendable {
         }
         let ns = namespace.hasSuffix("/") ? namespace : namespace + "/"
         return "\(ns)\(topic)"
+    }
+}
+
+extension ROS2Node {
+    /// Called from `ROS2Context.createNode` when parameter services are
+    /// enabled. Installs the per-node emitter so the store's `declare` /
+    /// `set*` / `undeclare` operations route the resulting `ParameterEvent`
+    /// out the `/parameter_events` topic.
+    internal func installParameterEventEmitter() async {
+        let fqn = self.fullyQualifiedName
+        await parameterStore.setEventEmitter { [weak self] event in
+            guard let self = self else { return }
+            var stamped = event
+            stamped.node = fqn
+            Task { await self.dispatchParameterEvent(stamped) }
+        }
+    }
+
+    /// Lazily creates the `/parameter_events` publisher on first emission
+    /// and forwards the event. The publisher is appended to `publishers`
+    /// so `destroy()` closes it like any other.
+    private func dispatchParameterEvent(_ event: ParameterEvent) async {
+        do {
+            let pub = try await ensureParameterEventPublisher()
+            try pub.publish(event)
+        } catch {
+            // Silent drop: emitting a parameter event must never throw out
+            // of a parameter mutation. The store has already committed.
+        }
+    }
+
+    private func ensureParameterEventPublisher() async throws -> ROS2Publisher<ParameterEvent> {
+        lock.lock()
+        if let p = parameterEventPublisher {
+            lock.unlock()
+            return p
+        }
+        lock.unlock()
+        let pub = try await createPublisher(
+            ParameterEvent.self,
+            topic: "/parameter_events",
+            qos: .parameterEvents
+        )
+        lock.lock()
+        // Race: another caller may have created one between unlock + create.
+        if let existing = parameterEventPublisher {
+            lock.unlock()
+            try? pub.closePublisher()
+            return existing
+        }
+        parameterEventPublisher = pub
+        lock.unlock()
+        return pub
     }
 }
 

--- a/Sources/SwiftROS2/Node.swift
+++ b/Sources/SwiftROS2/Node.swift
@@ -35,6 +35,7 @@ public final class ROS2Node: @unchecked Sendable {
 
     let parameterStore: ParameterStore = ParameterStore()
     private var parameterEventPublisher: ROS2Publisher<ParameterEvent>?
+    private var parameterEventPublisherTask: Task<ROS2Publisher<ParameterEvent>, Error>?
 
     init(
         name: String,
@@ -396,10 +397,13 @@ public final class ROS2Node: @unchecked Sendable {
 }
 
 extension ROS2Node {
-    /// Called from `ROS2Context.createNode` when parameter services are
-    /// enabled. Installs the per-node emitter so the store's `declare` /
-    /// `set*` / `undeclare` operations route the resulting `ParameterEvent`
-    /// out the `/parameter_events` topic.
+    /// Installs the per-node emitter so the store's `declare` / `set*` /
+    /// `undeclare` operations route the resulting `ParameterEvent` out the
+    /// `/parameter_events` topic. Called from `startParameterServices()`
+    /// so the emitter is wired whether the node was created with
+    /// `ROS2NodeOptions.startParameterServices = true` (auto-start path)
+    /// or whether the caller opted out and later invoked
+    /// `node.startParameterServices()` manually.
     internal func installParameterEventEmitter() async {
         let fqn = self.fullyQualifiedName
         await parameterStore.setEventEmitter { [weak self] event in
@@ -423,29 +427,51 @@ extension ROS2Node {
         }
     }
 
+    /// Single-flight publisher creation. Concurrent callers share the same
+    /// in-flight `Task`, so `createPublisher` runs at most once and we
+    /// never end up with a "loser" publisher leaked into `publishers`.
     private func ensureParameterEventPublisher() async throws -> ROS2Publisher<ParameterEvent> {
+        // Fast path: already created.
         lock.lock()
         if let p = parameterEventPublisher {
             lock.unlock()
             return p
         }
-        lock.unlock()
-        let pub = try await createPublisher(
-            ParameterEvent.self,
-            topic: "/parameter_events",
-            qos: .parameterEvents
-        )
-        lock.lock()
-        // Race: another caller may have created one between unlock + create.
-        if let existing = parameterEventPublisher {
+        // Slow path: piggyback on an in-flight creation if one is running,
+        // otherwise become the creator.
+        if let inflight = parameterEventPublisherTask {
             lock.unlock()
-            try? pub.closePublisher()
-            return existing
+            return try await inflight.value
         }
-        parameterEventPublisher = pub
+        let task = Task<ROS2Publisher<ParameterEvent>, Error> { [weak self] in
+            guard let self = self else { throw ParameterEventPublisherError.nodeDeallocated }
+            return try await self.createPublisher(
+                ParameterEvent.self,
+                topic: "/parameter_events",
+                qos: .parameterEvents
+            )
+        }
+        parameterEventPublisherTask = task
         lock.unlock()
-        return pub
+
+        do {
+            let pub = try await task.value
+            lock.lock()
+            parameterEventPublisher = pub
+            parameterEventPublisherTask = nil
+            lock.unlock()
+            return pub
+        } catch {
+            lock.lock()
+            parameterEventPublisherTask = nil
+            lock.unlock()
+            throw error
+        }
     }
+}
+
+private enum ParameterEventPublisherError: Error {
+    case nodeDeallocated
 }
 
 // Internal protocols for type-erased cleanup

--- a/Sources/SwiftROS2/Parameters/Node+ParameterCallbacks.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterCallbacks.swift
@@ -1,0 +1,49 @@
+// Phase 4 of the Parameter API: callback registration entry points on
+// `ROS2Node`. Three flavours mirroring rclcpp — pre-set (proposes
+// mutations to the incoming list), on-set (vetoes), post-set (observes).
+// Each returns an opaque `ROS2ParameterCallbackHandle` the caller must
+// retain for the callback to remain active. Detach explicitly with
+// `removeParameterCallback(_:)`.
+
+extension ROS2Node {
+    /// Register a pre-set callback. Runs first, on the store's actor,
+    /// before validation. May rewrite the proposed parameter list (e.g.
+    /// inject co-dependent parameters).
+    @discardableResult
+    public func setPreSetParametersCallback(
+        _ cb: @escaping @Sendable (inout [ROS2Parameter]) -> Void
+    ) async -> ROS2ParameterCallbackHandle {
+        await parameterStore.registerPreSet(cb)
+    }
+
+    /// Register an on-set callback. Runs after descriptor validation, on
+    /// the store's actor. Returning `successful: false` vetoes the entire
+    /// batch (or the single item, when called via `setParameter` /
+    /// `setParameters`). Vetoed batches emit no `ParameterEvent`.
+    @discardableResult
+    public func setOnSetParametersCallback(
+        _ cb: @escaping @Sendable ([ROS2Parameter]) -> ROS2SetParametersResult
+    ) async -> ROS2ParameterCallbackHandle {
+        await parameterStore.registerOnSet(cb)
+    }
+
+    /// Register a post-set callback. Runs after a successful write, on the
+    /// store's actor. Receives only the parameters that were actually
+    /// applied. Observation only — return value is `Void`.
+    @discardableResult
+    public func setPostSetParametersCallback(
+        _ cb: @escaping @Sendable ([ROS2Parameter]) -> Void
+    ) async -> ROS2ParameterCallbackHandle {
+        await parameterStore.registerPostSet(cb)
+    }
+
+    /// Detach a previously registered callback. Returns `true` if the
+    /// handle was found and removed, `false` if no such registration
+    /// exists (or it had already been removed). Idempotent.
+    @discardableResult
+    public func removeParameterCallback(
+        _ handle: ROS2ParameterCallbackHandle
+    ) async -> Bool {
+        await parameterStore.unregisterCallback(handle)
+    }
+}

--- a/Sources/SwiftROS2/Parameters/Node+ParameterCallbacks.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterCallbacks.swift
@@ -1,9 +1,9 @@
 // Phase 4 of the Parameter API: callback registration entry points on
 // `ROS2Node`. Three flavours mirroring rclcpp — pre-set (proposes
 // mutations to the incoming list), on-set (vetoes), post-set (observes).
-// Each returns an opaque `ROS2ParameterCallbackHandle` the caller must
-// retain for the callback to remain active. Detach explicitly with
-// `removeParameterCallback(_:)`.
+// Each returns an opaque `ROS2ParameterCallbackHandle`. The store retains
+// the closure; callbacks stay active until `removeParameterCallback(_:)`
+// is called — dropping the returned handle does **not** detach.
 
 extension ROS2Node {
     /// Register a pre-set callback. Runs first, on the store's actor,

--- a/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterServices.swift
@@ -76,6 +76,12 @@ extension ROS2Node {
             await parameterStore.resetServicesStarted()
             throw error
         }
+
+        // Wire the /parameter_events emitter here (rather than in
+        // Context.createNode) so a manual `startParameterServices()` after
+        // an opt-out construction also gets event publishing — keeping
+        // the two start paths consistent.
+        await installParameterEventEmitter()
     }
 
     // MARK: - Service handlers

--- a/Sources/SwiftROS2/Parameters/ParameterStore.swift
+++ b/Sources/SwiftROS2/Parameters/ParameterStore.swift
@@ -14,9 +14,11 @@ actor ParameterStore {
     private var entries: [String: ParameterEntry] = [:]
     private var servicesStarted = false
 
-    // Callback registries, keyed by a monotonic id so unregister-by-handle
-    // is O(1). Stored as ordered arrays (id, closure) so we can iterate in
-    // registration order without sorting on every call.
+    // Callback registries, keyed by a monotonic id. Stored as ordered
+    // arrays (id, closure) so we can iterate in registration order.
+    // Unregister-by-handle is linear in the registry size; the registries
+    // typically hold a handful of callbacks, so the constant factor wins
+    // over a dictionary plus a separate ordering structure.
     private typealias PreSetCallback = @Sendable (inout [ROS2Parameter]) -> Void
     private typealias OnSetCallback = @Sendable ([ROS2Parameter]) -> ROS2SetParametersResult
     private typealias PostSetCallback = @Sendable ([ROS2Parameter]) -> Void
@@ -133,28 +135,60 @@ extension ParameterStore {
     }
 
     func setMany(_ ps: [ROS2Parameter]) -> [ROS2SetParametersResult] {
-        var out: [ROS2SetParametersResult] = []
-        out.reserveCapacity(ps.count)
-        var applied: [ROS2Parameter] = []
-        for p in ps {
-            // Per-item pre-set: callback may mutate the single-element list.
-            var batch: [ROS2Parameter] = [p]
-            for cb in preSetCallbacks { cb.fn(&batch) }
-            // batch is normally one element; we proceed with batch[0] if it
-            // remained, otherwise treat as a no-op success (rclcpp parity).
-            guard let proposed = batch.first else {
-                out.append(.success())
+        // Pre-set runs once on the full proposed list and may mutate it
+        // (inject co-dependent params, rewrite values, drop entries). The
+        // possibly-grown list is what we then iterate — so pre-set
+        // injections are not lost.
+        var batch = ps
+        for cb in preSetCallbacks { cb.fn(&batch) }
+
+        // Per-item descriptor validation. Failures are recorded individually
+        // and don't short-circuit the batch.
+        var results = Array(repeating: ROS2SetParametersResult.success(), count: batch.count)
+        var passingIndices: [Int] = []
+        for (i, p) in batch.enumerated() {
+            guard let entry = entries[p.name] else {
+                results[i] = .failure(reason: "parameter '\(p.name)' is not declared")
                 continue
             }
-            let r = applySingle(proposed)
-            if r.successful { applied.append(proposed) }
-            out.append(r)
+            if let reason = validate(
+                name: p.name, value: p.value, descriptor: entry.descriptor,
+                allowWriteToReadOnly: false)
+            {
+                results[i] = .failure(reason: reason)
+                continue
+            }
+            passingIndices.append(i)
+        }
+
+        guard !passingIndices.isEmpty else { return results }
+
+        // On-set runs once on the items that cleared validation. A veto
+        // marks every passing slot as failed and skips the writes — this
+        // lets a callback enforce cross-parameter invariants for the call.
+        let candidates = passingIndices.map { batch[$0] }
+        for cb in onSetCallbacks {
+            let r = cb.fn(candidates)
+            if !r.successful {
+                for i in passingIndices { results[i] = r }
+                return results
+            }
+        }
+
+        // Apply the writes for every passing item.
+        var applied: [ROS2Parameter] = []
+        for i in passingIndices {
+            let p = batch[i]
+            guard var entry = entries[p.name] else { continue }
+            entry.value = p.value
+            entries[p.name] = entry
+            applied.append(p)
         }
         if !applied.isEmpty {
             for cb in postSetCallbacks { cb.fn(applied) }
             emitChanged(applied)
         }
-        return out
+        return results
     }
 
     func setAtomically(_ ps: [ROS2Parameter]) -> ROS2SetParametersResult {
@@ -191,27 +225,6 @@ extension ParameterStore {
         }
         for cb in postSetCallbacks { cb.fn(batch) }
         emitChanged(batch)
-        return .success()
-    }
-
-    /// Validate + on-set + write a single proposed parameter. Returns the
-    /// SetParametersResult.
-    private func applySingle(_ p: ROS2Parameter) -> ROS2SetParametersResult {
-        guard var entry = entries[p.name] else {
-            return .failure(reason: "parameter '\(p.name)' is not declared")
-        }
-        if let reason = validate(
-            name: p.name, value: p.value, descriptor: entry.descriptor,
-            allowWriteToReadOnly: false)
-        {
-            return .failure(reason: reason)
-        }
-        for cb in onSetCallbacks {
-            let r = cb.fn([p])
-            if !r.successful { return r }
-        }
-        entry.value = p.value
-        entries[p.name] = entry
         return .success()
     }
 
@@ -370,8 +383,14 @@ extension ParameterStore {
 
     private func nowAsTime() -> Time {
         let sec = Date().timeIntervalSince1970
-        let secInt = Int32(sec)
-        let nanos = UInt32((sec - Double(secInt)) * 1_000_000_000)
+        // builtin_interfaces/Time.sec is `int32`. Clamping (rather than
+        // converting) keeps long-lived nodes from trapping past Y2038 — the
+        // resulting timestamp is wrong, but the node stays up. ROS itself
+        // is going to have to deal with the overflow upstream regardless.
+        let clamped = min(max(sec, Double(Int32.min)), Double(Int32.max))
+        let secInt = Int32(clamped)
+        let frac = clamped - Double(secInt)
+        let nanos = UInt32(min(max(frac * 1_000_000_000, 0.0), 999_999_999.0))
         return Time(sec: secInt, nanosec: nanos)
     }
 }

--- a/Sources/SwiftROS2/Parameters/ParameterStore.swift
+++ b/Sources/SwiftROS2/Parameters/ParameterStore.swift
@@ -2,6 +2,9 @@
 // describe with validation. Service registration and ParameterEvent
 // publishing land in phases 3 and 4 respectively.
 
+import Foundation
+import SwiftROS2Messages
+
 struct ParameterEntry: Sendable, Equatable {
     var value: ROS2ParameterValue
     var descriptor: ROS2ParameterDescriptor
@@ -10,6 +13,20 @@ struct ParameterEntry: Sendable, Equatable {
 actor ParameterStore {
     private var entries: [String: ParameterEntry] = [:]
     private var servicesStarted = false
+
+    // Callback registries, keyed by a monotonic id so unregister-by-handle
+    // is O(1). Stored as ordered arrays (id, closure) so we can iterate in
+    // registration order without sorting on every call.
+    private typealias PreSetCallback = @Sendable (inout [ROS2Parameter]) -> Void
+    private typealias OnSetCallback = @Sendable ([ROS2Parameter]) -> ROS2SetParametersResult
+    private typealias PostSetCallback = @Sendable ([ROS2Parameter]) -> Void
+
+    private var preSetCallbacks: [(id: UInt64, fn: PreSetCallback)] = []
+    private var onSetCallbacks: [(id: UInt64, fn: OnSetCallback)] = []
+    private var postSetCallbacks: [(id: UInt64, fn: PostSetCallback)] = []
+    private var nextCallbackId: UInt64 = 1
+
+    private var eventEmitter: (@Sendable (ParameterEvent) -> Void)?
 
     init() {}
 
@@ -208,5 +225,60 @@ extension ParameterStore {
     /// caller's own cleanup) and the node is left in an un-started state.
     func resetServicesStarted() {
         servicesStarted = false
+    }
+}
+
+extension ParameterStore {
+    func registerPreSet(
+        _ cb: @escaping @Sendable (inout [ROS2Parameter]) -> Void
+    ) -> ROS2ParameterCallbackHandle {
+        let id = nextCallbackId
+        nextCallbackId &+= 1
+        preSetCallbacks.append((id, cb))
+        return ROS2ParameterCallbackHandle(id: id)
+    }
+
+    func registerOnSet(
+        _ cb: @escaping @Sendable ([ROS2Parameter]) -> ROS2SetParametersResult
+    ) -> ROS2ParameterCallbackHandle {
+        let id = nextCallbackId
+        nextCallbackId &+= 1
+        onSetCallbacks.append((id, cb))
+        return ROS2ParameterCallbackHandle(id: id)
+    }
+
+    func registerPostSet(
+        _ cb: @escaping @Sendable ([ROS2Parameter]) -> Void
+    ) -> ROS2ParameterCallbackHandle {
+        let id = nextCallbackId
+        nextCallbackId &+= 1
+        postSetCallbacks.append((id, cb))
+        return ROS2ParameterCallbackHandle(id: id)
+    }
+
+    /// Returns `true` if a callback with that handle was found and removed,
+    /// `false` if no such handle was registered (or it had already been
+    /// removed). Idempotent — repeated calls are safe.
+    @discardableResult
+    func unregisterCallback(_ handle: ROS2ParameterCallbackHandle) -> Bool {
+        if let idx = preSetCallbacks.firstIndex(where: { $0.id == handle.id }) {
+            preSetCallbacks.remove(at: idx)
+            return true
+        }
+        if let idx = onSetCallbacks.firstIndex(where: { $0.id == handle.id }) {
+            onSetCallbacks.remove(at: idx)
+            return true
+        }
+        if let idx = postSetCallbacks.firstIndex(where: { $0.id == handle.id }) {
+            postSetCallbacks.remove(at: idx)
+            return true
+        }
+        return false
+    }
+
+    func setEventEmitter(
+        _ emitter: (@Sendable (ParameterEvent) -> Void)?
+    ) {
+        self.eventEmitter = emitter
     }
 }

--- a/Sources/SwiftROS2/Parameters/ParameterStore.swift
+++ b/Sources/SwiftROS2/Parameters/ParameterStore.swift
@@ -126,6 +126,75 @@ extension ParameterStore {
 extension ParameterStore {
     @discardableResult
     func set(_ p: ROS2Parameter) -> ROS2SetParametersResult {
+        let results = setMany([p])
+        return results.first ?? .failure(reason: "no result")
+    }
+
+    func setMany(_ ps: [ROS2Parameter]) -> [ROS2SetParametersResult] {
+        var out: [ROS2SetParametersResult] = []
+        out.reserveCapacity(ps.count)
+        var applied: [ROS2Parameter] = []
+        for p in ps {
+            // Per-item pre-set: callback may mutate the single-element list.
+            var batch: [ROS2Parameter] = [p]
+            for cb in preSetCallbacks { cb.fn(&batch) }
+            // batch is normally one element; we proceed with batch[0] if it
+            // remained, otherwise treat as a no-op success (rclcpp parity).
+            guard let proposed = batch.first else {
+                out.append(.success())
+                continue
+            }
+            let r = applySingle(proposed)
+            if r.successful { applied.append(proposed) }
+            out.append(r)
+        }
+        if !applied.isEmpty {
+            for cb in postSetCallbacks { cb.fn(applied) }
+            emitChanged(applied)
+        }
+        return out
+    }
+
+    func setAtomically(_ ps: [ROS2Parameter]) -> ROS2SetParametersResult {
+        var batch = ps
+        for cb in preSetCallbacks { cb.fn(&batch) }
+        // Validate every item against its descriptor first; any failure
+        // aborts the batch with the offending reason.
+        for p in batch {
+            guard let entry = entries[p.name] else {
+                return .failure(reason: "parameter '\(p.name)' is not declared")
+            }
+            if let reason = validate(
+                name: p.name, value: p.value, descriptor: entry.descriptor,
+                allowWriteToReadOnly: false)
+            {
+                return .failure(reason: reason)
+            }
+        }
+        // On-set chain: first failure short-circuits the whole batch.
+        for cb in onSetCallbacks {
+            let r = cb.fn(batch)
+            if !r.successful { return r }
+        }
+        // Snapshot for safe rollback (defensive — validation passed for every
+        // item, so the writes should never throw).
+        let snapshot = entries
+        for p in batch {
+            guard var entry = entries[p.name] else {
+                entries = snapshot
+                return .failure(reason: "parameter '\(p.name)' disappeared mid-batch")
+            }
+            entry.value = p.value
+            entries[p.name] = entry
+        }
+        for cb in postSetCallbacks { cb.fn(batch) }
+        emitChanged(batch)
+        return .success()
+    }
+
+    /// Validate + on-set + write a single proposed parameter. Returns the
+    /// SetParametersResult.
+    private func applySingle(_ p: ROS2Parameter) -> ROS2SetParametersResult {
         guard var entry = entries[p.name] else {
             return .failure(reason: "parameter '\(p.name)' is not declared")
         }
@@ -135,24 +204,12 @@ extension ParameterStore {
         {
             return .failure(reason: reason)
         }
+        for cb in onSetCallbacks {
+            let r = cb.fn([p])
+            if !r.successful { return r }
+        }
         entry.value = p.value
         entries[p.name] = entry
-        return .success()
-    }
-
-    func setMany(_ ps: [ROS2Parameter]) -> [ROS2SetParametersResult] {
-        ps.map { set($0) }
-    }
-
-    func setAtomically(_ ps: [ROS2Parameter]) -> ROS2SetParametersResult {
-        let snapshot = entries
-        for p in ps {
-            let r = set(p)
-            if !r.successful {
-                entries = snapshot
-                return r
-            }
-        }
         return .success()
     }
 
@@ -281,4 +338,10 @@ extension ParameterStore {
     ) {
         self.eventEmitter = emitter
     }
+}
+
+extension ParameterStore {
+    func emitChanged(_ params: [ROS2Parameter]) { /* filled in Task 5 */  }
+    func emitNew(_ params: [ROS2Parameter]) { /* filled in Task 5 */  }
+    func emitDeleted(_ params: [ROS2Parameter]) { /* filled in Task 5 */  }
 }

--- a/Sources/SwiftROS2/Parameters/ParameterStore.swift
+++ b/Sources/SwiftROS2/Parameters/ParameterStore.swift
@@ -48,13 +48,15 @@ actor ParameterStore {
             throw ROS2ParameterError.invalidValue(name: name, reason: reason)
         }
         entries[name] = ParameterEntry(value: value, descriptor: descriptor)
+        emitNew([ROS2Parameter(name: name, value: value)])
         return value
     }
 
     func undeclare(name: String) throws {
-        guard entries.removeValue(forKey: name) != nil else {
+        guard let removed = entries.removeValue(forKey: name) else {
             throw ROS2ParameterError.notDeclared(name: name)
         }
+        emitDeleted([ROS2Parameter(name: name, value: removed.value)])
     }
 
     func has(name: String) -> Bool {
@@ -341,7 +343,35 @@ extension ParameterStore {
 }
 
 extension ParameterStore {
-    func emitChanged(_ params: [ROS2Parameter]) { /* filled in Task 5 */  }
-    func emitNew(_ params: [ROS2Parameter]) { /* filled in Task 5 */  }
-    func emitDeleted(_ params: [ROS2Parameter]) { /* filled in Task 5 */  }
+    /// Build a `ParameterEvent` from per-bucket lists and fan it out via the
+    /// installed emitter (if any). The `node` field is filled by the emitter
+    /// closure on the Node side — the store doesn't know its own FQN.
+    private func emit(
+        new: [ROS2Parameter] = [],
+        changed: [ROS2Parameter] = [],
+        deleted: [ROS2Parameter] = []
+    ) {
+        guard let emitter = eventEmitter else { return }
+        guard !(new.isEmpty && changed.isEmpty && deleted.isEmpty) else { return }
+        let now = nowAsTime()
+        let event = ParameterEvent(
+            stamp: now,
+            node: "",  // filled in by the Node-side emitter wrapper
+            newParameters: new.map { $0.toWire() },
+            changedParameters: changed.map { $0.toWire() },
+            deletedParameters: deleted.map { $0.toWire() }
+        )
+        emitter(event)
+    }
+
+    func emitChanged(_ params: [ROS2Parameter]) { emit(changed: params) }
+    func emitNew(_ params: [ROS2Parameter]) { emit(new: params) }
+    func emitDeleted(_ params: [ROS2Parameter]) { emit(deleted: params) }
+
+    private func nowAsTime() -> Time {
+        let sec = Date().timeIntervalSince1970
+        let secInt = Int32(sec)
+        let nanos = UInt32((sec - Double(secInt)) * 1_000_000_000)
+        return Time(sec: secInt, nanosec: nanos)
+    }
 }

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterCallbackHandle.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterCallbackHandle.swift
@@ -1,0 +1,16 @@
+/// Opaque token returned by the three callback-registration methods on
+/// `ROS2Node`. The caller must keep the handle alive for as long as the
+/// callback should remain active — letting it go out of scope detaches
+/// the registration on the next store mutation.
+///
+/// Mirrors rclcpp's `OnSetParametersCallbackHandle::SharedPtr` pattern.
+public struct ROS2ParameterCallbackHandle: Sendable, Hashable {
+    /// Monotonic id assigned by the owning `ParameterStore`. Internal-
+    /// visibility so test code in `@testable import SwiftROS2` can build
+    /// handles directly without going through registration.
+    let id: UInt64
+
+    init(id: UInt64) {
+        self.id = id
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterCallbackHandle.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterCallbackHandle.swift
@@ -1,9 +1,9 @@
 /// Opaque token returned by the three callback-registration methods on
-/// `ROS2Node`. The caller must keep the handle alive for as long as the
-/// callback should remain active — letting it go out of scope detaches
-/// the registration on the next store mutation.
-///
-/// Mirrors rclcpp's `OnSetParametersCallbackHandle::SharedPtr` pattern.
+/// `ROS2Node`. The handle is a value type that holds an id — the owning
+/// `ParameterStore` retains the closure independently. Callbacks remain
+/// active until you explicitly detach them via
+/// `ROS2Node.removeParameterCallback(_:)`; dropping the handle does not
+/// auto-unregister.
 public struct ROS2ParameterCallbackHandle: Sendable, Hashable {
     /// Monotonic id assigned by the owning `ParameterStore`. Internal-
     /// visibility so test code in `@testable import SwiftROS2` can build

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterCallbackHandle.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterCallbackHandle.swift
@@ -9,8 +9,4 @@ public struct ROS2ParameterCallbackHandle: Sendable, Hashable {
     /// visibility so test code in `@testable import SwiftROS2` can build
     /// handles directly without going through registration.
     let id: UInt64
-
-    init(id: UInt64) {
-        self.id = id
-    }
 }

--- a/Sources/SwiftROS2/QoSProfile.swift
+++ b/Sources/SwiftROS2/QoSProfile.swift
@@ -59,6 +59,15 @@ public struct QoSProfile: Sendable, Equatable {
         history: .keepLast(1)
     )
 
+    /// `rmw_qos_profile_parameter_events` — reliable, transient-local,
+    /// keep-last 1000. Used by the `/parameter_events` topic so a late-
+    /// joining subscriber sees recent events. Do not reduce the depth.
+    public static let parameterEvents = QoSProfile(
+        reliability: .reliable,
+        durability: .transientLocal,
+        history: .keepLast(1000)
+    )
+
     /// Default for services
     public static let servicesDefault = QoSProfile(
         reliability: .reliable,

--- a/Tests/SwiftROS2Tests/Parameters/ParameterCallbacksTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterCallbacksTests.swift
@@ -1,3 +1,4 @@
+import SwiftROS2Transport
 import XCTest
 
 @testable import SwiftROS2
@@ -7,6 +8,13 @@ final class ParameterCallbacksTests: XCTestCase {
         _ = try await store.declare(
             name: name, value: value,
             descriptor: ROS2ParameterDescriptor(name: name, type: value.parameterType))
+    }
+
+    private func makeContext() async throws -> ROS2Context {
+        let config = TransportConfig.zenoh(locator: "tcp/mock:7447")
+        let mock = MockTransportSession()
+        mock.installEchoServiceTransport()
+        return try await ROS2Context(transport: config, session: mock)
     }
 
     func testPreSetMutatesProposedList() async throws {
@@ -72,6 +80,43 @@ final class ParameterCallbacksTests: XCTestCase {
         let b = try await store.get(name: "b")
         XCTAssertEqual(a.value, .integer(1))
         XCTAssertEqual(b.value, .integer(2))
+    }
+
+    func testNodeOnSetCallbackVetoesViaSet() async throws {
+        let ctx = try await makeContext()
+        let node = try await ctx.createNode(name: "n1")
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        _ = await node.setOnSetParametersCallback { _ in
+            ROS2SetParametersResult(successful: false, reason: "guarded")
+        }
+        let r = await node.setParameter(ROS2Parameter(name: "rate", value: .integer(99)))
+        XCTAssertFalse(r.successful)
+        XCTAssertEqual(r.reason, "guarded")
+    }
+
+    func testNodeRemoveParameterCallback() async throws {
+        let ctx = try await makeContext()
+        let node = try await ctx.createNode(name: "n2")
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        let h = await node.setOnSetParametersCallback { _ in
+            ROS2SetParametersResult(successful: false, reason: "guarded")
+        }
+        let removed = await node.removeParameterCallback(h)
+        XCTAssertTrue(removed)
+        let r = await node.setParameter(ROS2Parameter(name: "rate", value: .integer(99)))
+        XCTAssertTrue(r.successful)
     }
 
     func testRemovedCallbackStopsFiring() async throws {

--- a/Tests/SwiftROS2Tests/Parameters/ParameterCallbacksTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterCallbacksTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+
+@testable import SwiftROS2
+
+final class ParameterCallbacksTests: XCTestCase {
+    private func declared(_ store: ParameterStore, _ name: String, _ value: ROS2ParameterValue) async throws {
+        _ = try await store.declare(
+            name: name, value: value,
+            descriptor: ROS2ParameterDescriptor(name: name, type: value.parameterType))
+    }
+
+    func testPreSetMutatesProposedList() async throws {
+        let store = ParameterStore()
+        try await declared(store, "rate", .integer(30))
+        _ = await store.registerPreSet { ps in
+            ps = ps.map {
+                if $0.name == "rate", case .integer(let v) = $0.value {
+                    return ROS2Parameter(name: "rate", value: .integer(v * 2))
+                }
+                return $0
+            }
+        }
+        let r = await store.set(ROS2Parameter(name: "rate", value: .integer(20)))
+        XCTAssertTrue(r.successful)
+        let stored = try await store.get(name: "rate")
+        XCTAssertEqual(stored.value, .integer(40))
+    }
+
+    func testOnSetVetoBlocksWrite() async throws {
+        let store = ParameterStore()
+        try await declared(store, "rate", .integer(30))
+        _ = await store.registerOnSet { _ in .failure(reason: "vetoed") }
+        let r = await store.set(ROS2Parameter(name: "rate", value: .integer(20)))
+        XCTAssertFalse(r.successful)
+        XCTAssertEqual(r.reason, "vetoed")
+        let stored = try await store.get(name: "rate")
+        XCTAssertEqual(stored.value, .integer(30))
+    }
+
+    func testPostSetSeesOnlySuccesses() async throws {
+        let store = ParameterStore()
+        try await declared(store, "a", .integer(1))
+        try await declared(store, "b", .integer(2))
+        actor Box {
+            var seen: [ROS2Parameter] = []
+            func add(_ ps: [ROS2Parameter]) { seen += ps }
+        }
+        let box = Box()
+        _ = await store.registerPostSet { ps in Task { await box.add(ps) } }
+        _ = await store.setMany([
+            ROS2Parameter(name: "a", value: .integer(10)),
+            ROS2Parameter(name: "missing", value: .integer(0)),
+            ROS2Parameter(name: "b", value: .integer(20)),
+        ])
+        // Allow the detached Task posting into Box to drain.
+        try await Task.sleep(nanoseconds: 20_000_000)
+        let names = await box.seen.map { $0.name }
+        XCTAssertEqual(names.sorted(), ["a", "b"])
+    }
+
+    func testSetAtomicallyVetoLeavesNothingChanged() async throws {
+        let store = ParameterStore()
+        try await declared(store, "a", .integer(1))
+        try await declared(store, "b", .integer(2))
+        _ = await store.registerOnSet { _ in .failure(reason: "no") }
+        let r = await store.setAtomically([
+            ROS2Parameter(name: "a", value: .integer(10)),
+            ROS2Parameter(name: "b", value: .integer(20)),
+        ])
+        XCTAssertFalse(r.successful)
+        let a = try await store.get(name: "a")
+        let b = try await store.get(name: "b")
+        XCTAssertEqual(a.value, .integer(1))
+        XCTAssertEqual(b.value, .integer(2))
+    }
+
+    func testRemovedCallbackStopsFiring() async throws {
+        let store = ParameterStore()
+        try await declared(store, "a", .integer(1))
+        actor Counter {
+            var n = 0
+            func inc() { n += 1 }
+        }
+        let c = Counter()
+        let h = await store.registerPostSet { _ in Task { await c.inc() } }
+        _ = await store.set(ROS2Parameter(name: "a", value: .integer(2)))
+        try await Task.sleep(nanoseconds: 20_000_000)
+        let firstN = await c.n
+        XCTAssertEqual(firstN, 1)
+        let removed = await store.unregisterCallback(h)
+        XCTAssertTrue(removed)
+        _ = await store.set(ROS2Parameter(name: "a", value: .integer(3)))
+        try await Task.sleep(nanoseconds: 20_000_000)
+        let secondN = await c.n
+        XCTAssertEqual(secondN, 1)
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ParameterEventTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterEventTests.swift
@@ -37,6 +37,29 @@ final class ParameterEventTests: XCTestCase {
         }
     }
 
+    /// `dispatchParameterEvent` runs in a detached `Task`, so events arrive
+    /// asynchronously after the parameter mutation returns. CI runners are
+    /// considerably slower than dev macs — replace fixed sleeps with a
+    /// bounded poll so the tests stop being flaky under load.
+    private func waitForEvents(
+        on session: MockTransportSession,
+        atLeast count: Int,
+        timeout: Duration = .seconds(2)
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if decodedEvents(on: session).count >= count { return }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    /// For tests asserting the *absence* of additional events (vetoed sets,
+    /// opt-out nodes), give the system a short fixed window to emit any
+    /// stragglers before sampling.
+    private func settleEventQueue() async {
+        try? await Task.sleep(for: .milliseconds(150))
+    }
+
     func testDeclareEmitsNewParameterEvent() async throws {
         let (ctx, session, node) = try await makeContext()
         defer {
@@ -46,7 +69,7 @@ final class ParameterEventTests: XCTestCase {
             }
         }
         _ = try await node.declareParameter("rate", default: Int64(30))
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitForEvents(on: session, atLeast: 1)
         let events = decodedEvents(on: session)
         XCTAssertEqual(events.count, 1)
         XCTAssertEqual(events.first?.newParameters.count, 1)
@@ -64,7 +87,7 @@ final class ParameterEventTests: XCTestCase {
         }
         _ = try await node.declareParameter("rate", default: Int64(30))
         _ = await node.setParameter(ROS2Parameter(name: "rate", value: .integer(60)))
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await waitForEvents(on: session, atLeast: 2)
         let events = decodedEvents(on: session)
         XCTAssertEqual(events.count, 2)  // declare + set
         // Publishing happens through detached Tasks so ordering is best-effort.
@@ -82,7 +105,7 @@ final class ParameterEventTests: XCTestCase {
         }
         _ = try await node.declareParameter("rate", default: Int64(30))
         try await node.undeclareParameter("rate")
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await waitForEvents(on: session, atLeast: 2)
         let events = decodedEvents(on: session)
         XCTAssertEqual(events.count, 2)
         let deletedNames = events.flatMap { $0.deletedParameters }.map { $0.name }
@@ -100,7 +123,10 @@ final class ParameterEventTests: XCTestCase {
         _ = try await node.declareParameter("rate", default: Int64(30))
         _ = await node.setOnSetParametersCallback { _ in .failure(reason: "no") }
         _ = await node.setParameter(ROS2Parameter(name: "rate", value: .integer(60)))
-        try await Task.sleep(nanoseconds: 50_000_000)
+        // Wait for the declare event to land, then settle to confirm no
+        // veto-triggered event sneaks in afterwards.
+        await waitForEvents(on: session, atLeast: 1)
+        await settleEventQueue()
         let events = decodedEvents(on: session)
         // Only the declare event, not the vetoed set.
         XCTAssertEqual(events.count, 1)
@@ -115,7 +141,9 @@ final class ParameterEventTests: XCTestCase {
             }
         }
         _ = try await node.declareParameter("rate", default: Int64(30))
-        try await Task.sleep(nanoseconds: 50_000_000)
+        // Opt-out node: emitter is never installed, so no publisher should
+        // be created. Settle briefly so any phantom emit would surface.
+        await settleEventQueue()
         let pub = session.publishers.first(where: { $0.topic.hasSuffix("/parameter_events") })
         XCTAssertNil(pub)
     }
@@ -129,7 +157,7 @@ final class ParameterEventTests: XCTestCase {
             }
         }
         _ = try await node.declareParameter("rate", default: Int64(30))
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitForEvents(on: session, atLeast: 1)
         let pub = session.publishers.first(where: { $0.topic.hasSuffix("/parameter_events") })
         XCTAssertNotNil(pub)
         // ROS 2 publishes /parameter_events on the *root* namespace, not under

--- a/Tests/SwiftROS2Tests/Parameters/ParameterEventTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterEventTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import SwiftROS2CDR
+import SwiftROS2Messages
+import SwiftROS2Transport
+import XCTest
+
+@testable import SwiftROS2
+
+final class ParameterEventTests: XCTestCase {
+    private func makeContext(
+        startParameterServices: Bool = true
+    ) async throws -> (ROS2Context, MockTransportSession, ROS2Node) {
+        let session = MockTransportSession()
+        session.installEchoServiceTransport()
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447"),
+            distro: .jazzy,
+            session: session
+        )
+        let node = try await ctx.createNode(
+            name: "events_node",
+            namespace: "/test",
+            options: ROS2NodeOptions(startParameterServices: startParameterServices)
+        )
+        return (ctx, session, node)
+    }
+
+    private func decodedEvents(
+        on session: MockTransportSession
+    ) -> [ParameterEvent] {
+        // Find the publisher created for /test/events_node/parameter_events.
+        guard let pub = session.publishers.first(where: { $0.topic.hasSuffix("/parameter_events") })
+        else { return [] }
+        return pub.publishedPayloads.compactMap { payload in
+            guard let dec = try? CDRDecoder(data: payload.data, isLegacySchema: false) else { return nil }
+            return try? ParameterEvent(from: dec)
+        }
+    }
+
+    func testDeclareEmitsNewParameterEvent() async throws {
+        let (ctx, session, node) = try await makeContext()
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let events = decodedEvents(on: session)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.newParameters.count, 1)
+        XCTAssertEqual(events.first?.newParameters.first?.name, "rate")
+        XCTAssertEqual(events.first?.node, "/test/events_node")
+    }
+
+    func testSetEmitsChangedParameterEvent() async throws {
+        let (ctx, session, node) = try await makeContext()
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        _ = await node.setParameter(ROS2Parameter(name: "rate", value: .integer(60)))
+        try await Task.sleep(nanoseconds: 100_000_000)
+        let events = decodedEvents(on: session)
+        XCTAssertEqual(events.count, 2)  // declare + set
+        // Publishing happens through detached Tasks so ordering is best-effort.
+        let changedNames = events.flatMap { $0.changedParameters }.map { $0.name }
+        XCTAssertEqual(changedNames, ["rate"])
+    }
+
+    func testUndeclareEmitsDeletedParameterEvent() async throws {
+        let (ctx, session, node) = try await makeContext()
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        try await node.undeclareParameter("rate")
+        try await Task.sleep(nanoseconds: 100_000_000)
+        let events = decodedEvents(on: session)
+        XCTAssertEqual(events.count, 2)
+        let deletedNames = events.flatMap { $0.deletedParameters }.map { $0.name }
+        XCTAssertEqual(deletedNames, ["rate"])
+    }
+
+    func testVetoedSetEmitsNoEvent() async throws {
+        let (ctx, session, node) = try await makeContext()
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        _ = await node.setOnSetParametersCallback { _ in .failure(reason: "no") }
+        _ = await node.setParameter(ROS2Parameter(name: "rate", value: .integer(60)))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let events = decodedEvents(on: session)
+        // Only the declare event, not the vetoed set.
+        XCTAssertEqual(events.count, 1)
+    }
+
+    func testOptOutNodeNeverCreatesEventPublisher() async throws {
+        let (ctx, session, node) = try await makeContext(startParameterServices: false)
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let pub = session.publishers.first(where: { $0.topic.hasSuffix("/parameter_events") })
+        XCTAssertNil(pub)
+    }
+
+    func testEventPublisherTopicAndQoS() async throws {
+        let (ctx, session, node) = try await makeContext()
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let pub = session.publishers.first(where: { $0.topic.hasSuffix("/parameter_events") })
+        XCTAssertNotNil(pub)
+        // ROS 2 publishes /parameter_events on the *root* namespace, not under
+        // the node FQN. Both rclcpp and rclpy do this — the topic is global.
+        XCTAssertEqual(pub?.topic, "/parameter_events")
+        XCTAssertEqual(pub?.qos.reliability, .reliable)
+        XCTAssertEqual(pub?.qos.durability, .transientLocal)
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
@@ -282,6 +282,44 @@ final class ParameterServicesTests: XCTestCase {
         XCTAssertEqual(resp.values.first?.integerValue, 30)
     }
 
+    func testSetParametersServiceEmitsEvent() async throws {
+        // Phase-4 Task 8: confirm the wire `set_parameters` service routes
+        // through the same store path that emits a /parameter_events
+        // publication. We need the session handle to inspect publishers,
+        // so don't reuse the helper that drops it.
+        let mock = MockTransportSession()
+        mock.installEchoServiceTransport()
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/mock:7447"), session: mock)
+        let node = try await ctx.createNode(name: "talker")
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
+        _ = try await node.declareParameter("rate", default: Int64(30))
+
+        let cli = try await node.createClient(
+            SetParametersSrv.self, name: "/talker/set_parameters")
+        try await cli.waitForService(timeout: .milliseconds(100))
+
+        var v = SwiftROS2Messages.ParameterValue()
+        v.type = 2
+        v.integerValue = 99
+        _ = try await cli.call(
+            SetParametersRequest(parameters: [
+                Parameter(name: "rate", value: v)
+            ]),
+            timeout: .seconds(2)
+        )
+        try await Task.sleep(nanoseconds: 100_000_000)
+        let pub = mock.publishers.first { $0.topic.hasSuffix("/parameter_events") }
+        XCTAssertNotNil(pub)
+        // declare emits one, set_parameters emits a second.
+        XCTAssertGreaterThanOrEqual(pub?.publishedPayloads.count ?? 0, 2)
+    }
+
     func testOptOutSkipsRegistration() async throws {
         let mock = MockTransportSession()
         mock.installEchoServiceTransport()

--- a/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterServicesTests.swift
@@ -313,8 +313,16 @@ final class ParameterServicesTests: XCTestCase {
             ]),
             timeout: .seconds(2)
         )
-        try await Task.sleep(nanoseconds: 100_000_000)
-        let pub = mock.publishers.first { $0.topic.hasSuffix("/parameter_events") }
+        // Bounded poll instead of fixed sleep — `dispatchParameterEvent`
+        // runs in a detached task and may take longer than 100 ms on a
+        // loaded CI runner.
+        let deadline = ContinuousClock.now + .seconds(2)
+        var pub: MockTransportPublisher?
+        while ContinuousClock.now < deadline {
+            pub = mock.publishers.first { $0.topic.hasSuffix("/parameter_events") }
+            if (pub?.publishedPayloads.count ?? 0) >= 2 { break }
+            try await Task.sleep(for: .milliseconds(20))
+        }
         XCTAssertNotNil(pub)
         // declare emits one, set_parameters emits a second.
         XCTAssertGreaterThanOrEqual(pub?.publishedPayloads.count ?? 0, 2)

--- a/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ParameterStoreTests.swift
@@ -313,4 +313,20 @@ final class ParameterStoreTests: XCTestCase {
         XCTAssertTrue(first)
         XCTAssertFalse(second)
     }
+
+    func testRegisterCallbackReturnsUniqueHandle() async {
+        let store = ParameterStore()
+        let h1 = await store.registerOnSet { _ in .success() }
+        let h2 = await store.registerOnSet { _ in .success() }
+        XCTAssertNotEqual(h1, h2)
+    }
+
+    func testUnregisterCallbackReturnsTrueOnce() async {
+        let store = ParameterStore()
+        let h = await store.registerOnSet { _ in .success() }
+        let firstRemove = await store.unregisterCallback(h)
+        let secondRemove = await store.unregisterCallback(h)
+        XCTAssertTrue(firstRemove)
+        XCTAssertFalse(secondRemove)
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterCallbackHandleTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterCallbackHandleTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+@testable import SwiftROS2
+
+final class ROS2ParameterCallbackHandleTests: XCTestCase {
+    func testEqualityById() {
+        let a = ROS2ParameterCallbackHandle(id: 1)
+        let b = ROS2ParameterCallbackHandle(id: 1)
+        let c = ROS2ParameterCallbackHandle(id: 2)
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+
+    func testHashableMatchesEquality() {
+        let a = ROS2ParameterCallbackHandle(id: 1)
+        let b = ROS2ParameterCallbackHandle(id: 1)
+        var set: Set<ROS2ParameterCallbackHandle> = []
+        set.insert(a)
+        XCTAssertTrue(set.contains(b))
+    }
+}

--- a/Tests/SwiftROS2Tests/QoSProfileTests.swift
+++ b/Tests/SwiftROS2Tests/QoSProfileTests.swift
@@ -29,6 +29,17 @@ final class QoSProfileTests: XCTestCase {
         XCTAssertEqual(QoSProfile.servicesDefault.durability, .volatile)
     }
 
+    func testParameterEventsPreset() {
+        let q = QoSProfile.parameterEvents
+        XCTAssertEqual(q.reliability, .reliable)
+        XCTAssertEqual(q.durability, .transientLocal)
+        if case .keepLast(let depth) = q.history {
+            XCTAssertEqual(depth, 1000)
+        } else {
+            XCTFail("expected keepLast(1000), got \(q.history)")
+        }
+    }
+
     func testDefaultIsSensorData() {
         XCTAssertEqual(QoSProfile.default, QoSProfile.sensorData)
     }


### PR DESCRIPTION
## Summary

- `ROS2Publisher<ParameterEvent>` on `/parameter_events`, lazy per node, torn down by `Node.destroy()`.
- `setPreSetParametersCallback`, `setOnSetParametersCallback`, `setPostSetParametersCallback`, `removeParameterCallback` on `ROS2Node`. All run on the `ParameterStore` actor.
- `QoSProfile.parameterEvents` preset (reliable, transient-local, keep-last 1000) — matches `rmw_qos_profile_parameter_events`.
- Successful `declare` / `undeclare` / `set` / `setMany` / `setAtomically` emit one event each, batched. Vetoed sets emit nothing.

## Phase

Phase 4 of 6 from the parameter API roadmap. Stacked atop main (PR #104).

## Test plan

- [ ] `swift test --parallel` clean
- [ ] `swift package diagnose-api-breaking-changes 1.0.0` reports only additive changes
- [ ] `swift format lint --strict` clean