### PR TITLE
chore(release): 1.2.0 — pin xcframework URLs + checksums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.2.0] - 2026-06-06
+
+### Added
+
 - **Source-timestamp publishing.** `ROS2Publisher.publish(_:timestamp:sequenceNumber:)` is a new additive overload that stamps the attachment's `timestamp_ns` field with a caller-supplied source timestamp (nanoseconds since the Unix epoch) — e.g. a sensor capture time — instead of the wall-clock publish time, and optionally takes an explicit attachment sequence number (defaulting to the publisher's own monotonic counter, just like `publish(_:)`). The existing `publish(_:)` now delegates to it with `Date()` and a nil sequence number, so its bytes are unchanged. Purely additive — no existing public API changed.
 
 ## [1.1.1] - 2026-05-16

--- a/Package.swift
+++ b/Package.swift
@@ -79,7 +79,7 @@ let windowsCycloneDDSDir: String? = {
 // can only when `CYCLONEDDS_DIR` is set; Android never can.
 let canBuildDDS = !isAndroidBuild && (!isWindowsBuild || windowsCycloneDDSDir != nil)
 
-let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/1.1.1"
+let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/1.2.0"
 
 // Non-unix zenoh-pico platform backends shared between the Linux and
 // Android arms — both use the unix backend inside `src/system/unix`.
@@ -148,7 +148,7 @@ let cZenohPico: Target = {
         return .binaryTarget(
             name: "CZenohPico",
             url: "\(releaseBaseURL)/CZenohPico.xcframework.zip",
-            checksum: "199d0ce73e18b68e9d7f19f716e52e863601ecd4ae19a8d34862fb3406159840"
+            checksum: "8b2f47804138a06bba449dc56a68b62b52c73bc0f1aa67bc52149184b1699d23"
         )
     }
 }()
@@ -359,7 +359,7 @@ if canBuildDDS {
             return .binaryTarget(
                 name: "CCycloneDDS",
                 url: "\(releaseBaseURL)/CCycloneDDS.xcframework.zip",
-                checksum: "3cea206f17abcc1ef57f947fd445b9b6d6783bdca8b1c2bb6a4838a682d3451e"
+                checksum: "36f30e40506b02cc994fc1f0e1f8f03c488d7bc6dc2e5aac37a919ccc9060d36"
             )
         }
     }()


### PR DESCRIPTION
Follow-up to the `1.2.0` tag / release (the `release-xcframework.yml` run that built and attached `CZenohPico.xcframework.zip` + `CCycloneDDS.xcframework.zip`).

- `releaseBaseURL` → `1.2.0`
- `CZenohPico` checksum → `8b2f47804138a06bba449dc56a68b62b52c73bc0f1aa67bc52149184b1699d23`
- `CCycloneDDS` checksum → `36f30e40506b02cc994fc1f0e1f8f03c488d7bc6dc2e5aac37a919ccc9060d36`
- CHANGELOG `[Unreleased]` → `[1.2.0] - 2026-06-06`

Checksums recomputed with `swift package compute-checksum` on the GitHub-served zips (match the attached `.checksum` files). `swift build` verified against the 1.2.0 binaries.