### PR TITLE
feat(api): ros2 param CLI interop tests + 1.1.0 release (phase 6 of 6)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,6 +10,7 @@
 | 0.8.x | 0.9.0 | **None.** `swift-ros2-gen` (CLI + SwiftPM build plugin + hash-oracle CI) is purely additive — no existing public API changed. |
 | 0.9.x | 1.0.0 | **Six visibility-only changes** — plumbing types pulled out of the public surface (`TransportQoS`, `QoSPolicy`, `DDSBridge*`, `ZenohClientProtocol`/`DDSClientProtocol` + 10 related, `EntityManager`/`GIDManager` → `package`; `ZenohTransportPublisher`, `DeclaredKeyExpr`/`ZenohSubscriber`/`LivelinessToken` → `internal`). End-user APIs (`ROS2Context`, `ROS2Node`, `ROS2Publisher`, `ROS2Subscription`, `ROS2Service`, `ROS2Client`, `ROS2ActionServer`, `ROS2ActionClient`, `QoSProfile`, `TransportConfig`, all message types) are unchanged. |
 | 1.0.x | 1.x   | **None guaranteed.** Minor releases on the 1.x line will not break public API. |
+| 1.0.x | 1.1.0 | **None.** Parameter API (`ROS2Node.declareParameter` / `setParameter` / `setOnSetParametersCallback` / six standard parameter services / `/parameter_events` publisher / `ROS2ParameterClient`) is purely additive. |
 
 SwiftROS2 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once 1.0.0 is cut. Breaking changes after 1.0 require a major bump.
 
@@ -188,3 +189,48 @@ Diffs each generated `RIHS01_*` against the canonical rosidl JSON inside the nam
 ## 1.0 → 1.x compatibility contract
 
 After 1.0, no minor or patch release on the 1.x line will break the public API. Breaking changes require a major bump (2.0).
+
+---
+
+## 1.0 → 1.1 — Parameter API
+
+1.1.0 adds the ROS 2 Parameter API. Every existing 1.0.x symbol is unchanged; this section is just a tour of what's new so downstreams can adopt incrementally.
+
+### New Swift-public types
+
+- `ROS2ParameterValue` — sum type over the nine wire slots + `.notSet`.
+- `ROS2Parameter` — `name` + `value` pair.
+- `ROS2ParameterType` — Swift enum mirroring the wire `uint8` constants.
+- `ROS2ParameterDescriptor` — name, type, description, ranges, read-only / dynamic-typing flags.
+- `ROS2SetParametersResult`, `ROS2ListParametersResult` — Swift twins of the wire result structs.
+- `ROS2ParameterError` — typed errors for the throwing parameter APIs.
+- `ROS2ParameterCallbackHandle` — opaque token; keep it alive for the callback to remain active.
+- `ROS2ParameterClient` — high-level remote-node client.
+- `ROS2NodeOptions` — per-node creation toggles, currently `startParameterServices: Bool` (default `true`).
+- `QoSProfile.parameterEvents` — preset matching `rmw_qos_profile_parameter_events`.
+
+### New methods on `ROS2Node`
+
+```swift
+extension ROS2Node {
+    func declareParameter<T: ROS2ParameterConvertible>(_ name: String, default: T, descriptor: ROS2ParameterDescriptor, ignoreOverride: Bool) async throws -> T
+    func undeclareParameter(_ name: String) async throws
+    func hasParameter(_ name: String) async -> Bool
+    func listParameters(prefixes: [String], depth: UInt64) async -> ROS2ListParametersResult
+    func getParameter(_ name: String) async throws -> ROS2Parameter
+    func getParameterOrDefault<T: ROS2ParameterConvertible>(_ name: String, default: T) async -> T
+    func setParameter(_: ROS2Parameter) async -> ROS2SetParametersResult
+    func setParameters(_: [ROS2Parameter]) async -> [ROS2SetParametersResult]
+    func setParametersAtomically(_: [ROS2Parameter]) async -> ROS2SetParametersResult
+    func describeParameter(_ name: String) async throws -> ROS2ParameterDescriptor
+    func setPreSetParametersCallback(_:) async -> ROS2ParameterCallbackHandle
+    func setOnSetParametersCallback(_:) async -> ROS2ParameterCallbackHandle
+    func setPostSetParametersCallback(_:) async -> ROS2ParameterCallbackHandle
+    func removeParameterCallback(_:) async -> Bool
+    func createParameterClient(remoteNode: String, defaultTimeout: Duration) async throws -> ROS2ParameterClient
+}
+```
+
+### Adopting
+
+No code change is required to upgrade — `Context.createNode(...)` keeps its old signature and now also auto-registers the six parameter services (opt out via `ROS2NodeOptions(startParameterServices: false)` if you don't need them).

--- a/Package.swift
+++ b/Package.swift
@@ -465,6 +465,11 @@ if canBuildDDS {
             dependencies: ["SwiftROS2"],
             path: "Sources/Examples/ActionClient"
         ),
+        .executableTarget(
+            name: "parameter-demo",
+            dependencies: ["SwiftROS2"],
+            path: "Sources/Examples/ParameterDemo"
+        ),
 
         .testTarget(
             name: "SwiftROS2Tests",

--- a/README.md
+++ b/README.md
@@ -227,6 +227,44 @@ print(resp.success, resp.message)
 
 Failures (timeout, remote handler error, encoding / decoding) surface as `ServiceError` — pattern-match on `.timeout(_)`, `.handlerFailed(_)`, `.serviceUnavailable(_)`, `.taskCancelled`, etc.
 
+### Parameters
+
+Each `ROS2Node` exposes the standard six `rcl_interfaces` parameter services
+under `<node_fqn>/<service>`, plus a `/parameter_events` publisher. Declare
+parameters from Swift; remote tools (`ros2 param`, `rqt_param`) interoperate
+unchanged.
+
+```swift
+let node = try await ctx.createNode(name: "talker")
+_ = try await node.declareParameter(
+    "rate", default: Int64(30),
+    descriptor: ROS2ParameterDescriptor(
+        name: "rate", type: .integer, integerRange: Int64(1)...Int64(120)))
+
+_ = await node.setOnSetParametersCallback { proposed in
+    // Inspect proposed changes; return .failure(reason:) to veto.
+    .success()
+}
+```
+
+From a second terminal:
+
+```bash
+ros2 param list /talker
+ros2 param set  /talker rate 60
+ros2 topic echo /parameter_events
+```
+
+A runnable demo lives in [`Sources/Examples/ParameterDemo`](Sources/Examples/ParameterDemo/main.swift) — try `swift run parameter-demo zenoh`.
+
+To call a remote node's parameters from Swift:
+
+```swift
+let pc = try await node.createParameterClient(remoteNode: "/talker")
+try await pc.waitForService(timeout: .seconds(2))
+let values = try await pc.getParameters(["rate"])
+```
+
 ### Runnable examples
 
 End-to-end `talker` / `listener` demos modeled on `demo_nodes_cpp` — `swift run talker zenoh`, `swift run listener dds`, etc. — live under [`Sources/Examples/README.md`](Sources/Examples/README.md), with instructions for wiring them up to `ros2 topic echo` / `ros2 topic pub` on the ROS 2 side.

--- a/Sources/Examples/ParameterDemo/main.swift
+++ b/Sources/Examples/ParameterDemo/main.swift
@@ -1,0 +1,78 @@
+// Minimal parameter-server demo. Declares three parameters and idles
+// forever, so external tooling (`ros2 param list/get/set/describe`,
+// `rqt_param`) can drive the node from a second terminal.
+//
+// Usage:
+//   swift run parameter-demo zenoh [tcp/<host>:7447] [domain_id]
+//   swift run parameter-demo dds   [domain_id]
+
+import Foundation
+import SwiftROS2
+
+let args = Array(CommandLine.arguments.dropFirst())
+let transportName = args.first ?? "zenoh"
+
+let transport: TransportConfig
+switch transportName {
+case "zenoh":
+    let locator = args.dropFirst().first ?? "tcp/127.0.0.1:7447"
+    let domainId = args.dropFirst(2).first.flatMap(Int.init) ?? 0
+    transport = .zenoh(locator: locator, domainId: domainId)
+case "dds":
+    let domainId = args.dropFirst().first.flatMap(Int.init) ?? 0
+    transport = .ddsMulticast(domainId: domainId)
+default:
+    FileHandle.standardError.write(
+        Data("Unknown transport '\(transportName)'. Use 'zenoh' or 'dds'.\n".utf8))
+    exit(2)
+}
+
+let ctx = try await ROS2Context(transport: transport, distro: .jazzy)
+let node = try await ctx.createNode(name: "parameter_demo")
+
+_ = try await node.declareParameter(
+    "rate",
+    default: Int64(30),
+    descriptor: ROS2ParameterDescriptor(
+        name: "rate",
+        type: .integer,
+        description: "publish rate in Hz",
+        integerRange: Int64(1)...Int64(120)))
+
+_ = try await node.declareParameter(
+    "greeting",
+    default: "Hello, ROS 2",
+    descriptor: ROS2ParameterDescriptor(
+        name: "greeting",
+        type: .string,
+        description: "greeting message"))
+
+_ = try await node.declareParameter(
+    "enabled",
+    default: true,
+    descriptor: ROS2ParameterDescriptor(
+        name: "enabled",
+        type: .bool,
+        description: "publish on/off toggle"))
+
+_ = await node.setOnSetParametersCallback { proposed in
+    // Reject `rate` outside 1..120 even if the descriptor is bypassed.
+    for p in proposed {
+        if p.name == "rate", case .integer(let v) = p.value, !(1...120).contains(v) {
+            return .failure(reason: "rate must be in [1, 120]")
+        }
+    }
+    return .success()
+}
+
+print("parameter_demo running. Try:")
+print("  ros2 param list /parameter_demo")
+print("  ros2 param get  /parameter_demo rate")
+print("  ros2 param set  /parameter_demo rate 60")
+print("  ros2 param describe /parameter_demo greeting")
+
+while !Task.isCancelled {
+    try await Task.sleep(nanoseconds: 1_000_000_000)
+}
+
+await ctx.shutdown()

--- a/Tests/SwiftROS2IntegrationTests/Parameters/ParameterEventsInteropTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/Parameters/ParameterEventsInteropTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import SwiftROS2
+import SwiftROS2Messages
+import SwiftROS2Transport
+import XCTest
+
+final class ParameterEventsInteropTests: XCTestCase {
+    func testParameterEventsConsumableByROS2TopicEcho() async throws {
+        guard let _ = ProcessInfo.processInfo.environment["LINUX_IP"]
+        else { throw XCTSkip("Set LINUX_IP to run this test") }
+
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+            distro: .jazzy)
+        let node = try await ctx.createNode(name: "events_node", namespace: "/test")
+        defer { Task { await node.destroy(); await ctx.shutdown() } }
+
+        // Spawn a docker `ros2 topic echo --once` in the background. It
+        // returns the next message and exits.
+        let p = Process()
+        p.launchPath = "/usr/bin/env"
+        p.arguments = [
+            "docker", "exec", "ros_jazzy_zenoh", "bash", "-c",
+            "source /opt/ros/jazzy/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp && timeout 8 ros2 topic echo --once /parameter_events",
+        ]
+        let out = Pipe()
+        p.standardOutput = out
+        try p.run()
+
+        // Give the echo subscriber a moment to subscribe before we publish.
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+        _ = try await node.declareParameter("rate", default: Int64(30))
+
+        p.waitUntilExit()
+        let stdout = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        XCTAssertTrue(
+            stdout.contains("rate"),
+            "expected ros2 topic echo to receive ParameterEvent for 'rate', got: \(stdout)")
+        XCTAssertTrue(
+            stdout.contains("/test/events_node"),
+            "expected event.node to match swift-ros2 fqn, got: \(stdout)")
+    }
+}

--- a/Tests/SwiftROS2IntegrationTests/Parameters/ParameterEventsInteropTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/Parameters/ParameterEventsInteropTests.swift
@@ -6,8 +6,10 @@ import XCTest
 
 final class ParameterEventsInteropTests: XCTestCase {
     func testParameterEventsConsumableByROS2TopicEcho() async throws {
-        guard let _ = ProcessInfo.processInfo.environment["LINUX_IP"]
-        else { throw XCTSkip("Set LINUX_IP to run this test") }
+        // Match the gating used by the other LAN-gated tests in this
+        // target: skip on missing OR empty LINUX_IP.
+        guard let ip = ProcessInfo.processInfo.environment["LINUX_IP"], !ip.isEmpty
+        else { throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)") }
 
         let ctx = try await ROS2Context(
             transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
@@ -23,7 +25,7 @@ final class ParameterEventsInteropTests: XCTestCase {
         // Spawn a docker `ros2 topic echo --once` in the background. It
         // returns the next message and exits.
         let p = Process()
-        p.launchPath = "/usr/bin/env"
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         p.arguments = [
             "docker", "exec", "ros_jazzy_zenoh", "bash", "-c",
             "source /opt/ros/jazzy/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp && timeout 8 ros2 topic echo --once /parameter_events",

--- a/Tests/SwiftROS2IntegrationTests/Parameters/ParameterEventsInteropTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/Parameters/ParameterEventsInteropTests.swift
@@ -13,7 +13,12 @@ final class ParameterEventsInteropTests: XCTestCase {
             transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
             distro: .jazzy)
         let node = try await ctx.createNode(name: "events_node", namespace: "/test")
-        defer { Task { await node.destroy(); await ctx.shutdown() } }
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
 
         // Spawn a docker `ros2 topic echo --once` in the background. It
         // returns the next message and exits.

--- a/Tests/SwiftROS2IntegrationTests/Parameters/ROS2ParamCLIInteropTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/Parameters/ROS2ParamCLIInteropTests.swift
@@ -4,9 +4,16 @@ import SwiftROS2Messages
 import SwiftROS2Transport
 import XCTest
 
-/// LAN-gated `ros2 param` CLI interop. Runs against a docker stack defined
-/// in `support/docker/compose.yml` (Zenoh) and `compose-dds.yml` (DDS).
-/// Skips when `LINUX_IP` is unset.
+/// LAN-gated `ros2 param` CLI interop. Skips when `LINUX_IP` is unset
+/// or empty. Requires two running docker containers on the host:
+///   - `ros_jazzy_zenoh` — ROS 2 Jazzy + `rmw_zenoh_cpp` + an active
+///     `rmw_zenohd` peering at `tcp/127.0.0.1:7447`.
+///   - `ros_jazzy_dds`   — ROS 2 Jazzy + `rmw_cyclonedds_cpp` reachable
+///     on the chosen `ROS_DOMAIN_ID`.
+///
+/// The compose files for these containers live in the downstream Conduit
+/// repository under `support/docker/`; swift-ros2 itself does not ship a
+/// docker stack. Bring the containers up there before running the tests.
 final class ROS2ParamCLIInteropTests: XCTestCase {
     private func skipIfNoLinuxIP() throws -> String {
         guard let ip = ProcessInfo.processInfo.environment["LINUX_IP"], !ip.isEmpty
@@ -18,7 +25,7 @@ final class ROS2ParamCLIInteropTests: XCTestCase {
     /// on non-zero exit code with stderr in the message.
     private func dockerExec(container: String, _ shell: String) throws -> String {
         let p = Process()
-        p.launchPath = "/usr/bin/env"
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         p.arguments = ["docker", "exec", container, "bash", "-c", shell]
         let out = Pipe()
         let err = Pipe()

--- a/Tests/SwiftROS2IntegrationTests/Parameters/ROS2ParamCLIInteropTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/Parameters/ROS2ParamCLIInteropTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import SwiftROS2
+import SwiftROS2Messages
+import SwiftROS2Transport
+import XCTest
+
+/// LAN-gated `ros2 param` CLI interop. Runs against a docker stack defined
+/// in `support/docker/compose.yml` (Zenoh) and `compose-dds.yml` (DDS).
+/// Skips when `LINUX_IP` is unset.
+final class ROS2ParamCLIInteropTests: XCTestCase {
+    private func skipIfNoLinuxIP() throws -> String {
+        guard let ip = ProcessInfo.processInfo.environment["LINUX_IP"], !ip.isEmpty
+        else { throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)") }
+        return ip
+    }
+
+    /// Exec a command in the named docker container; returns stdout. Throws
+    /// on non-zero exit code with stderr in the message.
+    private func dockerExec(container: String, _ shell: String) throws -> String {
+        let p = Process()
+        p.launchPath = "/usr/bin/env"
+        p.arguments = ["docker", "exec", container, "bash", "-c", shell]
+        let out = Pipe()
+        let err = Pipe()
+        p.standardOutput = out
+        p.standardError = err
+        try p.run()
+        p.waitUntilExit()
+        let stdout = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        if p.terminationStatus != 0 {
+            let stderr = String(data: err.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            throw NSError(
+                domain: "DockerExec", code: Int(p.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "\(shell) failed: \(stderr)"])
+        }
+        return stdout
+    }
+
+    func testParamListGetSetDescribeOverZenoh() async throws {
+        _ = try skipIfNoLinuxIP()
+        let ctx = try await ROS2Context(
+            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+            distro: .jazzy)
+        let node = try await ctx.createNode(name: "cli_node", namespace: "/test")
+        defer { Task { await node.destroy(); await ctx.shutdown() } }
+
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        _ = try await node.declareParameter("greeting", default: "hi")
+        _ = try await node.declareParameter("enabled", default: true)
+
+        // Allow Zenoh discovery to settle.
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+
+        let prelude = "source /opt/ros/jazzy/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp"
+
+        let listOut = try dockerExec(
+            container: "ros_jazzy_zenoh",
+            "\(prelude) && ros2 param list /test/cli_node")
+        XCTAssertTrue(listOut.contains("rate"), "list missing rate: \(listOut)")
+        XCTAssertTrue(listOut.contains("greeting"))
+        XCTAssertTrue(listOut.contains("enabled"))
+
+        let getOut = try dockerExec(
+            container: "ros_jazzy_zenoh",
+            "\(prelude) && ros2 param get /test/cli_node rate")
+        XCTAssertTrue(getOut.contains("30"), "get rate not 30: \(getOut)")
+
+        let setOut = try dockerExec(
+            container: "ros_jazzy_zenoh",
+            "\(prelude) && ros2 param set /test/cli_node rate 60")
+        XCTAssertTrue(
+            setOut.contains("successful") || setOut.contains("Set"),
+            "set rate output unexpected: \(setOut)")
+
+        let storedAfterSet = try await node.getParameter("rate")
+        XCTAssertEqual(storedAfterSet.value, .integer(60))
+
+        let describeOut = try dockerExec(
+            container: "ros_jazzy_zenoh",
+            "\(prelude) && ros2 param describe /test/cli_node rate")
+        XCTAssertTrue(
+            describeOut.contains("Type: integer") || describeOut.contains("integer"),
+            "describe rate type missing: \(describeOut)")
+    }
+
+    func testParamListGetSetDescribeOverDDS() async throws {
+        let linuxIP = try skipIfNoLinuxIP()
+        let domain = 99
+        let ctx = try await ROS2Context(
+            transport: .ddsUnicast(
+                peers: [DDSPeer.peer(address: linuxIP, domainId: domain)],
+                domainId: domain),
+            distro: .jazzy, domainId: domain)
+        let node = try await ctx.createNode(name: "cli_node", namespace: "/test")
+        defer { Task { await node.destroy(); await ctx.shutdown() } }
+
+        _ = try await node.declareParameter("rate", default: Int64(30))
+        _ = try await node.declareParameter("greeting", default: "hi")
+
+        // CycloneDDS SPDP/SEDP needs more time than Zenoh.
+        try await Task.sleep(nanoseconds: 4_000_000_000)
+
+        let prelude =
+            "source /opt/ros/jazzy/setup.bash && export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp && export ROS_DOMAIN_ID=\(domain)"
+
+        let listOut = try dockerExec(
+            container: "ros_jazzy_dds",
+            "\(prelude) && ros2 param list /test/cli_node")
+        XCTAssertTrue(listOut.contains("rate"), "list missing rate (DDS): \(listOut)")
+
+        let setOut = try dockerExec(
+            container: "ros_jazzy_dds",
+            "\(prelude) && ros2 param set /test/cli_node rate 60")
+        XCTAssertTrue(
+            setOut.contains("successful") || setOut.contains("Set"),
+            "set rate (DDS) unexpected: \(setOut)")
+
+        let storedAfterSet = try await node.getParameter("rate")
+        XCTAssertEqual(storedAfterSet.value, .integer(60))
+    }
+}

--- a/Tests/SwiftROS2IntegrationTests/Parameters/ROS2ParamCLIInteropTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/Parameters/ROS2ParamCLIInteropTests.swift
@@ -42,7 +42,12 @@ final class ROS2ParamCLIInteropTests: XCTestCase {
             transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
             distro: .jazzy)
         let node = try await ctx.createNode(name: "cli_node", namespace: "/test")
-        defer { Task { await node.destroy(); await ctx.shutdown() } }
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
 
         _ = try await node.declareParameter("rate", default: Int64(30))
         _ = try await node.declareParameter("greeting", default: "hi")
@@ -92,7 +97,12 @@ final class ROS2ParamCLIInteropTests: XCTestCase {
                 domainId: domain),
             distro: .jazzy, domainId: domain)
         let node = try await ctx.createNode(name: "cli_node", namespace: "/test")
-        defer { Task { await node.destroy(); await ctx.shutdown() } }
+        defer {
+            Task {
+                await node.destroy()
+                await ctx.shutdown()
+            }
+        }
 
         _ = try await node.declareParameter("rate", default: Int64(30))
         _ = try await node.declareParameter("greeting", default: "hi")

--- a/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
+++ b/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
@@ -310,8 +310,20 @@ final class MockTransportPublisher: TransportPublisher, @unchecked Sendable {
 
     private let lock = NSLock()
     private var closed = false
-    private(set) var publishedPayloads: [(data: Data, timestamp: UInt64, sequenceNumber: Int64)] = []
+    private var _publishedPayloads: [(data: Data, timestamp: UInt64, sequenceNumber: Int64)] = []
     var deliveryFanout: ((Data, UInt64) -> Void)?
+
+    /// Snapshot of payloads observed so far, returned under the lock.
+    /// Reading the underlying storage without locking races against the
+    /// `publish(...)` writer — on Linux x86_64 (Swift 6.0 runtime) the
+    /// detector aborts the process with a "_ContiguousArrayStorage
+    /// deallocated with non-zero retain count" message; on other targets
+    /// it can silently mis-observe. Always go through the snapshot.
+    var publishedPayloads: [(data: Data, timestamp: UInt64, sequenceNumber: Int64)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _publishedPayloads
+    }
 
     var isActive: Bool {
         lock.lock()
@@ -332,7 +344,7 @@ final class MockTransportPublisher: TransportPublisher, @unchecked Sendable {
             lock.unlock()
             throw TransportError.publisherClosed
         }
-        publishedPayloads.append((data, timestamp, sequenceNumber))
+        _publishedPayloads.append((data, timestamp, sequenceNumber))
         let fanout = deliveryFanout
         lock.unlock()
         fanout?(data, timestamp)


### PR DESCRIPTION
## Summary

- New `Sources/Examples/ParameterDemo/main.swift` — talker-style executable showing declare + on-set callback + idle-loop. `swift run parameter-demo zenoh|dds`.
- New LAN-gated integration tests: `ROS2ParamCLIInteropTests` (`ros2 param list/get/set/describe`, both transports) and `ParameterEventsInteropTests` (`ros2 topic echo /parameter_events`).
- `MIGRATION.md` 1.0.0 → 1.1.0 section listing every new public symbol.
- `README.md` Parameter API section.

## Phase

Phase 6 of 6 — final phase before tagging 1.1.0. **Stacked atop `feat/parameter-client`** (phase 5). Will rebase to `main` once phases 4 + 5 land.

## Test plan

- [x] `swift test --parallel --skip SwiftROS2IntegrationTests` clean (skips LAN-gated tests when `LINUX_IP` is unset)
- [ ] `LINUX_IP=192.168.1.85 swift test --filter SwiftROS2IntegrationTests` passes against the docker stack (Zenoh + DDS, both Jazzy)
- [ ] `swift run parameter-demo zenoh` runs and accepts `ros2 param set` from a second terminal
- [x] `swift package diagnose-api-breaking-changes 1.0.0` additive-only
- [x] `swift format lint --strict` clean