### PR TITLE
feat(api): ROS2ParameterClient remote API (phase 5 of 6)

### DIFF
--- a/Sources/SwiftROS2/Parameters/Node+ParameterClient.swift
+++ b/Sources/SwiftROS2/Parameters/Node+ParameterClient.swift
@@ -1,0 +1,17 @@
+// Phase 5 of the Parameter API: factory on ROS2Node that constructs a
+// `ROS2ParameterClient` for a remote node by name. The extension is the
+// idiomatic entry point; constructing `ROS2ParameterClient` directly is
+// supported but discouraged.
+
+extension ROS2Node {
+    /// Construct a `ROS2ParameterClient` against a remote node's six
+    /// parameter services. The remote name must be the fully-qualified
+    /// node name (e.g. `/talker`, `/ns/talker`).
+    public func createParameterClient(
+        remoteNode: String,
+        defaultTimeout: Duration = .seconds(5)
+    ) async throws -> ROS2ParameterClient {
+        try await ROS2ParameterClient(
+            node: self, remoteNodeName: remoteNode, defaultTimeout: defaultTimeout)
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
@@ -139,11 +139,12 @@ extension ROS2ParameterClient {
 
 extension ROS2ParameterClient {
     /// Wait until every one of the six underlying clients reports that a
-    /// matching service is reachable, or until `timeout` elapses. Polls
-    /// in parallel via a child task group.
+    /// matching service is reachable, or until `timeout` elapses. Each
+    /// child wait sees the same `timeout` budget; whichever child throws
+    /// first cancels the rest via the task group.
     public func waitForService(timeout: Duration) async throws {
         try await withThrowingTaskGroup(of: Void.self) { group in
-            for cli in allClients() {
+            for cli in allClients(timeout: timeout) {
                 group.addTask { try await cli() }
             }
             try await group.waitForAll()
@@ -152,25 +153,27 @@ extension ROS2ParameterClient {
 
     /// Type-erases the six client `waitForService` calls into a list of
     /// throwing closures so the task group iterates uniformly.
-    private func allClients() -> [@Sendable () async throws -> Void] {
+    private func allClients(
+        timeout: Duration
+    ) -> [@Sendable () async throws -> Void] {
         [
             { [getParametersClient] in
-                try await getParametersClient.waitForService(timeout: .seconds(5))
+                try await getParametersClient.waitForService(timeout: timeout)
             },
             { [setParametersClient] in
-                try await setParametersClient.waitForService(timeout: .seconds(5))
+                try await setParametersClient.waitForService(timeout: timeout)
             },
             { [setParametersAtomicallyClient] in
-                try await setParametersAtomicallyClient.waitForService(timeout: .seconds(5))
+                try await setParametersAtomicallyClient.waitForService(timeout: timeout)
             },
             { [listParametersClient] in
-                try await listParametersClient.waitForService(timeout: .seconds(5))
+                try await listParametersClient.waitForService(timeout: timeout)
             },
             { [describeParametersClient] in
-                try await describeParametersClient.waitForService(timeout: .seconds(5))
+                try await describeParametersClient.waitForService(timeout: timeout)
             },
             { [getParameterTypesClient] in
-                try await getParameterTypesClient.waitForService(timeout: .seconds(5))
+                try await getParameterTypesClient.waitForService(timeout: timeout)
             },
         ]
     }

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
@@ -83,3 +83,26 @@ extension ROS2ParameterClient {
         return resp.values.map { ROS2ParameterValue(wire: $0) }
     }
 }
+
+extension ROS2ParameterClient {
+    public func setParameters(
+        _ ps: [ROS2Parameter], timeout: Duration? = nil
+    ) async throws -> [ROS2SetParametersResult] {
+        let req = SetParametersRequest(parameters: ps.map { $0.toWire() })
+        let resp = try await setParametersClient.call(
+            req, timeout: timeout ?? defaultTimeout)
+        return resp.results.map {
+            ROS2SetParametersResult(successful: $0.successful, reason: $0.reason)
+        }
+    }
+
+    public func setParametersAtomically(
+        _ ps: [ROS2Parameter], timeout: Duration? = nil
+    ) async throws -> ROS2SetParametersResult {
+        let req = SetParametersAtomicallyRequest(parameters: ps.map { $0.toWire() })
+        let resp = try await setParametersAtomicallyClient.call(
+            req, timeout: timeout ?? defaultTimeout)
+        return ROS2SetParametersResult(
+            successful: resp.result.successful, reason: resp.result.reason)
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
@@ -72,3 +72,14 @@ public final class ROS2ParameterClient: @unchecked Sendable {
         getParameterTypesClient.cancel()
     }
 }
+
+extension ROS2ParameterClient {
+    public func getParameters(
+        _ names: [String], timeout: Duration? = nil
+    ) async throws -> [ROS2ParameterValue] {
+        let req = GetParametersRequest(names: names)
+        let resp = try await getParametersClient.call(
+            req, timeout: timeout ?? defaultTimeout)
+        return resp.values.map { ROS2ParameterValue(wire: $0) }
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
@@ -106,3 +106,33 @@ extension ROS2ParameterClient {
             successful: resp.result.successful, reason: resp.result.reason)
     }
 }
+
+extension ROS2ParameterClient {
+    public func listParameters(
+        prefixes: [String] = [], depth: UInt64 = 0, timeout: Duration? = nil
+    ) async throws -> ROS2ListParametersResult {
+        let req = ListParametersRequest(prefixes: prefixes, depth: depth)
+        let resp = try await listParametersClient.call(
+            req, timeout: timeout ?? defaultTimeout)
+        return ROS2ListParametersResult(
+            names: resp.result.names, prefixes: resp.result.prefixes)
+    }
+
+    public func describeParameters(
+        _ names: [String], timeout: Duration? = nil
+    ) async throws -> [ROS2ParameterDescriptor] {
+        let req = DescribeParametersRequest(names: names)
+        let resp = try await describeParametersClient.call(
+            req, timeout: timeout ?? defaultTimeout)
+        return resp.descriptors.map { ROS2ParameterDescriptor(wire: $0) }
+    }
+
+    public func getParameterTypes(
+        _ names: [String], timeout: Duration? = nil
+    ) async throws -> [ROS2ParameterType] {
+        let req = GetParameterTypesRequest(names: names)
+        let resp = try await getParameterTypesClient.call(
+            req, timeout: timeout ?? defaultTimeout)
+        return resp.types.map { ROS2ParameterType(rawValue: $0) ?? .notSet }
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
@@ -136,3 +136,42 @@ extension ROS2ParameterClient {
         return resp.types.map { ROS2ParameterType(rawValue: $0) ?? .notSet }
     }
 }
+
+extension ROS2ParameterClient {
+    /// Wait until every one of the six underlying clients reports that a
+    /// matching service is reachable, or until `timeout` elapses. Polls
+    /// in parallel via a child task group.
+    public func waitForService(timeout: Duration) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for cli in allClients() {
+                group.addTask { try await cli() }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    /// Type-erases the six client `waitForService` calls into a list of
+    /// throwing closures so the task group iterates uniformly.
+    private func allClients() -> [@Sendable () async throws -> Void] {
+        [
+            { [getParametersClient] in
+                try await getParametersClient.waitForService(timeout: .seconds(5))
+            },
+            { [setParametersClient] in
+                try await setParametersClient.waitForService(timeout: .seconds(5))
+            },
+            { [setParametersAtomicallyClient] in
+                try await setParametersAtomicallyClient.waitForService(timeout: .seconds(5))
+            },
+            { [listParametersClient] in
+                try await listParametersClient.waitForService(timeout: .seconds(5))
+            },
+            { [describeParametersClient] in
+                try await describeParametersClient.waitForService(timeout: .seconds(5))
+            },
+            { [getParameterTypesClient] in
+                try await getParameterTypesClient.waitForService(timeout: .seconds(5))
+            },
+        ]
+    }
+}

--- a/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
+++ b/Sources/SwiftROS2/Parameters/ROS2ParameterClient.swift
@@ -1,0 +1,74 @@
+// Phase 5 of the Parameter API: a Swift-public client that talks to a
+// remote node's six rcl_interfaces parameter services. Each public method
+// is a thin wrapper: WireBridge encode → ROS2Client.call → WireBridge
+// decode. No transport-level work — every byte goes through the existing
+// ROS2Client / TransportClient stack.
+
+import Foundation
+import SwiftROS2Messages
+
+/// High-level client for a remote node's six parameter services.
+///
+/// Construct one via `ROS2Node.createParameterClient(remoteNode:)`.
+///
+/// ```swift
+/// let pc = try await node.createParameterClient(remoteNode: "/talker")
+/// try await pc.waitForService(timeout: .seconds(2))
+/// _ = try await pc.setParameters([
+///     ROS2Parameter(name: "rate", value: .integer(60))
+/// ])
+/// ```
+public final class ROS2ParameterClient: @unchecked Sendable {
+    public let remoteNodeName: String
+    public let defaultTimeout: Duration
+
+    private let getParametersClient: ROS2Client<GetParametersSrv>
+    private let setParametersClient: ROS2Client<SetParametersSrv>
+    private let setParametersAtomicallyClient: ROS2Client<SetParametersAtomicallySrv>
+    private let listParametersClient: ROS2Client<ListParametersSrv>
+    private let describeParametersClient: ROS2Client<DescribeParametersSrv>
+    private let getParameterTypesClient: ROS2Client<GetParameterTypesSrv>
+
+    private let lock = NSLock()
+    private var closed = false
+
+    public init(
+        node: ROS2Node,
+        remoteNodeName: String,
+        defaultTimeout: Duration = .seconds(5)
+    ) async throws {
+        self.remoteNodeName = remoteNodeName
+        self.defaultTimeout = defaultTimeout
+        self.getParametersClient = try await node.createClient(
+            GetParametersSrv.self, name: "\(remoteNodeName)/get_parameters")
+        self.setParametersClient = try await node.createClient(
+            SetParametersSrv.self, name: "\(remoteNodeName)/set_parameters")
+        self.setParametersAtomicallyClient = try await node.createClient(
+            SetParametersAtomicallySrv.self,
+            name: "\(remoteNodeName)/set_parameters_atomically")
+        self.listParametersClient = try await node.createClient(
+            ListParametersSrv.self, name: "\(remoteNodeName)/list_parameters")
+        self.describeParametersClient = try await node.createClient(
+            DescribeParametersSrv.self,
+            name: "\(remoteNodeName)/describe_parameters")
+        self.getParameterTypesClient = try await node.createClient(
+            GetParameterTypesSrv.self,
+            name: "\(remoteNodeName)/get_parameter_types")
+    }
+
+    public func close() async {
+        lock.lock()
+        if closed {
+            lock.unlock()
+            return
+        }
+        closed = true
+        lock.unlock()
+        getParametersClient.cancel()
+        setParametersClient.cancel()
+        setParametersAtomicallyClient.cancel()
+        listParametersClient.cancel()
+        describeParametersClient.cancel()
+        getParameterTypesClient.cancel()
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
@@ -208,4 +208,17 @@ final class ROS2ParameterClientTests: XCTestCase {
         let types = try await pc.getParameterTypes(["rate", "greeting", "missing"])
         XCTAssertEqual(types, [.integer, .string, .notSet])
     }
+
+    func testWaitForServiceSucceedsWhenAllSixAreUp() async throws {
+        let (ctx, server, client, pc) = try await makeServerAndClient()
+        defer {
+            Task {
+                await pc.close()
+                await client.destroy()
+                await server.destroy()
+                await ctx.shutdown()
+            }
+        }
+        try await pc.waitForService(timeout: .seconds(2))
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import SwiftROS2Messages
+import SwiftROS2Transport
+import XCTest
+
+@testable import SwiftROS2
+
+final class ROS2ParameterClientTests: XCTestCase {
+    private func makeContext() async throws -> (ROS2Context, MockTransportSession) {
+        let session = MockTransportSession()
+        session.installEchoServiceTransport()
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447"),
+            distro: .jazzy,
+            session: session
+        )
+        return (ctx, session)
+    }
+
+    /// Spin up one node that serves parameters and a second node that hosts
+    /// the client. Both share one MockTransportSession so the in-process
+    /// echo transport sees both sides.
+    private func makeServerAndClient(
+        params: [(String, ROS2ParameterValue)] = []
+    ) async throws -> (ROS2Context, ROS2Node, ROS2Node, ROS2ParameterClient) {
+        let (ctx, _) = try await makeContext()
+        let server = try await ctx.createNode(name: "server", namespace: "/test")
+        for (name, value) in params {
+            switch value {
+            case .integer(let v): _ = try await server.declareParameter(name, default: v)
+            case .double(let v): _ = try await server.declareParameter(name, default: v)
+            case .string(let v): _ = try await server.declareParameter(name, default: v)
+            case .bool(let v): _ = try await server.declareParameter(name, default: v)
+            default:
+                XCTFail("test helper does not declare \(value)")
+                throw XCTestError(.failureWhileWaiting)
+            }
+        }
+        let client = try await ctx.createNode(
+            name: "client", namespace: "/test",
+            options: ROS2NodeOptions(startParameterServices: false)
+        )
+        let pc = try await client.createParameterClient(
+            remoteNode: server.fullyQualifiedName)
+        return (ctx, server, client, pc)
+    }
+
+    func testInitCreatesAllSixUnderlyingClients() async throws {
+        let (ctx, server, client, pc) = try await makeServerAndClient()
+        defer {
+            Task {
+                await pc.close()
+                await client.destroy()
+                await server.destroy()
+                await ctx.shutdown()
+            }
+        }
+        XCTAssertEqual(pc.remoteNodeName, "/test/server")
+    }
+
+    func testCloseIsIdempotent() async throws {
+        let (ctx, server, client, pc) = try await makeServerAndClient()
+        defer {
+            Task {
+                await client.destroy()
+                await server.destroy()
+                await ctx.shutdown()
+            }
+        }
+        await pc.close()
+        await pc.close()  // must not crash
+    }
+}

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
@@ -70,4 +70,22 @@ final class ROS2ParameterClientTests: XCTestCase {
         await pc.close()
         await pc.close()  // must not crash
     }
+
+    func testGetParameters() async throws {
+        let (ctx, server, client, pc) = try await makeServerAndClient(
+            params: [("rate", .integer(30)), ("greeting", .string("hi"))])
+        defer {
+            Task {
+                await pc.close()
+                await client.destroy()
+                await server.destroy()
+                await ctx.shutdown()
+            }
+        }
+        let values = try await pc.getParameters(["rate", "greeting", "missing"])
+        XCTAssertEqual(values.count, 3)
+        XCTAssertEqual(values[0], .integer(30))
+        XCTAssertEqual(values[1], .string("hi"))
+        XCTAssertEqual(values[2], .notSet)
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
@@ -152,4 +152,60 @@ final class ROS2ParameterClientTests: XCTestCase {
         let a = try await server.getParameter("a")
         XCTAssertEqual(a.value, .integer(1))
     }
+
+    func testListParameters() async throws {
+        let (ctx, server, client, pc) = try await makeServerAndClient(
+            params: [("a.x", .integer(1)), ("a.y", .integer(2)), ("b", .integer(3))])
+        defer {
+            Task {
+                await pc.close()
+                await client.destroy()
+                await server.destroy()
+                await ctx.shutdown()
+            }
+        }
+        let r = try await pc.listParameters()
+        XCTAssertEqual(Set(r.names), ["a.x", "a.y", "b"])
+        XCTAssertEqual(Set(r.prefixes), ["a"])
+    }
+
+    func testDescribeParameters() async throws {
+        let (ctx, server, client, pc) = try await makeServerAndClient()
+        defer {
+            Task {
+                await pc.close()
+                await client.destroy()
+                await server.destroy()
+                await ctx.shutdown()
+            }
+        }
+        _ = try await server.declareParameter(
+            "rate",
+            default: Int64(30),
+            descriptor: ROS2ParameterDescriptor(
+                name: "rate", type: .integer,
+                description: "tick rate",
+                integerRange: 1...120))
+        let descs = try await pc.describeParameters(["rate"])
+        XCTAssertEqual(descs.count, 1)
+        XCTAssertEqual(descs[0].name, "rate")
+        XCTAssertEqual(descs[0].type, .integer)
+        XCTAssertEqual(descs[0].description, "tick rate")
+        XCTAssertEqual(descs[0].integerRange, 1...120)
+    }
+
+    func testGetParameterTypes() async throws {
+        let (ctx, server, client, pc) = try await makeServerAndClient(
+            params: [("rate", .integer(30)), ("greeting", .string("hi"))])
+        defer {
+            Task {
+                await pc.close()
+                await client.destroy()
+                await server.destroy()
+                await ctx.shutdown()
+            }
+        }
+        let types = try await pc.getParameterTypes(["rate", "greeting", "missing"])
+        XCTAssertEqual(types, [.integer, .string, .notSet])
+    }
 }

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
@@ -45,8 +45,12 @@ final class ROS2ParameterClientTests: XCTestCase {
         return (ctx, server, client, pc)
     }
 
-    func testInitCreatesAllSixUnderlyingClients() async throws {
-        let (ctx, server, client, pc) = try await makeServerAndClient()
+    func testInitWiresRemoteNameAndAllSixServiceClients() async throws {
+        // The init contract has two halves: the public `remoteNodeName` is
+        // recorded, and one underlying ROS2Client is created per service so
+        // every public method has somewhere to dispatch. Exercise both.
+        let (ctx, server, client, pc) = try await makeServerAndClient(
+            params: [("rate", .integer(30))])
         defer {
             Task {
                 await pc.close()
@@ -56,6 +60,20 @@ final class ROS2ParameterClientTests: XCTestCase {
             }
         }
         XCTAssertEqual(pc.remoteNodeName, "/test/server")
+        XCTAssertEqual(pc.defaultTimeout, .seconds(5))
+
+        // One round-trip per service confirms each underlying client was
+        // created against the right service name and connects to a handler.
+        _ = try await pc.getParameters(["rate"])
+        _ = try await pc.setParameters([
+            ROS2Parameter(name: "rate", value: .integer(31))
+        ])
+        _ = try await pc.setParametersAtomically([
+            ROS2Parameter(name: "rate", value: .integer(32))
+        ])
+        _ = try await pc.listParameters()
+        _ = try await pc.describeParameters(["rate"])
+        _ = try await pc.getParameterTypes(["rate"])
     }
 
     func testCloseIsIdempotent() async throws {

--- a/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/ROS2ParameterClientTests.swift
@@ -88,4 +88,68 @@ final class ROS2ParameterClientTests: XCTestCase {
         XCTAssertEqual(values[1], .string("hi"))
         XCTAssertEqual(values[2], .notSet)
     }
+
+    func testSetParameters() async throws {
+        let (ctx, server, client, pc) = try await makeServerAndClient(
+            params: [("rate", .integer(30))])
+        defer {
+            Task {
+                await pc.close()
+                await client.destroy()
+                await server.destroy()
+                await ctx.shutdown()
+            }
+        }
+        let results = try await pc.setParameters([
+            ROS2Parameter(name: "rate", value: .integer(99)),
+            ROS2Parameter(name: "missing", value: .integer(1)),
+        ])
+        XCTAssertEqual(results.count, 2)
+        XCTAssertTrue(results[0].successful)
+        XCTAssertFalse(results[1].successful)
+        let stored = try await server.getParameter("rate")
+        XCTAssertEqual(stored.value, .integer(99))
+    }
+
+    func testSetParametersAtomicallyBatchSuccess() async throws {
+        let (ctx, server, client, pc) = try await makeServerAndClient(
+            params: [("a", .integer(1)), ("b", .integer(2))])
+        defer {
+            Task {
+                await pc.close()
+                await client.destroy()
+                await server.destroy()
+                await ctx.shutdown()
+            }
+        }
+        let r = try await pc.setParametersAtomically([
+            ROS2Parameter(name: "a", value: .integer(10)),
+            ROS2Parameter(name: "b", value: .integer(20)),
+        ])
+        XCTAssertTrue(r.successful)
+        let a = try await server.getParameter("a")
+        let b = try await server.getParameter("b")
+        XCTAssertEqual(a.value, .integer(10))
+        XCTAssertEqual(b.value, .integer(20))
+    }
+
+    func testSetParametersAtomicallyRollsBackOnFailure() async throws {
+        let (ctx, server, client, pc) = try await makeServerAndClient(
+            params: [("a", .integer(1))])
+        defer {
+            Task {
+                await pc.close()
+                await client.destroy()
+                await server.destroy()
+                await ctx.shutdown()
+            }
+        }
+        let r = try await pc.setParametersAtomically([
+            ROS2Parameter(name: "a", value: .integer(10)),
+            ROS2Parameter(name: "missing", value: .integer(0)),
+        ])
+        XCTAssertFalse(r.successful)
+        let a = try await server.getParameter("a")
+        XCTAssertEqual(a.value, .integer(1))
+    }
 }


### PR DESCRIPTION
## Summary

- New `ROS2ParameterClient` class — six wire-typed `ROS2Client` instances backing thin async wrappers (`getParameters`, `setParameters`, `setParametersAtomically`, `listParameters`, `describeParameters`, `getParameterTypes`).
- New `ROS2Node.createParameterClient(remoteNode:defaultTimeout:)` factory.
- `waitForService` polls all six sub-clients in parallel.

## Phase

Phase 5 of 6 from the parameter API roadmap. **Stacked atop `feat/parameter-events`** (phase 4 PR). Rebase on `main` once that lands.

## Test plan

- [ ] `swift test --parallel` clean
- [ ] `swift package diagnose-api-breaking-changes 1.0.0` additive-only
- [ ] `swift format lint --strict` clean