### PR TITLE
feat(publisher): add publish(_:timestamp:sequenceNumber:) source-timestamp overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Source-timestamp publishing.** `ROS2Publisher.publish(_:timestamp:sequenceNumber:)` is a new additive overload that stamps the attachment's `timestamp_ns` field with a caller-supplied source timestamp (nanoseconds since the Unix epoch) — e.g. a sensor capture time — instead of the wall-clock publish time, and optionally takes an explicit attachment sequence number (defaulting to the publisher's own monotonic counter, just like `publish(_:)`). The existing `publish(_:)` now delegates to it with `Date()` and a nil sequence number, so its bytes are unchanged. Purely additive — no existing public API changed.
+
 ## [1.1.1] - 2026-05-16
 
 ### Fixed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,6 +11,7 @@
 | 0.9.x | 1.0.0 | **Six visibility-only changes** — plumbing types pulled out of the public surface (`TransportQoS`, `QoSPolicy`, `DDSBridge*`, `ZenohClientProtocol`/`DDSClientProtocol` + 10 related, `EntityManager`/`GIDManager` → `package`; `ZenohTransportPublisher`, `DeclaredKeyExpr`/`ZenohSubscriber`/`LivelinessToken` → `internal`). End-user APIs (`ROS2Context`, `ROS2Node`, `ROS2Publisher`, `ROS2Subscription`, `ROS2Service`, `ROS2Client`, `ROS2ActionServer`, `ROS2ActionClient`, `QoSProfile`, `TransportConfig`, all message types) are unchanged. |
 | 1.0.x | 1.x   | **None guaranteed.** Minor releases on the 1.x line will not break public API. |
 | 1.0.x | 1.1.0 | **None.** Parameter API (`ROS2Node.declareParameter` / `setParameter` / `setOnSetParametersCallback` / six standard parameter services / `/parameter_events` publisher / `ROS2ParameterClient`) is purely additive. |
+| 1.1.x | 1.2.0 | **None.** The `ROS2Publisher.publish(_:timestamp:sequenceNumber:)` source-timestamp overload is purely additive — the existing `publish(_:)` is unchanged (it now delegates to the overload with the same wall-clock timestamp + monotonic sequence). |
 
 SwiftROS2 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once 1.0.0 is cut. Breaking changes after 1.0 require a major bump.
 

--- a/Sources/SwiftROS2/Publisher.swift
+++ b/Sources/SwiftROS2/Publisher.swift
@@ -30,18 +30,48 @@ public final class ROS2Publisher<M: CDREncodable & ROS2MessageType>: @unchecked 
     /// `ROS2Message` conformers (generated and hand-written) write payload only —
     /// the Publisher writes the header. Per-type `encode(to:)` implementations
     /// must therefore not call `writeEncapsulationHeader()` themselves.
+    ///
+    /// The attachment's `timestamp_ns` field carries the wall-clock publish time
+    /// and the sequence number comes from this publisher's own monotonic counter.
+    /// Use ``publish(_:timestamp:sequenceNumber:)`` to supply a source timestamp
+    /// (e.g. a sensor capture time) and/or an explicit sequence number instead.
     public func publish(_ message: M) throws {
+        let timestamp = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
+        try publish(message, timestamp: timestamp, sequenceNumber: nil)
+    }
+
+    /// Publish a message with a caller-supplied source timestamp.
+    ///
+    /// Identical to ``publish(_:)`` in how it serializes the message (4-byte CDR
+    /// encapsulation header + `message.encode(to:)`), but the attachment's
+    /// `timestamp_ns` field carries `timestamp` instead of the wall-clock publish
+    /// time. This lets a publisher stamp the message with the moment the data was
+    /// captured (e.g. a sensor sample time) rather than the moment it went on the
+    /// wire.
+    ///
+    /// - Parameters:
+    ///   - message: The typed message to publish.
+    ///   - timestamp: Source timestamp in nanoseconds since the Unix epoch,
+    ///     written verbatim into the attachment's `timestamp_ns` field.
+    ///   - sequenceNumber: An explicit attachment sequence number. When `nil`
+    ///     (the default) this publisher's own monotonic counter is used, exactly
+    ///     as ``publish(_:)`` does.
+    public func publish(_ message: M, timestamp: UInt64, sequenceNumber: Int64? = nil) throws {
         let encoder = CDREncoder(isLegacySchema: isLegacySchema)
         encoder.writeEncapsulationHeader()
         try message.encode(to: encoder)
         let data = encoder.getData()
 
-        lock.lock()
-        let seq = sequenceNumber
-        sequenceNumber += 1
-        lock.unlock()
+        let seq: Int64
+        if let sequenceNumber {
+            seq = sequenceNumber
+        } else {
+            lock.lock()
+            seq = self.sequenceNumber
+            self.sequenceNumber += 1
+            lock.unlock()
+        }
 
-        let timestamp = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
         try transportPublisher.publish(data: data, timestamp: timestamp, sequenceNumber: seq)
     }
 

--- a/Tests/SwiftROS2Tests/NodeLifecycleTests.swift
+++ b/Tests/SwiftROS2Tests/NodeLifecycleTests.swift
@@ -83,6 +83,39 @@ final class NodeLifecycleTests: XCTestCase {
         XCTAssertEqual(seqs, [0, 1, 2])
     }
 
+    func testPublishWithSourceTimestampForwardsTimestampAndSequence() async throws {
+        let (ctx, session) = try await makeContext()
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+        let pub = try await node.createPublisher(StringMsg.self, topic: "chatter")
+
+        let sourceTimestamp: UInt64 = 1_700_000_000_123_456_789
+        try pub.publish(StringMsg(data: "hello"), timestamp: sourceTimestamp, sequenceNumber: 42)
+
+        let recorded = session.publishers[0]
+        XCTAssertEqual(recorded.publishedPayloads.count, 1)
+        let payload = recorded.publishedPayloads[0]
+        XCTAssertEqual(payload.timestamp, sourceTimestamp, "Caller timestamp must reach the attachment verbatim")
+        XCTAssertEqual(payload.sequenceNumber, 42, "Caller sequence number must be used as-is")
+        XCTAssertGreaterThanOrEqual(payload.data.count, 4, "CDR encapsulation header must be present")
+    }
+
+    func testPublishWithSourceTimestampNilSequenceUsesMonotonicCounter() async throws {
+        let (ctx, session) = try await makeContext()
+        let node = try await ctx.createNode(name: "n", namespace: "/ns")
+        let pub = try await node.createPublisher(StringMsg.self, topic: "chatter")
+
+        // Mixing the timestamp overload (nil sequence) with the plain overload
+        // must share the one monotonic counter: 0, 1, 2.
+        try pub.publish(StringMsg(data: "a"), timestamp: 100)
+        try pub.publish(StringMsg(data: "b"))
+        try pub.publish(StringMsg(data: "c"), timestamp: 300)
+
+        let payloads = session.publishers[0].publishedPayloads
+        XCTAssertEqual(payloads.map { $0.sequenceNumber }, [0, 1, 2])
+        XCTAssertEqual(payloads.map { $0.timestamp }[0], 100)
+        XCTAssertEqual(payloads.map { $0.timestamp }[2], 300)
+    }
+
     func testPublisherUsesAbsoluteTopicWhenLeadingSlash() async throws {
         let (ctx, session) = try await makeContext()
         let node = try await ctx.createNode(name: "n", namespace: "/ns")


### PR DESCRIPTION
## What

Adds an additive `ROS2Publisher` overload:

```swift
public func publish(_ message: M, timestamp: UInt64, sequenceNumber: Int64? = nil) throws
```

It serializes the message identically to `publish(_:)` (4-byte XCDR v1 encapsulation header + `message.encode(to:)`) but writes the caller-supplied `timestamp` (nanoseconds since the Unix epoch) into the attachment's `timestamp_ns` field instead of the wall-clock publish time, and optionally takes an explicit attachment sequence number (defaulting to the publisher's own monotonic counter).

The existing `publish(_:)` now delegates to the overload with `Date()` + a nil sequence number, so its bytes are unchanged.

## Why

Lets a publisher stamp the wire attachment with the moment data was captured (e.g. a sensor sample time) rather than the moment it went on the wire. Downstream consumers (Conduit) carry a sensor-header timestamp and previously reached into the package-internal transport layer to set it; this exposes it through the public API.

## Compatibility

Purely additive — no existing public type, function, or wire output changes. Documented as `1.1.x → 1.2.0` (no breaking changes) in `MIGRATION.md` and under `[Unreleased]` in `CHANGELOG.md`.

## Tests

- New `NodeLifecycleTests` cases assert the caller timestamp + sequence number reach the transport verbatim, and that a nil sequence shares the monotonic counter with `publish(_:)`.
- Full suite green (`swift test --parallel`), golden CDR/wire byte tests unaffected, `swift format lint --strict` clean.
- Live round-trip verified: published `Imu` over Zenoh to a real `rmw_zenoh_cpp` (Jazzy) router and confirmed receipt with correct fields via `ros2 topic echo`.