### PR TITLE
feat(rcl): native RCL DDS backend — M1 P1 publish (sensor_msgs/Imu via rcl_publish_serialized_message)

### DIFF
--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -76,4 +76,13 @@ jobs:
           xcodebuild -scheme crcl-smoke \
             -destination 'platform=macOS,variant=Mac Catalyst,arch=arm64' \
             -derivedDataPath build/dd-ci-crclsmoke build CODE_SIGNING_ALLOWED=NO
-          "$(find build/dd-ci-crclsmoke -name crcl-smoke -type f -perm +111 | head -1)"
+          bin="$(find build/dd-ci-crclsmoke -name crcl-smoke -type f -perm +111 | head -1)"
+          echo "Running smoke: $bin"
+          # crcl-smoke prints the OK line + fflush right after the publish call
+          # succeeds, before DDS teardown. On a headless runner CycloneDDS
+          # teardown can block on failed multicast writes, so bound the run with
+          # a SIGALRM timeout and decide success on the OK line, not the
+          # (possibly killed) exit code.
+          out="$(perl -e 'alarm 60; exec @ARGV' "$bin" 2>&1)" || true
+          printf '%s\n' "$out"
+          printf '%s\n' "$out" | grep -q "crcl_smoke OK: publish path exercised"

--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -33,6 +33,13 @@ jobs:
           python-version: "3.11"
       - run: brew install cmake
 
+      # ament_cmake's package_xml_2_cmake.py runs under the runner's base python
+      # (CMake's FindPython resolves to it, not the script's venv), so the ROS 2
+      # build deps must be importable there too — install them into the runner
+      # python in addition to the venv the build script creates.
+      - name: Install ROS 2 build deps into runner python
+        run: pip install -r Scripts/ros2/requirements.txt
+
       # Cross-compile rcl + rmw_cyclonedds_cpp + rosidl introspection into a
       # single-slice (maccatalyst) CRos2Jazzy.xcframework. One slice is enough:
       # `xcodebuild -create-xcframework` accepts a single library, and every

--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -1,0 +1,66 @@
+name: ci-rcl
+# RCL (native rcl + rmw_cyclonedds_cpp) backend CI. Opt-in / scheduled only:
+# the cost driver is cross-compiling the real ROS 2 stack into
+# CRos2Jazzy.xcframework (~30-60 min), so this is NOT run on every PR. The
+# mock-based RCL unit tests need no xcframework and already run in ci.yml; this
+# job covers the parts that require the real xcframework + Mac Catalyst.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+
+jobs:
+  rcl-build-smoke:
+    name: RCL build + smoke (Mac Catalyst)
+    # macos-26 + Xcode 26.4.1 to match ci.yml's build-macos job (the maintained
+    # macOS toolchain); the xcframework cross-build is validated on this Xcode.
+    runs-on: macos-26
+    timeout-minutes: 180
+    env:
+      SWIFT_ROS2_ENABLE_RCL: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: brew install cmake
+
+      # Cross-compile rcl + rmw_cyclonedds_cpp + rosidl introspection into a
+      # single-slice (maccatalyst) CRos2Jazzy.xcframework. One slice is enough:
+      # `xcodebuild -create-xcframework` accepts a single library, and every
+      # step below targets Mac Catalyst. Device-slice verification is done
+      # on-device via Conduit, not here. (The full maccatalyst+iphoneos pair is
+      # built by the separate build-ros2-xcframework.yml workflow when needed.)
+      - name: Build CRos2Jazzy.xcframework (maccatalyst)
+        run: Scripts/build-ros2-xcframework.sh maccatalyst
+
+      # Regression guard for the umbrella build path
+      # (SwiftROS2 -> SwiftROS2DDS -> CDDSBridge). This is the path the
+      # CRos2Jazzy modulemap interaction broke on enableRcl Catalyst; building
+      # SwiftROS2RCL / crcl-smoke alone does NOT pull CDDSBridge and would miss
+      # a regression there. Must reach ** BUILD SUCCEEDED **.
+      - name: Build SwiftROS2 umbrella (enableRcl, Catalyst)
+        run: |
+          xcodebuild -scheme SwiftROS2 \
+            -destination 'platform=macOS,variant=Mac Catalyst,arch=arm64' \
+            build CODE_SIGNING_ALLOWED=NO
+
+      # Full test bundle: also compiles the RCL integration test and both smoke
+      # executables, and confirms the native-only ros2-CLI integration tests
+      # stay excluded on Mac Catalyst. Must reach ** TEST BUILD SUCCEEDED **.
+      - name: Build full test bundle (enableRcl, Catalyst)
+        run: |
+          xcodebuild build-for-testing -scheme swift-ros2-Package \
+            -destination 'platform=macOS,variant=Mac Catalyst,arch=arm64' \
+            build CODE_SIGNING_ALLOWED=NO
+
+      # End-to-end FFI smoke: real rcl context -> node -> Imu publisher ->
+      # rcl_publish_serialized_message. Must print the OK line and exit 0.
+      - name: Build + run crcl-smoke (Catalyst)
+        run: |
+          xcodebuild -scheme crcl-smoke \
+            -destination 'platform=macOS,variant=Mac Catalyst,arch=arm64' \
+            -derivedDataPath build/dd-ci-crclsmoke build CODE_SIGNING_ALLOWED=NO
+          "$(find build/dd-ci-crclsmoke -name crcl-smoke -type f -perm +111 | head -1)"

--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -8,6 +8,12 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  # TEMPORARY (remove before merging PR #120): a brand-new workflow cannot be
+  # workflow_dispatch'd until it lands on the default branch, so trigger one
+  # pre-merge run on this PR to validate the macos-26 runner xcframework
+  # cross-build + Catalyst gates. ci-rcl is otherwise manual/scheduled only.
+  pull_request:
+    branches: [main]
 
 jobs:
   rcl-build-smoke:

--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -8,12 +8,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * 1" # Mondays 06:00 UTC
-  # TEMPORARY (remove before merging PR #120): a brand-new workflow cannot be
-  # workflow_dispatch'd until it lands on the default branch, so trigger one
-  # pre-merge run on this PR to validate the macos-26 runner xcframework
-  # cross-build + Catalyst gates. ci-rcl is otherwise manual/scheduled only.
-  pull_request:
-    branches: [main]
 
 jobs:
   rcl-build-smoke:

--- a/Package.swift
+++ b/Package.swift
@@ -443,6 +443,15 @@ if canBuildDDS {
         swiftROS2TestsSwiftSettings.append(.define("SWIFT_ROS2_RCL"))
     }
 
+    var integrationDeps: [Target.Dependency] = [
+        "SwiftROS2", "SwiftROS2Messages", "SwiftROS2Transport",
+    ]
+    var integrationSwiftSettings: [SwiftSetting] = []
+    if enableRcl {
+        integrationDeps.append("SwiftROS2RCL")
+        integrationSwiftSettings.append(.define("SWIFT_ROS2_RCL"))
+    }
+
     targets.append(contentsOf: [
         .target(
             name: "SwiftROS2",
@@ -503,8 +512,9 @@ if canBuildDDS {
         ),
         .testTarget(
             name: "SwiftROS2IntegrationTests",
-            dependencies: ["SwiftROS2", "SwiftROS2Messages", "SwiftROS2Transport"],
-            path: "Tests/SwiftROS2IntegrationTests"
+            dependencies: integrationDeps,
+            path: "Tests/SwiftROS2IntegrationTests",
+            swiftSettings: integrationSwiftSettings
         ),
     ])
 }

--- a/Package.swift
+++ b/Package.swift
@@ -514,6 +514,24 @@ if enableRcl {
             linkerSettings: [.linkedLibrary("c++")]
         ))
     products.append(.executable(name: "rcl-smoke", targets: ["rcl-smoke"]))
+    targets.append(
+        .target(
+            name: "CRclBridge",
+            dependencies: ["CRos2Jazzy"],
+            path: "Sources/CRclBridge",
+            sources: ["rcl_bridge.c"],
+            publicHeadersPath: "include",
+            // rmw_cyclonedds_cpp / rcpputils in CRos2Jazzy are C++.
+            linkerSettings: [.linkedLibrary("c++")]
+        ))
+    targets.append(
+        .executableTarget(
+            name: "crcl-smoke",
+            dependencies: ["CRclBridge"],
+            path: "Sources/Examples/CrclSmoke",
+            linkerSettings: [.linkedLibrary("c++")]
+        ))
+    products.append(.executable(name: "crcl-smoke", targets: ["crcl-smoke"]))
 }
 
 // Only pull in swift-docc-plugin when actually building documentation

--- a/Package.swift
+++ b/Package.swift
@@ -427,16 +427,28 @@ if canBuildDDS {
         ),
 
         // Public API umbrella: Context, Node, Publisher, Subscription
+    ])
+
+    var swiftROS2Deps: [Target.Dependency] = [
+        "SwiftROS2Messages", "SwiftROS2Transport", "SwiftROS2Wire", "SwiftROS2Zenoh", "SwiftROS2DDS",
+    ]
+    var swiftROS2SwiftSettings: [SwiftSetting] = []
+    if enableRcl {
+        swiftROS2Deps.append("SwiftROS2RCL")
+        swiftROS2SwiftSettings.append(.define("SWIFT_ROS2_RCL"))
+    }
+
+    var swiftROS2TestsSwiftSettings: [SwiftSetting] = []
+    if enableRcl {
+        swiftROS2TestsSwiftSettings.append(.define("SWIFT_ROS2_RCL"))
+    }
+
+    targets.append(contentsOf: [
         .target(
             name: "SwiftROS2",
-            dependencies: [
-                "SwiftROS2Messages",
-                "SwiftROS2Transport",
-                "SwiftROS2Wire",
-                "SwiftROS2Zenoh",
-                "SwiftROS2DDS",
-            ],
-            path: "Sources/SwiftROS2"
+            dependencies: swiftROS2Deps,
+            path: "Sources/SwiftROS2",
+            swiftSettings: swiftROS2SwiftSettings
         ),
 
         // Example executables — minimal std_msgs/String talker + listener
@@ -481,7 +493,8 @@ if canBuildDDS {
         .testTarget(
             name: "SwiftROS2Tests",
             dependencies: ["SwiftROS2", "SwiftROS2Messages", "SwiftROS2CDR"],
-            path: "Tests/SwiftROS2Tests"
+            path: "Tests/SwiftROS2Tests",
+            swiftSettings: swiftROS2TestsSwiftSettings
         ),
         .testTarget(
             name: "SwiftROS2DDSTests",
@@ -532,6 +545,13 @@ if enableRcl {
             linkerSettings: [.linkedLibrary("c++")]
         ))
     products.append(.executable(name: "crcl-smoke", targets: ["crcl-smoke"]))
+    targets.append(
+        .target(
+            name: "SwiftROS2RCL",
+            dependencies: ["CRclBridge", "SwiftROS2Transport"],
+            path: "Sources/SwiftROS2RCL"
+        ))
+    products.append(.library(name: "SwiftROS2RCL", targets: ["SwiftROS2RCL"]))
 }
 
 // Only pull in swift-docc-plugin when actually building documentation

--- a/Scripts/api-breakage-allowlist.txt
+++ b/Scripts/api-breakage-allowlist.txt
@@ -14,3 +14,9 @@
 #
 # Removals of public APIs are SemVer-breaking on the 1.x line — adding an
 # entry here is a signal that a 2.0 bump is required.
+
+# M1 (native RCL backend): a new transport-selector case. Source-additive (no
+# removal) — the diagnose tool flags any added enum case, but this is an
+# intentional feature addition that ships as a 1.3.0 minor. Drop this entry
+# once a tag is cut whose baseline already includes TransportType.rcl.
+API breakage: enumelement TransportType.rcl has been added as a new enum case

--- a/Scripts/ros2/CRos2Jazzy.h
+++ b/Scripts/ros2/CRos2Jazzy.h
@@ -1,12 +1,16 @@
-// Umbrella header for the CRos2Jazzy module.
+// Curated module header for the CRos2Jazzy module.
 //
-// Using an umbrella *header* (not `umbrella "."`) means Clang only compiles
-// the headers reachable from here, not every file installed in the headers
-// directory. ROS 2 / CycloneDDS install platform-specific and C++ headers
-// (e.g. rcutils/stdatomic_helper/win32/stdatomic.h -> <Windows.h>, fastcdr
-// C++ headers) that do not compile in a macOS/iOS C module build; an umbrella
-// directory would try to compile all of them. The rcl C API reachable from
-// <rcl/rcl.h> is self-contained C, so this stays clean.
+// Declared as a plain `header` (not `umbrella header` / `umbrella "."`) in
+// module.modulemap, so Clang compiles only the headers reachable from here,
+// not every file installed in the headers directory. ROS 2 / CycloneDDS
+// install platform-specific and C++ headers (e.g.
+// rcutils/stdatomic_helper/win32/stdatomic.h -> <Windows.h>, fastcdr C++
+// headers) that do not compile in a macOS/iOS C module build; an umbrella
+// *directory* would try to compile all of them, and an umbrella *header*
+// would additionally associate sibling binary targets' headers (notably
+// CCycloneDDS's dds/ tree, flattened into the shared build-products include
+// dir) with this module. The rcl C API reachable from <rcl/rcl.h> is
+// self-contained C, so this stays clean.
 //
 // Extend this list as the native-rcl backend grows (M1+): add the per-message
 // introspection typesupport handle headers the publisher needs.

--- a/Scripts/ros2/CRos2Jazzy.h
+++ b/Scripts/ros2/CRos2Jazzy.h
@@ -11,6 +11,9 @@
 // Extend this list as the native-rcl backend grows (M1+): add the per-message
 // introspection typesupport handle headers the publisher needs.
 #include <rcl/rcl.h>
+#include <rcl/error_handling.h>
 #include <rcl/publisher.h>
 #include <rmw/rmw.h>
 #include <rosidl_runtime_c/message_type_support_struct.h>
+// M1: sensor_msgs/Imu typesupport declaration (rosidl_typesupport_c symbol).
+#include <sensor_msgs/msg/imu.h>

--- a/Scripts/ros2/module.modulemap
+++ b/Scripts/ros2/module.modulemap
@@ -1,7 +1,15 @@
 module CRos2Jazzy {
-  // Umbrella *header* (not `umbrella "."`): only headers reachable from
-  // CRos2Jazzy.h are compiled into the module, so platform-specific / C++
-  // headers installed by ROS 2 + CycloneDDS don't break the C module build.
-  umbrella header "CRos2Jazzy.h"
+  // Plain `header` — NOT `umbrella header` and NOT `umbrella "."`. Clang still
+  // compiles only the headers reachable from CRos2Jazzy.h (so the C++ /
+  // platform-specific headers ROS 2 + CycloneDDS install don't break the C
+  // module build). A plain `header` additionally stops clang from treating
+  // this modulemap's directory as an umbrella: SwiftPM/xcodebuild flatten
+  // every binary target's public headers into one shared build-products
+  // include/ dir, so an `umbrella header` here associated CCycloneDDS's
+  // sibling dds/ tree with module CRos2Jazzy, routing CDDSBridge's
+  // `#include <dds/...>` into this module (incomplete struct ddsi_sertype) on
+  // the enableRcl Mac Catalyst umbrella build. A plain header keeps dds/
+  // textual so it resolves against CCycloneDDS.
+  header "CRos2Jazzy.h"
   export *
 }

--- a/Sources/CRclBridge/include/module.modulemap
+++ b/Sources/CRclBridge/include/module.modulemap
@@ -1,0 +1,4 @@
+module CRclBridge {
+    header "rcl_bridge.h"
+    export *
+}

--- a/Sources/CRclBridge/include/rcl_bridge.h
+++ b/Sources/CRclBridge/include/rcl_bridge.h
@@ -1,0 +1,48 @@
+//
+// rcl_bridge.h
+// C-FFI bridge for the real rcl + rmw_cyclonedds_cpp stack (CRos2Jazzy).
+// Types use the "crcl_" prefix to avoid colliding with rcl types.
+//
+#ifndef CRCL_BRIDGE_H
+#define CRCL_BRIDGE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct crcl_context_s crcl_context_t;
+typedef struct crcl_node_s crcl_node_t;
+typedef struct crcl_publisher_s crcl_publisher_t;
+
+/// QoS mapped from Swift TransportQoS (primitives only — no rmw types leak).
+typedef struct crcl_qos_s {
+    int reliability;  // 0 = best_effort, 1 = reliable
+    int durability;   // 0 = volatile,    1 = transient_local
+    int history;      // 0 = keep_last,   1 = keep_all
+    size_t depth;     // used when history == keep_last
+} crcl_qos_t;
+
+/// Lifecycle. Each create returns NULL on failure; call crcl_last_error().
+crcl_context_t *crcl_context_create(size_t domain_id);
+void crcl_context_destroy(crcl_context_t *ctx);
+
+crcl_node_t *crcl_node_create(crcl_context_t *ctx, const char *name, const char *ns);
+void crcl_node_destroy(crcl_node_t *node);
+
+crcl_publisher_t *crcl_publisher_create(
+    crcl_node_t *node, const char *ros_type_name, const char *topic, crcl_qos_t qos);
+void crcl_publisher_destroy(crcl_publisher_t *pub);
+
+/// Publish pre-serialized CDR bytes. Returns 0 on success, non-zero rcl_ret_t otherwise.
+int crcl_publish_serialized(crcl_publisher_t *pub, const uint8_t *data, size_t len);
+
+/// Last error from the rcutils error stack; "" if none.
+const char *crcl_last_error(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // CRCL_BRIDGE_H

--- a/Sources/CRclBridge/rcl_bridge.c
+++ b/Sources/CRclBridge/rcl_bridge.c
@@ -1,0 +1,156 @@
+#include "rcl_bridge.h"
+
+#include <rcl/rcl.h>
+#include <rcl/publisher.h>
+// rcl_serialized_message_t is typedef'd in <rcl/types.h>, pulled in by <rcl/rcl.h>.
+// There is no standalone <rcl/serialized_message.h> in this distribution.
+#include <rmw/qos_profiles.h>
+#include <rmw/serialized_message.h>
+#include <rcutils/allocator.h>
+#include <rosidl_runtime_c/message_type_support_struct.h>
+// Use the rosidl_typesupport_c symbol (T in the static lib).
+// ROSIDL_GET_MSG_TYPE_SUPPORT expands to
+//   rosidl_typesupport_c__get_message_type_support_handle__sensor_msgs__msg__Imu()
+#include <sensor_msgs/msg/imu.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+struct crcl_context_s {
+    rcl_context_t ctx;
+    rcl_init_options_t opts;
+};
+struct crcl_node_s {
+    rcl_node_t node;
+};
+struct crcl_publisher_s {
+    rcl_publisher_t pub;
+    rcl_node_t *node;  // borrowed; node must outlive the publisher
+};
+
+static char g_err[1024];
+
+static void capture_error(void) {
+    rcl_error_string_t s = rcl_get_error_string();
+    strncpy(g_err, s.str, sizeof(g_err) - 1);
+    g_err[sizeof(g_err) - 1] = '\0';
+    rcl_reset_error();
+}
+const char *crcl_last_error(void) { return g_err; }
+
+// Type-name -> typesupport table.
+// rosidl_typesupport_c symbol is defined (T) in CRos2Jazzy; use
+// ROSIDL_GET_MSG_TYPE_SUPPORT (from <sensor_msgs/msg/imu.h>) to obtain it.
+static const rosidl_message_type_support_t *resolve_typesupport(const char *ros_type_name) {
+    if (strcmp(ros_type_name, "sensor_msgs/msg/Imu") == 0) {
+        return ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, Imu);
+    }
+    return NULL;
+}
+
+crcl_context_t *crcl_context_create(size_t domain_id) {
+    crcl_context_t *c = calloc(1, sizeof(*c));
+    if (!c) return NULL;
+    c->opts = rcl_get_zero_initialized_init_options();
+    c->ctx = rcl_get_zero_initialized_context();
+    rcl_allocator_t alloc = rcl_get_default_allocator();
+    if (rcl_init_options_init(&c->opts, alloc) != RCL_RET_OK) {
+        capture_error();
+        free(c);
+        return NULL;
+    }
+    if (rcl_init_options_set_domain_id(&c->opts, domain_id) != RCL_RET_OK) {
+        capture_error();
+        rcl_init_options_fini(&c->opts);
+        free(c);
+        return NULL;
+    }
+    if (rcl_init(0, NULL, &c->opts, &c->ctx) != RCL_RET_OK) {
+        capture_error();
+        rcl_init_options_fini(&c->opts);
+        free(c);
+        return NULL;
+    }
+    return c;
+}
+
+void crcl_context_destroy(crcl_context_t *c) {
+    if (!c) return;
+    if (rcl_context_is_valid(&c->ctx)) {
+        rcl_shutdown(&c->ctx);
+    }
+    rcl_context_fini(&c->ctx);
+    rcl_init_options_fini(&c->opts);
+    free(c);
+}
+
+crcl_node_t *crcl_node_create(crcl_context_t *c, const char *name, const char *ns) {
+    if (!c) return NULL;
+    crcl_node_t *n = calloc(1, sizeof(*n));
+    if (!n) return NULL;
+    n->node = rcl_get_zero_initialized_node();
+    rcl_node_options_t nopts = rcl_node_get_default_options();
+    if (rcl_node_init(&n->node, name, ns, &c->ctx, &nopts) != RCL_RET_OK) {
+        capture_error();
+        free(n);
+        return NULL;
+    }
+    return n;
+}
+
+void crcl_node_destroy(crcl_node_t *n) {
+    if (!n) return;
+    rcl_node_fini(&n->node);
+    free(n);
+}
+
+crcl_publisher_t *crcl_publisher_create(
+    crcl_node_t *n, const char *ros_type_name, const char *topic, crcl_qos_t q) {
+    if (!n) return NULL;
+    const rosidl_message_type_support_t *ts = resolve_typesupport(ros_type_name);
+    if (!ts) {
+        snprintf(g_err, sizeof(g_err), "unsupported type: %s", ros_type_name);
+        return NULL;
+    }
+    crcl_publisher_t *p = calloc(1, sizeof(*p));
+    if (!p) return NULL;
+    p->pub = rcl_get_zero_initialized_publisher();
+    p->node = &n->node;
+    rcl_publisher_options_t popts = rcl_publisher_get_default_options();
+    popts.qos = rmw_qos_profile_default;
+    popts.qos.reliability =
+        q.reliability ? RMW_QOS_POLICY_RELIABILITY_RELIABLE : RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+    popts.qos.durability =
+        q.durability ? RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL : RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    popts.qos.history =
+        q.history ? RMW_QOS_POLICY_HISTORY_KEEP_ALL : RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+    popts.qos.depth = q.depth;
+    if (rcl_publisher_init(&p->pub, &n->node, ts, topic, &popts) != RCL_RET_OK) {
+        capture_error();
+        free(p);
+        return NULL;
+    }
+    return p;
+}
+
+void crcl_publisher_destroy(crcl_publisher_t *p) {
+    if (!p) return;
+    rcl_publisher_fini(&p->pub, p->node);
+    free(p);
+}
+
+int crcl_publish_serialized(crcl_publisher_t *p, const uint8_t *data, size_t len) {
+    if (!p) return -1;
+    rcl_serialized_message_t ser = rmw_get_zero_initialized_serialized_message();
+    // Borrow the caller's buffer; rcl_publish_serialized_message only reads it.
+    ser.buffer = (uint8_t *)data;
+    ser.buffer_length = len;
+    ser.buffer_capacity = len;
+    ser.allocator = rcutils_get_default_allocator();
+    rcl_ret_t ret = rcl_publish_serialized_message(&p->pub, &ser, NULL);
+    if (ret != RCL_RET_OK) {
+        capture_error();
+        return (int)ret;
+    }
+    return 0;
+}

--- a/Sources/CRclBridge/rcl_bridge.c
+++ b/Sources/CRclBridge/rcl_bridge.c
@@ -28,7 +28,14 @@ struct crcl_publisher_s {
     rcl_node_t *node;  // borrowed; node must outlive the publisher
 };
 
-static char g_err[1024];
+#ifdef _Thread_local
+#define CRCL_THREAD_LOCAL _Thread_local
+#elif defined(__GNUC__) || defined(__clang__)
+#define CRCL_THREAD_LOCAL __thread
+#else
+#define CRCL_THREAD_LOCAL
+#endif
+static CRCL_THREAD_LOCAL char g_err[1024] = {0};
 
 static void capture_error(void) {
     rcl_error_string_t s = rcl_get_error_string();
@@ -61,13 +68,13 @@ crcl_context_t *crcl_context_create(size_t domain_id) {
     }
     if (rcl_init_options_set_domain_id(&c->opts, domain_id) != RCL_RET_OK) {
         capture_error();
-        rcl_init_options_fini(&c->opts);
+        (void)rcl_init_options_fini(&c->opts);
         free(c);
         return NULL;
     }
     if (rcl_init(0, NULL, &c->opts, &c->ctx) != RCL_RET_OK) {
         capture_error();
-        rcl_init_options_fini(&c->opts);
+        (void)rcl_init_options_fini(&c->opts);
         free(c);
         return NULL;
     }
@@ -77,10 +84,10 @@ crcl_context_t *crcl_context_create(size_t domain_id) {
 void crcl_context_destroy(crcl_context_t *c) {
     if (!c) return;
     if (rcl_context_is_valid(&c->ctx)) {
-        rcl_shutdown(&c->ctx);
+        (void)rcl_shutdown(&c->ctx);
     }
-    rcl_context_fini(&c->ctx);
-    rcl_init_options_fini(&c->opts);
+    (void)rcl_context_fini(&c->ctx);
+    (void)rcl_init_options_fini(&c->opts);
     free(c);
 }
 
@@ -100,7 +107,7 @@ crcl_node_t *crcl_node_create(crcl_context_t *c, const char *name, const char *n
 
 void crcl_node_destroy(crcl_node_t *n) {
     if (!n) return;
-    rcl_node_fini(&n->node);
+    (void)rcl_node_fini(&n->node);
     free(n);
 }
 
@@ -109,6 +116,7 @@ crcl_publisher_t *crcl_publisher_create(
     if (!n) return NULL;
     const rosidl_message_type_support_t *ts = resolve_typesupport(ros_type_name);
     if (!ts) {
+        // Not an rcl error — no rcl error state to clear; set g_err directly.
         snprintf(g_err, sizeof(g_err), "unsupported type: %s", ros_type_name);
         return NULL;
     }
@@ -135,7 +143,7 @@ crcl_publisher_t *crcl_publisher_create(
 
 void crcl_publisher_destroy(crcl_publisher_t *p) {
     if (!p) return;
-    rcl_publisher_fini(&p->pub, p->node);
+    (void)rcl_publisher_fini(&p->pub, p->node);
     free(p);
 }
 

--- a/Sources/CRclBridge/rcl_bridge.c
+++ b/Sources/CRclBridge/rcl_bridge.c
@@ -2,6 +2,12 @@
 
 #include <rcl/rcl.h>
 #include <rcl/publisher.h>
+// rcl_error_string_t / rcl_get_error_string / rcl_reset_error (capture_error()).
+// Included explicitly for the symbols this TU uses rather than relying on the
+// CRos2Jazzy module re-exporting it: the modulemap declares CRos2Jazzy.h as a
+// plain (non-umbrella) header, so `#include <rcl/...>` resolves textually and
+// only brings what each header transitively pulls in.
+#include <rcl/error_handling.h>
 // rcl_serialized_message_t is typedef'd in <rcl/types.h>, pulled in by <rcl/rcl.h>.
 // There is no standalone <rcl/serialized_message.h> in this distribution.
 #include <rmw/qos_profiles.h>

--- a/Sources/Examples/CrclSmoke/main.c
+++ b/Sources/Examples/CrclSmoke/main.c
@@ -2,6 +2,8 @@
 #include "rcl_bridge.h"
 
 int main(void) {
+    // Smoke exits on first failure; the process teardown reclaims resources,
+    // so error paths intentionally skip explicit destroy calls.
     crcl_context_t *ctx = crcl_context_create(0);
     if (!ctx) { printf("context FAIL: %s\n", crcl_last_error()); return 1; }
 

--- a/Sources/Examples/CrclSmoke/main.c
+++ b/Sources/Examples/CrclSmoke/main.c
@@ -18,9 +18,17 @@ int main(void) {
     int rc = crcl_publish_serialized(pub, cdr, sizeof(cdr));
     if (rc != 0) { printf("publish FAIL (%d): %s\n", rc, crcl_last_error()); return 1; }
 
+    // The publish path is what this smoke validates, and it has now succeeded.
+    // Print + flush the result BEFORE teardown: on a headless CI runner with no
+    // working multicast, CycloneDDS participant teardown can block indefinitely
+    // on failed discovery writes, and stdout to a pipe is fully buffered, so a
+    // teardown hang would otherwise swallow this line. Teardown still runs after
+    // (best-effort; the OS reclaims everything on process exit).
+    printf("crcl_smoke OK: publish path exercised\n");
+    fflush(stdout);
+
     crcl_publisher_destroy(pub);
     crcl_node_destroy(node);
     crcl_context_destroy(ctx);
-    printf("crcl_smoke OK: publish path exercised\n");
     return 0;
 }

--- a/Sources/Examples/CrclSmoke/main.c
+++ b/Sources/Examples/CrclSmoke/main.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include "rcl_bridge.h"
+
+int main(void) {
+    crcl_context_t *ctx = crcl_context_create(0);
+    if (!ctx) { printf("context FAIL: %s\n", crcl_last_error()); return 1; }
+
+    crcl_node_t *node = crcl_node_create(ctx, "crcl_smoke", "/swift_ros2");
+    if (!node) { printf("node FAIL: %s\n", crcl_last_error()); return 1; }
+
+    crcl_qos_t qos = {.reliability = 1, .durability = 0, .history = 0, .depth = 10};
+    crcl_publisher_t *pub = crcl_publisher_create(node, "sensor_msgs/msg/Imu", "/imu", qos);
+    if (!pub) { printf("publisher FAIL: %s\n", crcl_last_error()); return 1; }
+
+    uint8_t cdr[8] = {0x00, 0x01, 0x00, 0x00, 0, 0, 0, 0};
+    int rc = crcl_publish_serialized(pub, cdr, sizeof(cdr));
+    if (rc != 0) { printf("publish FAIL (%d): %s\n", rc, crcl_last_error()); return 1; }
+
+    crcl_publisher_destroy(pub);
+    crcl_node_destroy(node);
+    crcl_context_destroy(ctx);
+    printf("crcl_smoke OK: publish path exercised\n");
+    return 0;
+}

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -102,6 +102,10 @@ public final class ROS2Context: @unchecked Sendable {
             entityManager: entityManager,
             gidManager: gidManager
         )
+        // Let the transport create a real node where it models one (rcl).
+        // Wire-level transports default to a no-op. On a later failure the
+        // `catch` below calls node.destroy(), which unregisters it.
+        try session.registerNode(name: name, namespace: namespace)
         if options.startParameterServices {
             // Register before the node is reachable from `shutdown` — if
             // any of the six createService calls throws, close the services

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -7,6 +7,10 @@ import SwiftROS2Transport
 import SwiftROS2Wire
 import SwiftROS2Zenoh
 
+#if SWIFT_ROS2_RCL
+    import SwiftROS2RCL
+#endif
+
 /// ROS 2 context — the entry point for creating nodes
 ///
 /// A context owns a single transport session. All nodes created from this context
@@ -171,6 +175,13 @@ extension ROS2Context {
             return ZenohTransportSession(client: ZenohClient())
         case .dds:
             return DDSTransportSession(client: DDSClient())
+        case .rcl:
+            #if SWIFT_ROS2_RCL
+                return RclTransportSession(client: RclClient())
+            #else
+                throw TransportError.unsupportedFeature(
+                    "rcl backend not built — rebuild with SWIFT_ROS2_ENABLE_RCL=1 on an Apple platform")
+            #endif
         }
     }
 }

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -180,7 +180,7 @@ extension ROS2Context {
                 return RclTransportSession(client: RclClient())
             #else
                 throw TransportError.unsupportedFeature(
-                    "rcl backend not built — rebuild with SWIFT_ROS2_ENABLE_RCL=1 on an Apple platform")
+                    "rcl backend not built — set SWIFT_ROS2_ENABLE_RCL=1 and rebuild on an Apple platform")
             #endif
         }
     }

--- a/Sources/SwiftROS2/Node.swift
+++ b/Sources/SwiftROS2/Node.swift
@@ -325,6 +325,7 @@ public final class ROS2Node: @unchecked Sendable {
                 try? c.closeActionClient()
             }
         }
+        session.unregisterNode(name: name, namespace: namespace)
     }
 
     // MARK: - Private (synchronous lock helpers)

--- a/Sources/SwiftROS2RCL/Exports.swift
+++ b/Sources/SwiftROS2RCL/Exports.swift
@@ -1,0 +1,4 @@
+// Re-export SwiftROS2Transport so a caller importing SwiftROS2RCL reaches
+// TransportConfig and the shared transport entry points without an extra
+// import, mirroring SwiftROS2DDS/Exports.swift.
+@_exported import SwiftROS2Transport

--- a/Sources/SwiftROS2RCL/RclClient.swift
+++ b/Sources/SwiftROS2RCL/RclClient.swift
@@ -1,0 +1,131 @@
+// RclClient.swift
+// Concrete RclClientProtocol over the CRclBridge C FFI. Apple-only, gated.
+
+import CRclBridge
+import Foundation
+import SwiftROS2Transport
+
+// MARK: - Handles
+
+private final class RclNodeBox: RclNodeHandle, @unchecked Sendable {
+    let ptr: OpaquePointer
+    init(_ ptr: OpaquePointer) { self.ptr = ptr }
+}
+
+/// Per-box lock serializes destroy vs. publish on the same publisher pointer.
+private final class RclPublisherBox: RclPublisherHandle, @unchecked Sendable {
+    private var ptr: OpaquePointer?
+    private let lock = NSLock()
+
+    init(_ ptr: OpaquePointer) { self.ptr = ptr }
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return ptr != nil
+    }
+
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        if let p = ptr {
+            crcl_publisher_destroy(p)
+            ptr = nil
+        }
+    }
+
+    func withPtr<R>(_ body: (OpaquePointer) -> R) -> R? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let p = ptr else { return nil }
+        return body(p)
+    }
+}
+
+// MARK: - Client
+
+/// Concrete implementation of ``RclClientProtocol`` wrapping the `CRclBridge` C FFI.
+///
+/// Thread-safety: the client-level `NSLock` serializes `createContext` /
+/// `destroyContext`. Publisher creation/destroy delegate thread-safety to the
+/// per-`RclPublisherBox` lock, mirroring the `DDSClient` pattern.
+public final class RclClient: RclClientProtocol, @unchecked Sendable {
+    private var ctx: OpaquePointer?
+    private let lock = NSLock()
+
+    public init() {}
+
+    package var isAvailable: Bool { true }
+
+    package func createContext(domainId: Int32) throws {
+        guard let c = crcl_context_create(Int(domainId)) else {
+            throw TransportError.connectionFailed(lastError())
+        }
+        lock.lock()
+        ctx = c
+        lock.unlock()
+    }
+
+    package func destroyContext() {
+        lock.lock()
+        let c = ctx
+        ctx = nil
+        lock.unlock()
+        if let c { crcl_context_destroy(c) }
+    }
+
+    package func createNode(name: String, namespace: String) throws -> any RclNodeHandle {
+        lock.lock()
+        let c = ctx
+        lock.unlock()
+        guard let c else { throw TransportError.notConnected }
+        guard let n = crcl_node_create(c, name, namespace) else {
+            throw TransportError.publisherCreationFailed(lastError())
+        }
+        return RclNodeBox(n)
+    }
+
+    package func destroyNode(_ node: any RclNodeHandle) {
+        guard let b = node as? RclNodeBox else { return }
+        crcl_node_destroy(b.ptr)
+    }
+
+    package func createPublisher(
+        node: any RclNodeHandle, typeName: String, topic: String, qos: TransportQoS
+    ) throws -> any RclPublisherHandle {
+        guard let b = node as? RclNodeBox else {
+            throw TransportError.publisherCreationFailed("invalid node handle")
+        }
+        var q = crcl_qos_t()
+        q.reliability = qos.reliability == .reliable ? Int32(1) : Int32(0)
+        q.durability = qos.durability == .transientLocal ? Int32(1) : Int32(0)
+        switch qos.history {
+        case .keepLast(let depth):
+            q.history = Int32(0)
+            q.depth = depth
+        case .keepAll:
+            q.history = Int32(1)
+            q.depth = 0
+        }
+        guard let p = crcl_publisher_create(b.ptr, typeName, topic, q) else {
+            throw TransportError.publisherCreationFailed(lastError())
+        }
+        return RclPublisherBox(p)
+    }
+
+    package func publishSerialized(_ publisher: any RclPublisherHandle, data: Data) throws {
+        guard let b = publisher as? RclPublisherBox else {
+            throw TransportError.publishFailed("invalid publisher handle")
+        }
+        let rc: Int32? = data.withUnsafeBytes { raw in
+            b.withPtr { p in
+                crcl_publish_serialized(
+                    p, raw.bindMemory(to: UInt8.self).baseAddress, data.count)
+            }
+        }
+        guard let rc else { throw TransportError.publisherClosed }
+        if rc != 0 { throw TransportError.publishFailed(lastError()) }
+    }
+
+    private func lastError() -> String { String(cString: crcl_last_error()) }
+}

--- a/Sources/SwiftROS2RCL/RclClient.swift
+++ b/Sources/SwiftROS2RCL/RclClient.swift
@@ -46,9 +46,12 @@ private final class RclPublisherBox: RclPublisherHandle, @unchecked Sendable {
 
 /// Concrete implementation of ``RclClientProtocol`` wrapping the `CRclBridge` C FFI.
 ///
-/// Thread-safety: the client-level `NSLock` serializes `createContext` /
-/// `destroyContext`. Publisher creation/destroy delegate thread-safety to the
-/// per-`RclPublisherBox` lock, mirroring the `DDSClient` pattern.
+/// Thread-safety: the `ctx` pointer is read/written under `lock`.
+/// `crcl_context_create` runs outside the lock (one-time init); the guard rejects
+/// a second `createContext` call with `alreadyConnected`. `destroyContext`
+/// snapshots and nils `ctx` under lock, then calls `crcl_context_destroy` outside.
+/// Publisher create/destroy delegates thread-safety to the per-`RclPublisherBox` lock,
+/// mirroring the `DDSClient` pattern.
 public final class RclClient: RclClientProtocol, @unchecked Sendable {
     private var ctx: OpaquePointer?
     private let lock = NSLock()
@@ -58,6 +61,12 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
     package var isAvailable: Bool { true }
 
     package func createContext(domainId: Int32) throws {
+        lock.lock()
+        guard ctx == nil else {
+            lock.unlock()
+            throw TransportError.alreadyConnected
+        }
+        lock.unlock()
         guard let c = crcl_context_create(Int(domainId)) else {
             throw TransportError.connectionFailed(lastError())
         }
@@ -80,7 +89,7 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         lock.unlock()
         guard let c else { throw TransportError.notConnected }
         guard let n = crcl_node_create(c, name, namespace) else {
-            throw TransportError.publisherCreationFailed(lastError())
+            throw TransportError.connectionFailed(lastError())
         }
         return RclNodeBox(n)
     }
@@ -117,10 +126,10 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         guard let b = publisher as? RclPublisherBox else {
             throw TransportError.publishFailed("invalid publisher handle")
         }
-        let rc: Int32? = data.withUnsafeBytes { raw in
-            b.withPtr { p in
-                crcl_publish_serialized(
-                    p, raw.bindMemory(to: UInt8.self).baseAddress, data.count)
+        let rc: Int32? = data.withUnsafeBytes { raw -> Int32? in
+            guard let base = raw.bindMemory(to: UInt8.self).baseAddress else { return -1 }
+            return b.withPtr { p in
+                crcl_publish_serialized(p, base, data.count)
             }
         }
         guard let rc else { throw TransportError.publisherClosed }

--- a/Sources/SwiftROS2Transport/RclClientProtocol.swift
+++ b/Sources/SwiftROS2Transport/RclClientProtocol.swift
@@ -1,0 +1,37 @@
+// RclClientProtocol.swift
+// FFI seam for the real-rcl backend. The concrete RclClient lives in the
+// gated SwiftROS2RCL target; this protocol stays C-free so RclTransportSession
+// is unit-testable with a mock (no xcframework) in ordinary CI.
+
+import Foundation
+
+/// Opaque handle to an rcl node owned by the client.
+public protocol RclNodeHandle: AnyObject, Sendable {}
+
+/// Opaque handle to an rcl publisher owned by the client.
+public protocol RclPublisherHandle: AnyObject, Sendable {
+    var isActive: Bool { get }
+    func close()
+}
+
+/// Lifecycle + publish operations the rcl C bridge exposes.
+package protocol RclClientProtocol: Sendable {
+    /// Whether the native rcl stack is linked and usable.
+    var isAvailable: Bool { get }
+
+    func createContext(domainId: Int32) throws
+    func destroyContext()
+
+    func createNode(name: String, namespace: String) throws -> any RclNodeHandle
+    func destroyNode(_ node: any RclNodeHandle)
+
+    func createPublisher(
+        node: any RclNodeHandle,
+        typeName: String,
+        topic: String,
+        qos: TransportQoS
+    ) throws -> any RclPublisherHandle
+
+    /// Publish pre-serialized CDR bytes (XCDR1 incl. the 4-byte encapsulation header).
+    func publishSerialized(_ publisher: any RclPublisherHandle, data: Data) throws
+}

--- a/Sources/SwiftROS2Transport/RclClientProtocol.swift
+++ b/Sources/SwiftROS2Transport/RclClientProtocol.swift
@@ -6,10 +6,10 @@
 import Foundation
 
 /// Opaque handle to an rcl node owned by the client.
-public protocol RclNodeHandle: AnyObject, Sendable {}
+package protocol RclNodeHandle: AnyObject, Sendable {}
 
 /// Opaque handle to an rcl publisher owned by the client.
-public protocol RclPublisherHandle: AnyObject, Sendable {
+package protocol RclPublisherHandle: AnyObject, Sendable {
     var isActive: Bool { get }
     func close()
 }

--- a/Sources/SwiftROS2Transport/RclTransportSession+Publisher.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession+Publisher.swift
@@ -1,0 +1,73 @@
+// RclTransportSession+Publisher.swift
+// Publisher creation and the RclTransportPublisher concrete type.
+
+import Foundation
+
+extension RclTransportSession {
+    package func createPublisher(
+        topic: String, typeName: String, typeHash: String?, qos: TransportQoS
+    ) throws -> any TransportPublisher {
+        guard !topic.isEmpty else {
+            throw TransportError.invalidConfiguration("Topic name cannot be empty")
+        }
+        guard !typeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Type name cannot be empty")
+        }
+        guard isConnected else { throw TransportError.notConnected }
+        let node = try activeNode()
+        let handle = try client.createPublisher(
+            node: node, typeName: typeName, topic: topic, qos: qos)
+        let pub = RclTransportPublisher(client: client, handle: handle, topic: topic)
+        appendPublisher(pub, for: topic)
+        return pub
+    }
+}
+
+final class RclTransportPublisher: TransportPublisher, @unchecked Sendable {
+    private let client: any RclClientProtocol
+    private var handle: (any RclPublisherHandle)?
+    public let topic: String
+    private let lock = NSLock()
+    private var closed = false
+
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if closed { return false }
+        return handle?.isActive ?? false
+    }
+
+    init(client: any RclClientProtocol, handle: any RclPublisherHandle, topic: String) {
+        self.client = client
+        self.handle = handle
+        self.topic = topic
+    }
+
+    public func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws {
+        // P1: timestamp/sequenceNumber are unused — rmw assigns the source
+        // timestamp and the sensor time rides in the CDR header.stamp.
+        guard data.count >= 4 else {
+            throw TransportError.publishFailed("Data too short: missing CDR encapsulation header")
+        }
+        lock.lock()
+        guard !closed, let h = handle else {
+            lock.unlock()
+            throw TransportError.publisherClosed
+        }
+        lock.unlock()
+        try client.publishSerialized(h, data: data)
+    }
+
+    public func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let h = handle
+        handle = nil
+        lock.unlock()
+        h?.close()
+    }
+}

--- a/Sources/SwiftROS2Transport/RclTransportSession+Publisher.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession+Publisher.swift
@@ -13,8 +13,7 @@ extension RclTransportSession {
         guard !typeName.isEmpty else {
             throw TransportError.invalidConfiguration("Type name cannot be empty")
         }
-        guard isConnected else { throw TransportError.notConnected }
-        let node = try activeNode()
+        let node = try preflightPublisher(topic: topic)
         let handle = try client.createPublisher(
             node: node, typeName: typeName, topic: topic, qos: qos)
         let pub = RclTransportPublisher(client: client, handle: handle, topic: topic)
@@ -46,6 +45,9 @@ final class RclTransportPublisher: TransportPublisher, @unchecked Sendable {
     public func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws {
         // P1: timestamp/sequenceNumber are unused — rmw assigns the source
         // timestamp and the sensor time rides in the CDR header.stamp.
+        guard !data.isEmpty else {
+            throw TransportError.publishFailed("Data is empty")
+        }
         guard data.count >= 4 else {
             throw TransportError.publishFailed("Data too short: missing CDR encapsulation header")
         }

--- a/Sources/SwiftROS2Transport/RclTransportSession.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession.swift
@@ -1,0 +1,161 @@
+// RclTransportSession.swift
+// TransportSession backed by the real rcl + rmw_cyclonedds_cpp stack via
+// RclClientProtocol. M1 is publish-only and assumes a single node.
+
+import Foundation
+
+public final class RclTransportSession: TransportSession, @unchecked Sendable {
+    let client: any RclClientProtocol
+    private let lock = NSLock()
+    private var isOpen = false
+    private var _sessionId = ""
+    private var nodes: [String: any RclNodeHandle] = [:]
+    private var currentNode: (any RclNodeHandle)?
+    var publishers: [String: RclTransportPublisher] = [:]
+
+    public var transportType: TransportType { .rcl }
+
+    public var isConnected: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return isOpen
+    }
+
+    public var sessionId: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return _sessionId
+    }
+
+    package init(client: any RclClientProtocol) {
+        self.client = client
+    }
+
+    public func open(config: TransportConfig) async throws {
+        guard config.type == .rcl else {
+            throw TransportError.invalidConfiguration("Expected RCL configuration, got \(config.type)")
+        }
+        try config.validate()
+        guard client.isAvailable else {
+            throw TransportError.unsupportedFeature("RCL transport not available (CRos2Jazzy not built)")
+        }
+        try client.createContext(domainId: Int32(config.domainId))
+        lock.lock()
+        isOpen = true
+        _sessionId = "rcl-\(config.domainId)"
+        lock.unlock()
+    }
+
+    public func registerNode(name: String, namespace: String) throws {
+        let node = try client.createNode(name: name, namespace: namespace)
+        lock.lock()
+        nodes[nodeKey(name, namespace)] = node
+        currentNode = node
+        lock.unlock()
+    }
+
+    public func unregisterNode(name: String, namespace: String) {
+        lock.lock()
+        let removed = nodes.removeValue(forKey: nodeKey(name, namespace))
+        if let removed, currentNode === removed {
+            currentNode = nodes.values.first
+        }
+        lock.unlock()
+        if let removed {
+            client.destroyNode(removed)
+        }
+    }
+
+    /// The node a new publisher attaches to (M1 single-node assumption).
+    func activeNode() throws -> any RclNodeHandle {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let node = currentNode else {
+            throw TransportError.publisherCreationFailed("no node registered — create a node first")
+        }
+        return node
+    }
+
+    package func createSubscriber(
+        topic: String,
+        typeName: String,
+        typeHash: String?,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any TransportSubscriber {
+        throw TransportError.unsupportedFeature("createSubscriber (transport: rcl) — M1 is publish-only")
+    }
+
+    public func close() throws {
+        lock.lock()
+        let pubs = Array(publishers.values)
+        publishers.removeAll()
+        let ns = Array(nodes.values)
+        nodes.removeAll()
+        currentNode = nil
+        isOpen = false
+        _sessionId = ""
+        lock.unlock()
+        for p in pubs { try? p.close() }
+        for n in ns { client.destroyNode(n) }
+        client.destroyContext()
+    }
+
+    public func checkHealth() -> Bool { isConnected }
+
+    // MARK: - Helpers
+
+    private func nodeKey(_ name: String, _ namespace: String) -> String {
+        "\(namespace)/\(name)"
+    }
+
+    func appendPublisher(_ pub: RclTransportPublisher, for topic: String) {
+        lock.lock()
+        publishers[topic] = pub
+        lock.unlock()
+    }
+
+    // TEMPORARY stub to satisfy the TransportSession protocol until Task 4
+    // moves the real implementation into RclTransportSession+Publisher.swift.
+    package func createPublisher(
+        topic: String,
+        typeName: String,
+        typeHash: String?,
+        qos: TransportQoS
+    ) throws -> any TransportPublisher {
+        throw TransportError.unsupportedFeature("createPublisher (rcl) — implemented in Task 4")
+    }
+
+    package func createServiceServer(
+        name: String,
+        serviceTypeName: String,
+        requestTypeHash: String?,
+        responseTypeHash: String?,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data) async throws -> Data
+    ) throws -> any TransportService {
+        throw TransportError.unsupportedFeature("createServiceServer (transport: rcl) — not supported in M1")
+    }
+
+    package func createServiceClient(
+        name: String,
+        serviceTypeName: String,
+        requestTypeHash: String?,
+        responseTypeHash: String?,
+        qos: TransportQoS
+    ) throws -> any TransportClient {
+        throw TransportError.unsupportedFeature("createServiceClient (transport: rcl) — not supported in M1")
+    }
+}
+
+// Minimal placeholder; Task 4 replaces this with the full implementation in
+// RclTransportSession+Publisher.swift.
+final class RclTransportPublisher: TransportPublisher, @unchecked Sendable {
+    let topic: String
+    var isActive: Bool { false }
+    init(topic: String) { self.topic = topic }
+    func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws {
+        throw TransportError.unsupportedFeature("RclTransportPublisher — implemented in Task 4")
+    }
+    func close() throws {}
+}

--- a/Sources/SwiftROS2Transport/RclTransportSession.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession.swift
@@ -123,17 +123,6 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
         lock.unlock()
     }
 
-    // TEMPORARY stub to satisfy the TransportSession protocol until Task 4
-    // moves the real implementation into RclTransportSession+Publisher.swift.
-    package func createPublisher(
-        topic: String,
-        typeName: String,
-        typeHash: String?,
-        qos: TransportQoS
-    ) throws -> any TransportPublisher {
-        throw TransportError.unsupportedFeature("createPublisher (rcl) — implemented in Task 4")
-    }
-
     package func createServiceServer(
         name: String,
         serviceTypeName: String,
@@ -154,16 +143,4 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
     ) throws -> any TransportClient {
         throw TransportError.unsupportedFeature("createServiceClient (transport: rcl) — not supported in M1")
     }
-}
-
-// Minimal placeholder; Task 4 replaces this with the full implementation in
-// RclTransportSession+Publisher.swift.
-final class RclTransportPublisher: TransportPublisher, @unchecked Sendable {
-    let topic: String
-    var isActive: Bool { false }
-    init(topic: String) { self.topic = topic }
-    func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws {
-        throw TransportError.unsupportedFeature("RclTransportPublisher — implemented in Task 4")
-    }
-    func close() throws {}
 }

--- a/Sources/SwiftROS2Transport/RclTransportSession.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession.swift
@@ -4,6 +4,8 @@
 
 import Foundation
 
+/// `TransportSession` backed by the real `rcl` + `rmw_cyclonedds_cpp` stack via
+/// `RclClientProtocol`. M1 is publish-only and assumes a single node.
 public final class RclTransportSession: TransportSession, @unchecked Sendable {
     let client: any RclClientProtocol
     private let lock = NSLock()

--- a/Sources/SwiftROS2Transport/RclTransportSession.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession.swift
@@ -47,6 +47,12 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
     }
 
     public func registerNode(name: String, namespace: String) throws {
+        lock.lock()
+        guard isOpen else {
+            lock.unlock()
+            throw TransportError.notConnected
+        }
+        lock.unlock()
         let node = try client.createNode(name: name, namespace: namespace)
         lock.lock()
         nodes[nodeKey(name, namespace)] = node
@@ -88,6 +94,7 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
 
     public func close() throws {
         lock.lock()
+        let wasOpen = isOpen
         let pubs = Array(publishers.values)
         publishers.removeAll()
         let ns = Array(nodes.values)
@@ -98,7 +105,7 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
         lock.unlock()
         for p in pubs { try? p.close() }
         for n in ns { client.destroyNode(n) }
-        client.destroyContext()
+        if wasOpen { client.destroyContext() }
     }
 
     public func checkHealth() -> Bool { isConnected }
@@ -106,7 +113,8 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
     // MARK: - Helpers
 
     private func nodeKey(_ name: String, _ namespace: String) -> String {
-        "\(namespace)/\(name)"
+        let ns = namespace.isEmpty ? "/" : namespace
+        return ns.hasSuffix("/") ? "\(ns)\(name)" : "\(ns)/\(name)"
     }
 
     func appendPublisher(_ pub: RclTransportPublisher, for topic: String) {

--- a/Sources/SwiftROS2Transport/RclTransportSession.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession.swift
@@ -72,10 +72,15 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
         }
     }
 
-    /// The node a new publisher attaches to (M1 single-node assumption).
-    func activeNode() throws -> any RclNodeHandle {
+    /// Atomically validate the session is open, the topic is free, and a node
+    /// exists; returns the node a new publisher attaches to (M1 single-node).
+    func preflightPublisher(topic: String) throws -> any RclNodeHandle {
         lock.lock()
         defer { lock.unlock() }
+        guard isOpen else { throw TransportError.notConnected }
+        guard publishers[topic] == nil else {
+            throw TransportError.publisherCreationFailed("Publisher already exists for topic: \(topic)")
+        }
         guard let node = currentNode else {
             throw TransportError.publisherCreationFailed("no node registered — create a node first")
         }

--- a/Sources/SwiftROS2Transport/TransportConfig.swift
+++ b/Sources/SwiftROS2Transport/TransportConfig.swift
@@ -13,11 +13,13 @@ import SwiftROS2Wire
 public enum TransportType: String, Codable, CaseIterable, Sendable {
     case zenoh
     case dds
+    case rcl
 
     public var displayName: String {
         switch self {
         case .zenoh: return "Zenoh"
         case .dds: return "DDS"
+        case .rcl: return "RCL (DDS)"
         }
     }
 }
@@ -119,6 +121,15 @@ public struct TransportConfig: Sendable {
         )
     }
 
+    /// Real `rcl` + `rmw_cyclonedds_cpp` backend (Apple, Jazzy; opt-in).
+    public static func rcl(domainId: Int = 0) -> TransportConfig {
+        TransportConfig(
+            type: .rcl, domainId: domainId,
+            zenohLocator: nil, wireMode: nil, connectionTimeout: 10.0,
+            ddsDiscoveryMode: .multicast, ddsUnicastPeers: [], ddsNetworkInterface: nil
+        )
+    }
+
     public init(
         type: TransportType,
         domainId: Int = 0,
@@ -152,6 +163,8 @@ public struct TransportConfig: Sendable {
             if ddsDiscoveryMode.requiresPeerConfiguration && ddsUnicastPeers.isEmpty {
                 throw TransportError.invalidConfiguration("DDS \(ddsDiscoveryMode) mode requires peer configuration")
             }
+        case .rcl:
+            break
         }
     }
 }

--- a/Sources/SwiftROS2Transport/TransportConfig.swift
+++ b/Sources/SwiftROS2Transport/TransportConfig.swift
@@ -121,7 +121,11 @@ public struct TransportConfig: Sendable {
         )
     }
 
-    /// Real `rcl` + `rmw_cyclonedds_cpp` backend (Apple, Jazzy; opt-in).
+    /// RCL + `rmw_cyclonedds_cpp` backend.
+    ///
+    /// Requires an Apple platform and building with `SWIFT_ROS2_ENABLE_RCL=1`.
+    /// On other configurations, `ROS2Context(transport:)` throws
+    /// ``TransportError/unsupportedFeature(_:)``.
     public static func rcl(domainId: Int = 0) -> TransportConfig {
         TransportConfig(
             type: .rcl, domainId: domainId,

--- a/Sources/SwiftROS2Transport/TransportSession.swift
+++ b/Sources/SwiftROS2Transport/TransportSession.swift
@@ -27,8 +27,8 @@ package protocol TransportSession: AnyObject, Sendable {
     /// Default: no-op.
     func registerNode(name: String, namespace: String) throws
 
-    /// Tear down a node previously registered via `registerNode`.
-    /// Default: no-op.
+    /// Tear down a node previously registered via a successful `registerNode`
+    /// call. Called by `ROS2Node.destroy()`. Default: no-op.
     func unregisterNode(name: String, namespace: String)
 
     /// Create a publisher for a topic

--- a/Sources/SwiftROS2Transport/TransportSession.swift
+++ b/Sources/SwiftROS2Transport/TransportSession.swift
@@ -21,6 +21,16 @@ package protocol TransportSession: AnyObject, Sendable {
     func close() throws
     func checkHealth() -> Bool
 
+    /// Register a ROS 2 node so backends that model real nodes (the rcl
+    /// backend) create one with the caller's name. Wire-level transports
+    /// (Zenoh/DDS) synthesize node identity per publisher and ignore this.
+    /// Default: no-op.
+    func registerNode(name: String, namespace: String) throws
+
+    /// Tear down a node previously registered via `registerNode`.
+    /// Default: no-op.
+    func unregisterNode(name: String, namespace: String)
+
     /// Create a publisher for a topic
     func createPublisher(
         topic: String,
@@ -104,6 +114,9 @@ package protocol TransportSession: AnyObject, Sendable {
 }
 
 extension TransportSession {
+    package func registerNode(name: String, namespace: String) throws {}
+    package func unregisterNode(name: String, namespace: String) {}
+
     /// Default — concrete sessions override in Phases 4 / 5.
     package func createActionServer(
         name: String,

--- a/Tests/SwiftROS2IntegrationTests/DDSRoundTripTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/DDSRoundTripTests.swift
@@ -3,104 +3,107 @@ import SwiftROS2Messages
 import SwiftROS2Transport
 import XCTest
 
-/// Round-trip integration test over CycloneDDS. Requires:
-/// - `LINUX_IP` env var (the host running a matching-domain ros2 topic echo)
-/// - A running `ros2 topic echo /test/imu` on that host with
-///   `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp` and `ROS_DOMAIN_ID=99`
-///
-/// Uses unicast discovery so the test works across WiFi / Parallels /
-/// environments where DDS multicast may be filtered.
-final class DDSRoundTripTests: XCTestCase {
-    func testImuPublishReceivedByLinuxDDS() async throws {
-        guard let linuxIP = ProcessInfo.processInfo.environment["LINUX_IP"], !linuxIP.isEmpty else {
-            throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)")
-        }
-
-        let domain = 99
-        let ctx = try await ROS2Context(
-            transport: .ddsUnicast(
-                peers: [DDSPeer.peer(address: linuxIP, domainId: domain)],
-                domainId: domain
-            ),
-            distro: .jazzy,
-            domainId: domain
-        )
-        let node = try await ctx.createNode(name: "swift_ros2_it_dds", namespace: "/test")
-        let pub = try await node.createPublisher(Imu.self, topic: "imu")
-
-        // DDS endpoint discovery through SPDP/SEDP is slower than Zenoh.
-        try await Task.sleep(nanoseconds: 3_000_000_000)
-
-        for i in 0..<10 {
-            try pub.publish(
-                Imu(
-                    header: Header.now(frameId: "imu_link"),
-                    linearAcceleration: Vector3(x: 0.0, y: 0.0, z: 9.81 + Double(i) * 0.01)
-                ))
-            try await Task.sleep(nanoseconds: 100_000_000)
-        }
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-        await ctx.shutdown()
-    }
-
-    /// Same-process publisher to subscriber over DDS multicast on the loopback
-    /// interface. No LINUX_IP required — runs anywhere CycloneDDS loopback
-    /// works, which is every Darwin / Linux machine. Uses domain 42 (distinct
-    /// from the remote-host test at domain 99 so the two cannot interfere if
-    /// both run).
-    func testLoopbackPubSubSameProcess() async throws {
-        let domain = 42
-        let ctx = try await ROS2Context(
-            transport: .ddsMulticast(domainId: domain),
-            distro: .jazzy,
-            domainId: domain
-        )
-        let node = try await ctx.createNode(name: "dds_loopback", namespace: "/loopback")
-
-        // Bind the subscriber first so SEDP can advertise the reader before
-        // the writer starts sending.
-        let sub = try await node.createSubscription(StringMsg.self, topic: "chatter")
-        let pub = try await node.createPublisher(StringMsg.self, topic: "chatter")
-
-        // DDS endpoint discovery (SPDP/SEDP) is slower than Zenoh; give both
-        // sides time to match before the first publish.
-        try await Task.sleep(nanoseconds: 2_000_000_000)
-
-        let expectation = XCTestExpectation(description: "receive at least 3 chatter messages")
-        expectation.expectedFulfillmentCount = 3
-        expectation.assertForOverFulfill = false
-
-        let buf = LoopbackReceivedBuffer()
-        let consumer = Task {
-            for await msg in sub.messages {
-                await buf.append(msg.data)
-                expectation.fulfill()
+// Exec's the `ros2` CLI via Process — native-host only; unavailable on Mac Catalyst.
+#if !targetEnvironment(macCatalyst)
+    /// Round-trip integration test over CycloneDDS. Requires:
+    /// - `LINUX_IP` env var (the host running a matching-domain ros2 topic echo)
+    /// - A running `ros2 topic echo /test/imu` on that host with
+    ///   `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp` and `ROS_DOMAIN_ID=99`
+    ///
+    /// Uses unicast discovery so the test works across WiFi / Parallels /
+    /// environments where DDS multicast may be filtered.
+    final class DDSRoundTripTests: XCTestCase {
+        func testImuPublishReceivedByLinuxDDS() async throws {
+            guard let linuxIP = ProcessInfo.processInfo.environment["LINUX_IP"], !linuxIP.isEmpty else {
+                throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)")
             }
+
+            let domain = 99
+            let ctx = try await ROS2Context(
+                transport: .ddsUnicast(
+                    peers: [DDSPeer.peer(address: linuxIP, domainId: domain)],
+                    domainId: domain
+                ),
+                distro: .jazzy,
+                domainId: domain
+            )
+            let node = try await ctx.createNode(name: "swift_ros2_it_dds", namespace: "/test")
+            let pub = try await node.createPublisher(Imu.self, topic: "imu")
+
+            // DDS endpoint discovery through SPDP/SEDP is slower than Zenoh.
+            try await Task.sleep(nanoseconds: 3_000_000_000)
+
+            for i in 0..<10 {
+                try pub.publish(
+                    Imu(
+                        header: Header.now(frameId: "imu_link"),
+                        linearAcceleration: Vector3(x: 0.0, y: 0.0, z: 9.81 + Double(i) * 0.01)
+                    ))
+                try await Task.sleep(nanoseconds: 100_000_000)
+            }
+
+            try await Task.sleep(nanoseconds: 500_000_000)
+            await ctx.shutdown()
         }
 
-        for i in 0..<5 {
-            try pub.publish(StringMsg(data: "hello-\(i)"))
-            // 200 ms between publishes gives RTPS reliability acknowledgements
-            // time to fire on the loopback interface.
-            try await Task.sleep(nanoseconds: 200_000_000)
+        /// Same-process publisher to subscriber over DDS multicast on the loopback
+        /// interface. No LINUX_IP required — runs anywhere CycloneDDS loopback
+        /// works, which is every Darwin / Linux machine. Uses domain 42 (distinct
+        /// from the remote-host test at domain 99 so the two cannot interfere if
+        /// both run).
+        func testLoopbackPubSubSameProcess() async throws {
+            let domain = 42
+            let ctx = try await ROS2Context(
+                transport: .ddsMulticast(domainId: domain),
+                distro: .jazzy,
+                domainId: domain
+            )
+            let node = try await ctx.createNode(name: "dds_loopback", namespace: "/loopback")
+
+            // Bind the subscriber first so SEDP can advertise the reader before
+            // the writer starts sending.
+            let sub = try await node.createSubscription(StringMsg.self, topic: "chatter")
+            let pub = try await node.createPublisher(StringMsg.self, topic: "chatter")
+
+            // DDS endpoint discovery (SPDP/SEDP) is slower than Zenoh; give both
+            // sides time to match before the first publish.
+            try await Task.sleep(nanoseconds: 2_000_000_000)
+
+            let expectation = XCTestExpectation(description: "receive at least 3 chatter messages")
+            expectation.expectedFulfillmentCount = 3
+            expectation.assertForOverFulfill = false
+
+            let buf = LoopbackReceivedBuffer()
+            let consumer = Task {
+                for await msg in sub.messages {
+                    await buf.append(msg.data)
+                    expectation.fulfill()
+                }
+            }
+
+            for i in 0..<5 {
+                try pub.publish(StringMsg(data: "hello-\(i)"))
+                // 200 ms between publishes gives RTPS reliability acknowledgements
+                // time to fire on the loopback interface.
+                try await Task.sleep(nanoseconds: 200_000_000)
+            }
+
+            await fulfillment(of: [expectation], timeout: 10.0)
+            consumer.cancel()
+
+            let items = await buf.items
+            XCTAssertGreaterThanOrEqual(
+                items.count, 3, "expected at least 3 messages; got \(items)")
+            for item in items {
+                XCTAssertTrue(item.starts(with: "hello-"), "unexpected payload: \(item)")
+            }
+
+            await ctx.shutdown()
         }
-
-        await fulfillment(of: [expectation], timeout: 10.0)
-        consumer.cancel()
-
-        let items = await buf.items
-        XCTAssertGreaterThanOrEqual(
-            items.count, 3, "expected at least 3 messages; got \(items)")
-        for item in items {
-            XCTAssertTrue(item.starts(with: "hello-"), "unexpected payload: \(item)")
-        }
-
-        await ctx.shutdown()
     }
-}
 
-private actor LoopbackReceivedBuffer {
-    private(set) var items: [String] = []
-    func append(_ s: String) { items.append(s) }
-}
+    private actor LoopbackReceivedBuffer {
+        private(set) var items: [String] = []
+        func append(_ s: String) { items.append(s) }
+    }
+#endif

--- a/Tests/SwiftROS2IntegrationTests/Parameters/ParameterEventsInteropTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/Parameters/ParameterEventsInteropTests.swift
@@ -4,47 +4,50 @@ import SwiftROS2Messages
 import SwiftROS2Transport
 import XCTest
 
-final class ParameterEventsInteropTests: XCTestCase {
-    func testParameterEventsConsumableByROS2TopicEcho() async throws {
-        // Match the gating used by the other LAN-gated tests in this
-        // target: skip on missing OR empty LINUX_IP.
-        guard let ip = ProcessInfo.processInfo.environment["LINUX_IP"], !ip.isEmpty
-        else { throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)") }
+// Exec's the `ros2` CLI via Process — native-host only; unavailable on Mac Catalyst.
+#if !targetEnvironment(macCatalyst)
+    final class ParameterEventsInteropTests: XCTestCase {
+        func testParameterEventsConsumableByROS2TopicEcho() async throws {
+            // Match the gating used by the other LAN-gated tests in this
+            // target: skip on missing OR empty LINUX_IP.
+            guard let ip = ProcessInfo.processInfo.environment["LINUX_IP"], !ip.isEmpty
+            else { throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)") }
 
-        let ctx = try await ROS2Context(
-            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
-            distro: .jazzy)
-        let node = try await ctx.createNode(name: "events_node", namespace: "/test")
-        defer {
-            Task {
-                await node.destroy()
-                await ctx.shutdown()
+            let ctx = try await ROS2Context(
+                transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+                distro: .jazzy)
+            let node = try await ctx.createNode(name: "events_node", namespace: "/test")
+            defer {
+                Task {
+                    await node.destroy()
+                    await ctx.shutdown()
+                }
             }
+
+            // Spawn a docker `ros2 topic echo --once` in the background. It
+            // returns the next message and exits.
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            p.arguments = [
+                "docker", "exec", "ros_jazzy_zenoh", "bash", "-c",
+                "source /opt/ros/jazzy/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp && timeout 8 ros2 topic echo --once /parameter_events",
+            ]
+            let out = Pipe()
+            p.standardOutput = out
+            try p.run()
+
+            // Give the echo subscriber a moment to subscribe before we publish.
+            try await Task.sleep(nanoseconds: 1_500_000_000)
+            _ = try await node.declareParameter("rate", default: Int64(30))
+
+            p.waitUntilExit()
+            let stdout = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            XCTAssertTrue(
+                stdout.contains("rate"),
+                "expected ros2 topic echo to receive ParameterEvent for 'rate', got: \(stdout)")
+            XCTAssertTrue(
+                stdout.contains("/test/events_node"),
+                "expected event.node to match swift-ros2 fqn, got: \(stdout)")
         }
-
-        // Spawn a docker `ros2 topic echo --once` in the background. It
-        // returns the next message and exits.
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        p.arguments = [
-            "docker", "exec", "ros_jazzy_zenoh", "bash", "-c",
-            "source /opt/ros/jazzy/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp && timeout 8 ros2 topic echo --once /parameter_events",
-        ]
-        let out = Pipe()
-        p.standardOutput = out
-        try p.run()
-
-        // Give the echo subscriber a moment to subscribe before we publish.
-        try await Task.sleep(nanoseconds: 1_500_000_000)
-        _ = try await node.declareParameter("rate", default: Int64(30))
-
-        p.waitUntilExit()
-        let stdout = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        XCTAssertTrue(
-            stdout.contains("rate"),
-            "expected ros2 topic echo to receive ParameterEvent for 'rate', got: \(stdout)")
-        XCTAssertTrue(
-            stdout.contains("/test/events_node"),
-            "expected event.node to match swift-ros2 fqn, got: \(stdout)")
     }
-}
+#endif

--- a/Tests/SwiftROS2IntegrationTests/Parameters/ROS2ParamCLIInteropTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/Parameters/ROS2ParamCLIInteropTests.swift
@@ -4,135 +4,138 @@ import SwiftROS2Messages
 import SwiftROS2Transport
 import XCTest
 
-/// LAN-gated `ros2 param` CLI interop. Skips when `LINUX_IP` is unset
-/// or empty. Requires two running docker containers on the host:
-///   - `ros_jazzy_zenoh` — ROS 2 Jazzy + `rmw_zenoh_cpp` + an active
-///     `rmw_zenohd` peering at `tcp/127.0.0.1:7447`.
-///   - `ros_jazzy_dds`   — ROS 2 Jazzy + `rmw_cyclonedds_cpp` reachable
-///     on the chosen `ROS_DOMAIN_ID`.
-///
-/// The compose files for these containers live in the downstream Conduit
-/// repository under `support/docker/`; swift-ros2 itself does not ship a
-/// docker stack. Bring the containers up there before running the tests.
-final class ROS2ParamCLIInteropTests: XCTestCase {
-    private func skipIfNoLinuxIP() throws -> String {
-        guard let ip = ProcessInfo.processInfo.environment["LINUX_IP"], !ip.isEmpty
-        else { throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)") }
-        return ip
-    }
-
-    /// Exec a command in the named docker container; returns stdout. Throws
-    /// on non-zero exit code with stderr in the message.
-    private func dockerExec(container: String, _ shell: String) throws -> String {
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        p.arguments = ["docker", "exec", container, "bash", "-c", shell]
-        let out = Pipe()
-        let err = Pipe()
-        p.standardOutput = out
-        p.standardError = err
-        try p.run()
-        p.waitUntilExit()
-        let stdout = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        if p.terminationStatus != 0 {
-            let stderr = String(data: err.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-            throw NSError(
-                domain: "DockerExec", code: Int(p.terminationStatus),
-                userInfo: [NSLocalizedDescriptionKey: "\(shell) failed: \(stderr)"])
+// Exec's the `ros2` CLI via Process — native-host only; unavailable on Mac Catalyst.
+#if !targetEnvironment(macCatalyst)
+    /// LAN-gated `ros2 param` CLI interop. Skips when `LINUX_IP` is unset
+    /// or empty. Requires two running docker containers on the host:
+    ///   - `ros_jazzy_zenoh` — ROS 2 Jazzy + `rmw_zenoh_cpp` + an active
+    ///     `rmw_zenohd` peering at `tcp/127.0.0.1:7447`.
+    ///   - `ros_jazzy_dds`   — ROS 2 Jazzy + `rmw_cyclonedds_cpp` reachable
+    ///     on the chosen `ROS_DOMAIN_ID`.
+    ///
+    /// The compose files for these containers live in the downstream Conduit
+    /// repository under `support/docker/`; swift-ros2 itself does not ship a
+    /// docker stack. Bring the containers up there before running the tests.
+    final class ROS2ParamCLIInteropTests: XCTestCase {
+        private func skipIfNoLinuxIP() throws -> String {
+            guard let ip = ProcessInfo.processInfo.environment["LINUX_IP"], !ip.isEmpty
+            else { throw XCTSkip("Set LINUX_IP to run this test (e.g., LINUX_IP=192.168.1.85)") }
+            return ip
         }
-        return stdout
-    }
 
-    func testParamListGetSetDescribeOverZenoh() async throws {
-        _ = try skipIfNoLinuxIP()
-        let ctx = try await ROS2Context(
-            transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
-            distro: .jazzy)
-        let node = try await ctx.createNode(name: "cli_node", namespace: "/test")
-        defer {
-            Task {
-                await node.destroy()
-                await ctx.shutdown()
+        /// Exec a command in the named docker container; returns stdout. Throws
+        /// on non-zero exit code with stderr in the message.
+        private func dockerExec(container: String, _ shell: String) throws -> String {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            p.arguments = ["docker", "exec", container, "bash", "-c", shell]
+            let out = Pipe()
+            let err = Pipe()
+            p.standardOutput = out
+            p.standardError = err
+            try p.run()
+            p.waitUntilExit()
+            let stdout = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            if p.terminationStatus != 0 {
+                let stderr = String(data: err.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                throw NSError(
+                    domain: "DockerExec", code: Int(p.terminationStatus),
+                    userInfo: [NSLocalizedDescriptionKey: "\(shell) failed: \(stderr)"])
             }
+            return stdout
         }
 
-        _ = try await node.declareParameter("rate", default: Int64(30))
-        _ = try await node.declareParameter("greeting", default: "hi")
-        _ = try await node.declareParameter("enabled", default: true)
-
-        // Allow Zenoh discovery to settle.
-        try await Task.sleep(nanoseconds: 1_500_000_000)
-
-        let prelude = "source /opt/ros/jazzy/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp"
-
-        let listOut = try dockerExec(
-            container: "ros_jazzy_zenoh",
-            "\(prelude) && ros2 param list /test/cli_node")
-        XCTAssertTrue(listOut.contains("rate"), "list missing rate: \(listOut)")
-        XCTAssertTrue(listOut.contains("greeting"))
-        XCTAssertTrue(listOut.contains("enabled"))
-
-        let getOut = try dockerExec(
-            container: "ros_jazzy_zenoh",
-            "\(prelude) && ros2 param get /test/cli_node rate")
-        XCTAssertTrue(getOut.contains("30"), "get rate not 30: \(getOut)")
-
-        let setOut = try dockerExec(
-            container: "ros_jazzy_zenoh",
-            "\(prelude) && ros2 param set /test/cli_node rate 60")
-        XCTAssertTrue(
-            setOut.contains("successful") || setOut.contains("Set"),
-            "set rate output unexpected: \(setOut)")
-
-        let storedAfterSet = try await node.getParameter("rate")
-        XCTAssertEqual(storedAfterSet.value, .integer(60))
-
-        let describeOut = try dockerExec(
-            container: "ros_jazzy_zenoh",
-            "\(prelude) && ros2 param describe /test/cli_node rate")
-        XCTAssertTrue(
-            describeOut.contains("Type: integer") || describeOut.contains("integer"),
-            "describe rate type missing: \(describeOut)")
-    }
-
-    func testParamListGetSetDescribeOverDDS() async throws {
-        let linuxIP = try skipIfNoLinuxIP()
-        let domain = 99
-        let ctx = try await ROS2Context(
-            transport: .ddsUnicast(
-                peers: [DDSPeer.peer(address: linuxIP, domainId: domain)],
-                domainId: domain),
-            distro: .jazzy, domainId: domain)
-        let node = try await ctx.createNode(name: "cli_node", namespace: "/test")
-        defer {
-            Task {
-                await node.destroy()
-                await ctx.shutdown()
+        func testParamListGetSetDescribeOverZenoh() async throws {
+            _ = try skipIfNoLinuxIP()
+            let ctx = try await ROS2Context(
+                transport: .zenoh(locator: "tcp/127.0.0.1:7447", domainId: 0),
+                distro: .jazzy)
+            let node = try await ctx.createNode(name: "cli_node", namespace: "/test")
+            defer {
+                Task {
+                    await node.destroy()
+                    await ctx.shutdown()
+                }
             }
+
+            _ = try await node.declareParameter("rate", default: Int64(30))
+            _ = try await node.declareParameter("greeting", default: "hi")
+            _ = try await node.declareParameter("enabled", default: true)
+
+            // Allow Zenoh discovery to settle.
+            try await Task.sleep(nanoseconds: 1_500_000_000)
+
+            let prelude = "source /opt/ros/jazzy/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp"
+
+            let listOut = try dockerExec(
+                container: "ros_jazzy_zenoh",
+                "\(prelude) && ros2 param list /test/cli_node")
+            XCTAssertTrue(listOut.contains("rate"), "list missing rate: \(listOut)")
+            XCTAssertTrue(listOut.contains("greeting"))
+            XCTAssertTrue(listOut.contains("enabled"))
+
+            let getOut = try dockerExec(
+                container: "ros_jazzy_zenoh",
+                "\(prelude) && ros2 param get /test/cli_node rate")
+            XCTAssertTrue(getOut.contains("30"), "get rate not 30: \(getOut)")
+
+            let setOut = try dockerExec(
+                container: "ros_jazzy_zenoh",
+                "\(prelude) && ros2 param set /test/cli_node rate 60")
+            XCTAssertTrue(
+                setOut.contains("successful") || setOut.contains("Set"),
+                "set rate output unexpected: \(setOut)")
+
+            let storedAfterSet = try await node.getParameter("rate")
+            XCTAssertEqual(storedAfterSet.value, .integer(60))
+
+            let describeOut = try dockerExec(
+                container: "ros_jazzy_zenoh",
+                "\(prelude) && ros2 param describe /test/cli_node rate")
+            XCTAssertTrue(
+                describeOut.contains("Type: integer") || describeOut.contains("integer"),
+                "describe rate type missing: \(describeOut)")
         }
 
-        _ = try await node.declareParameter("rate", default: Int64(30))
-        _ = try await node.declareParameter("greeting", default: "hi")
+        func testParamListGetSetDescribeOverDDS() async throws {
+            let linuxIP = try skipIfNoLinuxIP()
+            let domain = 99
+            let ctx = try await ROS2Context(
+                transport: .ddsUnicast(
+                    peers: [DDSPeer.peer(address: linuxIP, domainId: domain)],
+                    domainId: domain),
+                distro: .jazzy, domainId: domain)
+            let node = try await ctx.createNode(name: "cli_node", namespace: "/test")
+            defer {
+                Task {
+                    await node.destroy()
+                    await ctx.shutdown()
+                }
+            }
 
-        // CycloneDDS SPDP/SEDP needs more time than Zenoh.
-        try await Task.sleep(nanoseconds: 4_000_000_000)
+            _ = try await node.declareParameter("rate", default: Int64(30))
+            _ = try await node.declareParameter("greeting", default: "hi")
 
-        let prelude =
-            "source /opt/ros/jazzy/setup.bash && export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp && export ROS_DOMAIN_ID=\(domain)"
+            // CycloneDDS SPDP/SEDP needs more time than Zenoh.
+            try await Task.sleep(nanoseconds: 4_000_000_000)
 
-        let listOut = try dockerExec(
-            container: "ros_jazzy_dds",
-            "\(prelude) && ros2 param list /test/cli_node")
-        XCTAssertTrue(listOut.contains("rate"), "list missing rate (DDS): \(listOut)")
+            let prelude =
+                "source /opt/ros/jazzy/setup.bash && export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp && export ROS_DOMAIN_ID=\(domain)"
 
-        let setOut = try dockerExec(
-            container: "ros_jazzy_dds",
-            "\(prelude) && ros2 param set /test/cli_node rate 60")
-        XCTAssertTrue(
-            setOut.contains("successful") || setOut.contains("Set"),
-            "set rate (DDS) unexpected: \(setOut)")
+            let listOut = try dockerExec(
+                container: "ros_jazzy_dds",
+                "\(prelude) && ros2 param list /test/cli_node")
+            XCTAssertTrue(listOut.contains("rate"), "list missing rate (DDS): \(listOut)")
 
-        let storedAfterSet = try await node.getParameter("rate")
-        XCTAssertEqual(storedAfterSet.value, .integer(60))
+            let setOut = try dockerExec(
+                container: "ros_jazzy_dds",
+                "\(prelude) && ros2 param set /test/cli_node rate 60")
+            XCTAssertTrue(
+                setOut.contains("successful") || setOut.contains("Set"),
+                "set rate (DDS) unexpected: \(setOut)")
+
+            let storedAfterSet = try await node.getParameter("rate")
+            XCTAssertEqual(storedAfterSet.value, .integer(60))
+        }
     }
-}
+#endif

--- a/Tests/SwiftROS2IntegrationTests/RclPublishIntegrationTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/RclPublishIntegrationTests.swift
@@ -1,0 +1,46 @@
+import SwiftROS2Messages
+import XCTest
+
+@testable import SwiftROS2
+
+/// Publishes sensor_msgs/Imu through the real rcl + rmw_cyclonedds_cpp stack.
+/// Gated: requires the RCL backend built (SWIFT_ROS2_RCL) and a reachable
+/// Jazzy host (LINUX_IP). Host-side verification is documented at the bottom.
+final class RclPublishIntegrationTests: XCTestCase {
+    func testPublishImuOverRcl() async throws {
+        #if !SWIFT_ROS2_RCL
+            throw XCTSkip("RCL backend not built (set SWIFT_ROS2_ENABLE_RCL=1)")
+        #else
+            guard ProcessInfo.processInfo.environment["LINUX_IP"] != nil else {
+                throw XCTSkip("LINUX_IP not set — skipping LAN integration test")
+            }
+
+            let ctx = try await ROS2Context(transport: .rcl(domainId: 0))
+            let node = try await ctx.createNode(
+                name: "swift_ros2_rcl_test", namespace: "/swift_ros2_rcl",
+                options: ROS2NodeOptions(startParameterServices: false)  // M1 is publish-only
+            )
+            let pub = try await node.createPublisher(Imu.self, topic: "imu")
+
+            var imu = Imu()
+            imu.linearAcceleration.x = 1.0
+            imu.linearAcceleration.y = 2.0
+            imu.linearAcceleration.z = 9.81
+            imu.angularVelocity.z = 0.5
+
+            for _ in 0..<50 {
+                try await pub.publish(imu)
+                try await Task.sleep(for: .milliseconds(100))
+            }
+
+            await ctx.shutdown()
+
+        // Host-side verification (run on the Jazzy host while this publishes):
+        //   ros2 node list            -> shows /swift_ros2_rcl/swift_ros2_rcl_test
+        //   ros2 topic echo /swift_ros2_rcl/imu
+        //                             -> Imu with linear_acceleration {1,2,9.81}
+        //   ros2 topic info /swift_ros2_rcl/imu --verbose
+        //                             -> type sensor_msgs/msg/Imu, 1 publisher
+        #endif
+    }
+}

--- a/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
+++ b/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
@@ -27,6 +27,7 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
     private var _isConnected = true
     private var _sessionIdValue = "mock-umbrella-session"
     private var _openShouldThrow: TransportError?
+    private var _registerNodeShouldThrow: TransportError?
     private var _createPublisherShouldThrow: TransportError?
     private var _createSubscriberShouldThrow: TransportError?
     private var _openedConfigs: [TransportConfig] = []
@@ -66,6 +67,11 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
     var openShouldThrow: TransportError? {
         get { synchronized { _openShouldThrow } }
         set { synchronized { _openShouldThrow = newValue } }
+    }
+
+    var registerNodeShouldThrow: TransportError? {
+        get { synchronized { _registerNodeShouldThrow } }
+        set { synchronized { _registerNodeShouldThrow = newValue } }
     }
 
     var createPublisherShouldThrow: TransportError? {
@@ -244,6 +250,7 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
     }
 
     func registerNode(name: String, namespace: String) throws {
+        if let e = synchronized({ _registerNodeShouldThrow }) { throw e }
         synchronized { _registeredNodes.append((name, namespace)) }
     }
 

--- a/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
+++ b/Tests/SwiftROS2Tests/Mocks/MockTransportSession.swift
@@ -33,6 +33,8 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
     private var _publishers: [MockTransportPublisher] = []
     private var _subscribers: [MockTransportSubscriber] = []
     private var _closedCount = 0
+    private var _registeredNodes: [(name: String, namespace: String)] = []
+    private var _unregisteredNodes: [(name: String, namespace: String)] = []
 
     // Service-related state. Default-disabled so tests that don't opt in
     // keep getting the original "unsupportedFeature" throw.
@@ -80,6 +82,8 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
     var publishers: [MockTransportPublisher] { synchronized { _publishers } }
     var subscribers: [MockTransportSubscriber] { synchronized { _subscribers } }
     var closedCount: Int { synchronized { _closedCount } }
+    var registeredNodes: [(name: String, namespace: String)] { synchronized { _registeredNodes } }
+    var unregisteredNodes: [(name: String, namespace: String)] { synchronized { _unregisteredNodes } }
 
     // MARK: - TransportSession
 
@@ -237,6 +241,14 @@ final class MockTransportSession: TransportSession, @unchecked Sendable {
             synchronized { _clients.append(cli) }
             return cli
         }
+    }
+
+    func registerNode(name: String, namespace: String) throws {
+        synchronized { _registeredNodes.append((name, namespace)) }
+    }
+
+    func unregisterNode(name: String, namespace: String) {
+        synchronized { _unregisteredNodes.append((name, namespace)) }
     }
 
     // MARK: - Action overrides

--- a/Tests/SwiftROS2Tests/NodeRegistrationTests.swift
+++ b/Tests/SwiftROS2Tests/NodeRegistrationTests.swift
@@ -37,4 +37,31 @@ final class NodeRegistrationTests: XCTestCase {
         XCTAssertEqual(session.unregisteredNodes.first?.name, "imu_node")
         XCTAssertEqual(session.unregisteredNodes.first?.namespace, "/ios")
     }
+
+    func testRegisterNodeFailureDoesNotTriggerUnregister() async throws {
+        let session = MockTransportSession()
+        session.registerNodeShouldThrow = TransportError.connectionFailed("simulated")
+        let ctx = try await makeContext(session)
+        do {
+            _ = try await ctx.createNode(
+                name: "imu_node", namespace: "/ios",
+                options: ROS2NodeOptions(startParameterServices: false))
+            XCTFail("Expected createNode to throw")
+        } catch {}
+        XCTAssertEqual(session.registeredNodes.count, 0)
+        XCTAssertEqual(session.unregisteredNodes.count, 0)
+    }
+
+    func testContextShutdownUnregistersAllNodes() async throws {
+        let session = MockTransportSession()
+        let ctx = try await makeContext(session)
+        _ = try await ctx.createNode(
+            name: "a", namespace: "/ns",
+            options: ROS2NodeOptions(startParameterServices: false))
+        _ = try await ctx.createNode(
+            name: "b", namespace: "/ns",
+            options: ROS2NodeOptions(startParameterServices: false))
+        await ctx.shutdown()
+        XCTAssertEqual(session.unregisteredNodes.count, 2)
+    }
 }

--- a/Tests/SwiftROS2Tests/NodeRegistrationTests.swift
+++ b/Tests/SwiftROS2Tests/NodeRegistrationTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import SwiftROS2
+@testable import SwiftROS2Transport
+
+final class NodeRegistrationTests: XCTestCase {
+    private func makeContext(
+        _ session: MockTransportSession
+    ) async throws -> ROS2Context {
+        try await ROS2Context(
+            transport: .zenoh(locator: "tcp/m:7447"),
+            session: session
+        )
+    }
+
+    func testCreateNodeRegistersNodeOnSession() async throws {
+        let session = MockTransportSession()
+        let ctx = try await makeContext(session)
+        _ = try await ctx.createNode(
+            name: "imu_node", namespace: "/ios",
+            options: ROS2NodeOptions(startParameterServices: false)
+        )
+        XCTAssertEqual(session.registeredNodes.count, 1)
+        XCTAssertEqual(session.registeredNodes.first?.name, "imu_node")
+        XCTAssertEqual(session.registeredNodes.first?.namespace, "/ios")
+    }
+
+    func testDestroyNodeUnregistersNodeOnSession() async throws {
+        let session = MockTransportSession()
+        let ctx = try await makeContext(session)
+        let node = try await ctx.createNode(
+            name: "imu_node", namespace: "/ios",
+            options: ROS2NodeOptions(startParameterServices: false)
+        )
+        await node.destroy()
+        XCTAssertEqual(session.unregisteredNodes.count, 1)
+        XCTAssertEqual(session.unregisteredNodes.first?.name, "imu_node")
+        XCTAssertEqual(session.unregisteredNodes.first?.namespace, "/ios")
+    }
+}

--- a/Tests/SwiftROS2Tests/RclConfigTests.swift
+++ b/Tests/SwiftROS2Tests/RclConfigTests.swift
@@ -8,6 +8,10 @@ final class RclConfigTests: XCTestCase {
         let cfg = TransportConfig.rcl(domainId: 7)
         XCTAssertEqual(cfg.type, .rcl)
         XCTAssertEqual(cfg.domainId, 7)
+        XCTAssertNil(cfg.zenohLocator)
+        XCTAssertNil(cfg.wireMode)
+        XCTAssertEqual(cfg.ddsDiscoveryMode, .multicast)
+        XCTAssertTrue(cfg.ddsUnicastPeers.isEmpty)
         XCTAssertNoThrow(try cfg.validate())
     }
 

--- a/Tests/SwiftROS2Tests/RclConfigTests.swift
+++ b/Tests/SwiftROS2Tests/RclConfigTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+@testable import SwiftROS2
+@testable import SwiftROS2Transport
+
+final class RclConfigTests: XCTestCase {
+    func testRclFactoryProducesRclConfig() throws {
+        let cfg = TransportConfig.rcl(domainId: 7)
+        XCTAssertEqual(cfg.type, .rcl)
+        XCTAssertEqual(cfg.domainId, 7)
+        XCTAssertNoThrow(try cfg.validate())
+    }
+
+    func testRclDisplayName() {
+        XCTAssertEqual(TransportType.rcl.displayName, "RCL (DDS)")
+    }
+
+    func testRclContextThrowsWhenBackendNotBuilt() async throws {
+        #if SWIFT_ROS2_RCL
+            throw XCTSkip("RCL backend is built; throw-path not applicable")
+        #else
+            do {
+                _ = try await ROS2Context(transport: .rcl(domainId: 0))
+                XCTFail("expected unsupportedFeature")
+            } catch let error as TransportError {
+                guard case .unsupportedFeature = error else {
+                    return XCTFail("expected unsupportedFeature, got \(error)")
+                }
+            } catch {
+                XCTFail("expected TransportError, got \(error)")
+            }
+        #endif
+    }
+}

--- a/Tests/SwiftROS2TransportTests/Mocks/MockRclClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockRclClient.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+@testable import SwiftROS2Transport
+
+final class MockRclNode: RclNodeHandle, @unchecked Sendable {
+    let name: String
+    let namespace: String
+    init(name: String, namespace: String) {
+        self.name = name
+        self.namespace = namespace
+    }
+}
+
+final class MockRclPublisher: RclPublisherHandle, @unchecked Sendable {
+    let topic: String
+    let typeName: String
+    private let lock = NSLock()
+    private var closed = false
+    init(topic: String, typeName: String) {
+        self.topic = topic
+        self.typeName = typeName
+    }
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !closed
+    }
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        closed = true
+    }
+}
+
+final class MockRclClient: RclClientProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private func sync<T>(_ b: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return b()
+    }
+
+    var isAvailable = true
+
+    private(set) var contextCreated = false
+    private(set) var contextDestroyed = false
+    private(set) var lastDomainId: Int32 = -1
+    private(set) var nodesCreated: [(name: String, namespace: String)] = []
+    private(set) var nodesDestroyed: [(name: String, namespace: String)] = []
+    private(set) var publishersCreated: [(topic: String, typeName: String)] = []
+    private(set) var publishedPayloads: [Data] = []
+
+    var createPublisherShouldThrow: TransportError?
+
+    func createContext(domainId: Int32) throws {
+        sync {
+            contextCreated = true
+            lastDomainId = domainId
+        }
+    }
+    func destroyContext() { sync { contextDestroyed = true } }
+
+    func createNode(name: String, namespace: String) throws -> any RclNodeHandle {
+        sync { nodesCreated.append((name, namespace)) }
+        return MockRclNode(name: name, namespace: namespace)
+    }
+    func destroyNode(_ node: any RclNodeHandle) {
+        guard let n = node as? MockRclNode else { return }
+        sync { nodesDestroyed.append((n.name, n.namespace)) }
+    }
+
+    func createPublisher(
+        node: any RclNodeHandle, typeName: String, topic: String, qos: TransportQoS
+    ) throws -> any RclPublisherHandle {
+        if let e = createPublisherShouldThrow { throw e }
+        sync { publishersCreated.append((topic, typeName)) }
+        return MockRclPublisher(topic: topic, typeName: typeName)
+    }
+
+    func publishSerialized(_ publisher: any RclPublisherHandle, data: Data) throws {
+        sync { publishedPayloads.append(data) }
+    }
+}

--- a/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
+++ b/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+
+@testable import SwiftROS2Transport
+
+final class RclTransportSessionTests: XCTestCase {
+    private func openSession(
+        _ client: MockRclClient = MockRclClient(),
+        domainId: Int = 0
+    ) async throws -> RclTransportSession {
+        let s = RclTransportSession(client: client)
+        try await s.open(config: .rcl(domainId: domainId))
+        return s
+    }
+
+    func testOpenCreatesContext() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client, domainId: 5)
+        XCTAssertTrue(client.contextCreated)
+        XCTAssertEqual(client.lastDomainId, 5)
+        XCTAssertTrue(s.isConnected)
+        XCTAssertEqual(s.transportType, .rcl)
+    }
+
+    func testOpenRejectsNonRclConfig() async {
+        let s = RclTransportSession(client: MockRclClient())
+        do {
+            try await s.open(config: .ddsMulticast(domainId: 0))
+            XCTFail("expected invalidConfiguration")
+        } catch let e as TransportError {
+            guard case .invalidConfiguration = e else { return XCTFail("got \(e)") }
+        } catch { XCTFail("got \(error)") }
+    }
+
+    func testOpenFailsWhenUnavailable() async {
+        let client = MockRclClient()
+        client.isAvailable = false
+        let s = RclTransportSession(client: client)
+        do {
+            try await s.open(config: .rcl(domainId: 0))
+            XCTFail("expected unsupportedFeature")
+        } catch let e as TransportError {
+            guard case .unsupportedFeature = e else { return XCTFail("got \(e)") }
+        } catch { XCTFail("got \(error)") }
+    }
+
+    func testRegisterNodeCreatesRclNode() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        XCTAssertEqual(client.nodesCreated.count, 1)
+        XCTAssertEqual(client.nodesCreated.first?.name, "imu_node")
+        XCTAssertEqual(client.nodesCreated.first?.namespace, "/ios")
+    }
+
+    func testUnregisterNodeDestroysRclNode() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        s.unregisterNode(name: "imu_node", namespace: "/ios")
+        XCTAssertEqual(client.nodesDestroyed.count, 1)
+        XCTAssertEqual(client.nodesDestroyed.first?.name, "imu_node")
+    }
+
+    func testCreateSubscriberUnsupported() async throws {
+        let s = try await openSession()
+        XCTAssertThrowsError(
+            try s.createSubscriber(
+                topic: "/t", typeName: "std_msgs/msg/String", typeHash: nil,
+                qos: .sensorData, handler: { _, _ in })
+        ) { error in
+            guard case TransportError.unsupportedFeature = error else {
+                return XCTFail("got \(error)")
+            }
+        }
+    }
+
+    func testCloseDestroysNodesAndContext() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        try s.close()
+        XCTAssertTrue(client.contextDestroyed)
+        XCTAssertEqual(client.nodesDestroyed.count, 1)
+        XCTAssertFalse(s.isConnected)
+    }
+}

--- a/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
+++ b/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
@@ -19,6 +19,7 @@ final class RclTransportSessionTests: XCTestCase {
         XCTAssertEqual(client.lastDomainId, 5)
         XCTAssertTrue(s.isConnected)
         XCTAssertEqual(s.transportType, .rcl)
+        XCTAssertEqual(s.sessionId, "rcl-5")
     }
 
     func testOpenRejectsNonRclConfig() async {
@@ -82,5 +83,19 @@ final class RclTransportSessionTests: XCTestCase {
         XCTAssertTrue(client.contextDestroyed)
         XCTAssertEqual(client.nodesDestroyed.count, 1)
         XCTAssertFalse(s.isConnected)
+    }
+
+    func testRegisterNodeBeforeOpenThrows() {
+        let s = RclTransportSession(client: MockRclClient())
+        XCTAssertThrowsError(try s.registerNode(name: "n", namespace: "/")) { error in
+            guard case TransportError.notConnected = error else { return XCTFail("got \(error)") }
+        }
+    }
+
+    func testCloseWithoutOpenSkipsDestroyContext() throws {
+        let client = MockRclClient()
+        let s = RclTransportSession(client: client)
+        try s.close()
+        XCTAssertFalse(client.contextDestroyed)
     }
 }

--- a/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
+++ b/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
@@ -98,4 +98,50 @@ final class RclTransportSessionTests: XCTestCase {
         try s.close()
         XCTAssertFalse(client.contextDestroyed)
     }
+
+    func testCreatePublisherRequiresNode() async throws {
+        let s = try await openSession()
+        XCTAssertThrowsError(
+            try s.createPublisher(
+                topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil, qos: .sensorData)
+        ) { error in
+            guard case TransportError.publisherCreationFailed = error else {
+                return XCTFail("got \(error)")
+            }
+        }
+    }
+
+    func testCreatePublisherAttachesToCurrentNode() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        let pub = try s.createPublisher(
+            topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil, qos: .sensorData)
+        XCTAssertEqual(client.publishersCreated.count, 1)
+        XCTAssertEqual(client.publishersCreated.first?.topic, "/imu")
+        XCTAssertEqual(client.publishersCreated.first?.typeName, "sensor_msgs/msg/Imu")
+        XCTAssertTrue(pub.isActive)
+    }
+
+    func testPublishForwardsSerializedBytes() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        let pub = try s.createPublisher(
+            topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil, qos: .sensorData)
+        let cdr = Data([0x00, 0x01, 0x00, 0x00, 0xDE, 0xAD])
+        try pub.publish(data: cdr, timestamp: 123, sequenceNumber: 1)
+        XCTAssertEqual(client.publishedPayloads, [cdr])
+    }
+
+    func testPublishRejectsShortData() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        let pub = try s.createPublisher(
+            topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil, qos: .sensorData)
+        XCTAssertThrowsError(try pub.publish(data: Data([0x00]), timestamp: 0, sequenceNumber: 0)) {
+            guard case TransportError.publishFailed = $0 else { return XCTFail("got \($0)") }
+        }
+    }
 }

--- a/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
+++ b/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
@@ -144,4 +144,35 @@ final class RclTransportSessionTests: XCTestCase {
             guard case TransportError.publishFailed = $0 else { return XCTFail("got \($0)") }
         }
     }
+
+    func testPublishAfterCloseThrows() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        let pub = try s.createPublisher(
+            topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil, qos: .sensorData)
+        try pub.close()
+        XCTAssertFalse(pub.isActive)
+        XCTAssertThrowsError(
+            try pub.publish(data: Data([0x00, 0x01, 0x00, 0x00]), timestamp: 0, sequenceNumber: 0)
+        ) { error in
+            guard case TransportError.publisherClosed = error else { return XCTFail("got \(error)") }
+        }
+    }
+
+    func testCreatePublisherDuplicateTopicThrows() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        _ = try s.createPublisher(
+            topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil, qos: .sensorData)
+        XCTAssertThrowsError(
+            try s.createPublisher(
+                topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil, qos: .sensorData)
+        ) { error in
+            guard case TransportError.publisherCreationFailed = error else {
+                return XCTFail("got \(error)")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

M1 (P1 publish) of the native RCL DDS backend: an **opt-in** path that publishes `sensor_msgs/Imu` through real `rcl` + `rmw_cyclonedds_cpp` via `rcl_publish_serialized_message`, reusing the production `SwiftROS2CDR` encoder. The pure-Swift wire path stays the default and is unchanged.

Builds on the M0 spike (#119). Everything here is gated behind `SWIFT_ROS2_ENABLE_RCL=1` (Apple only) — when unset, none of it is compiled into the build graph.

## What's included

- **Transport seam (cross-platform Swift):** `package` `registerNode`/`unregisterNode` on `TransportSession` (default no-op); `.rcl(domainId:)` `TransportConfig`; `RclClientProtocol` + `RclTransportSession` / `RclTransportPublisher`, mockable without the xcframework so the unit tests run in ordinary CI.
- **FFI (Apple, enableRcl only):** `CRclBridge` C shim over `rcl`; `SwiftROS2RCL` (`RclClient`); `crcl-smoke` acceptance binary.
- **Faithful node model (decision A):** a real `rcl_node_t` named by the caller via the `package` seam hook; M1 assumes a single node.
- **RCL CI** (`.github/workflows/ci-rcl.yml`, manual/scheduled): cross-builds the maccatalyst `CRos2Jazzy.xcframework`, then builds the `SwiftROS2` umbrella + full test bundle and runs `crcl-smoke` on Mac Catalyst.

## Public API

Additive only — the public surface is unchanged. `registerNode`/`unregisterNode` and the rcl handle protocols are `package`; `RclClient` is `public` (mirrors `DDSClient`) but its conformance members are `package`. Preserves the 1.x freeze.

## Verification

- Default (non-RCL) `swift build` + `swift test --parallel` (111 tests) + `swift format lint --recursive --strict` — green locally on macOS. Cross-platform CI (Linux / Windows / Android) runs here for the first time.
- enableRcl on **Mac Catalyst** (local, Xcode 26): `SwiftROS2` umbrella build, full test-bundle build, and `crcl-smoke` (real rcl context → node → Imu publisher → serialized publish) all succeed.
- `ci-rcl` is dispatched on this branch to validate the xcframework cross-build + the above on a clean runner.

## Notable fix in this PR

`43f407a` fixes an enableRcl Mac Catalyst umbrella-build blocker. `CRos2Jazzy`'s modulemap used `umbrella header`, which — because SwiftPM/xcodebuild flatten every binary target's headers into one shared build-products `include/` dir — made clang treat that dir as an umbrella directory and capture the sibling CCycloneDDS `dds/` tree into module `CRos2Jazzy`. `CDDSBridge`'s `#include <dds/...>` was then routed into that module (which doesn't expose the internal types), leaving `struct ddsi_sertype` incomplete. Fixed by declaring `CRos2Jazzy.h` as a plain `header` (not `umbrella header`) plus an explicit `#include <rcl/error_handling.h>` the change surfaced in `rcl_bridge.c`.

## Scope / follow-ups

- `CRos2Jazzy` stays a **local-path** binaryTarget; the URL+checksum binaryTarget is M3.
- Remaining M1 acceptance: live `ros2 topic echo /…/imu` + `ros2 node list` (caller-supplied node name) on a real Jazzy host — manual (LAN or Conduit on-device).
- Typed publish via introspection (`rcl_publish`) is P2, a later milestone.
