### PR TITLE
feat(rcl): native RCL DDS backend — M2 P2 serialization validation (Imu wire == rmw_serialize)

### DIFF
--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -80,3 +80,19 @@ jobs:
           out="$(perl -e 'alarm 60; exec @ARGV' "$bin" 2>&1)" || true
           printf '%s\n' "$out"
           printf '%s\n' "$out" | grep -q "crcl_smoke OK: publish path exercised"
+
+      # In-process serialization validation: SwiftROS2CDR wire bytes vs the real
+      # ROS 2 introspection serializer (rmw_serialize) for sensor_msgs/Imu, plus
+      # the RIHS01 type-hash check. rmw_serialize touches no DDS participant, but
+      # bound the run anyway (consistent with crcl-smoke) and decide success on
+      # the OK line.
+      - name: Build + run crcl-golden (Catalyst)
+        run: |
+          xcodebuild -scheme crcl-golden \
+            -destination 'platform=macOS,variant=Mac Catalyst,arch=arm64' \
+            -derivedDataPath build/dd-ci-crclgolden build CODE_SIGNING_ALLOWED=NO
+          bin="$(find build/dd-ci-crclgolden -name crcl-golden -type f -perm +111 | head -1)"
+          echo "Running golden: $bin"
+          out="$(perl -e 'alarm 60; exec @ARGV' "$bin" 2>&1)" || true
+          printf '%s\n' "$out"
+          printf '%s\n' "$out" | grep -q "crcl_golden OK:"

--- a/Package.swift
+++ b/Package.swift
@@ -558,7 +558,7 @@ if enableRcl {
     targets.append(
         .target(
             name: "SwiftROS2RCL",
-            dependencies: ["CRclBridge", "SwiftROS2Transport"],
+            dependencies: ["CRclBridge", "SwiftROS2Transport", "SwiftROS2Messages"],
             path: "Sources/SwiftROS2RCL"
         ))
     products.append(.library(name: "SwiftROS2RCL", targets: ["SwiftROS2RCL"]))

--- a/Package.swift
+++ b/Package.swift
@@ -556,6 +556,14 @@ if enableRcl {
         ))
     products.append(.executable(name: "crcl-smoke", targets: ["crcl-smoke"]))
     targets.append(
+        .executableTarget(
+            name: "crcl-golden",
+            dependencies: ["SwiftROS2", "SwiftROS2RCL"],
+            path: "Sources/Examples/CrclGolden",
+            linkerSettings: [.linkedLibrary("c++")]
+        ))
+    products.append(.executable(name: "crcl-golden", targets: ["crcl-golden"]))
+    targets.append(
         .target(
             name: "SwiftROS2RCL",
             dependencies: ["CRclBridge", "SwiftROS2Transport", "SwiftROS2Messages"],

--- a/Sources/CRclBridge/include/rcl_bridge.h
+++ b/Sources/CRclBridge/include/rcl_bridge.h
@@ -58,6 +58,12 @@ int crcl_serialize_imu(
 /// Free a buffer returned by crcl_serialize_imu.
 void crcl_free(uint8_t *buf);
 
+/// Write the canonical RIHS01 type-hash string (e.g. "RIHS01_7d9a00ff…") for a
+/// supported ROS type into `out` (NUL-terminated, truncated to `cap`). Returns 0
+/// on success, non-zero on failure (unsupported type, or the handle carries no
+/// type hash — see crcl_last_error()).
+int crcl_type_hash(const char *ros_type_name, char *out, size_t cap);
+
 /// Last error from the rcutils error stack; "" if none.
 const char *crcl_last_error(void);
 

--- a/Sources/CRclBridge/include/rcl_bridge.h
+++ b/Sources/CRclBridge/include/rcl_bridge.h
@@ -39,6 +39,25 @@ void crcl_publisher_destroy(crcl_publisher_t *pub);
 /// Publish pre-serialized CDR bytes. Returns 0 on success, non-zero rcl_ret_t otherwise.
 int crcl_publish_serialized(crcl_publisher_t *pub, const uint8_t *data, size_t len);
 
+/// Serialize a sensor_msgs/msg/Imu from flat fields using the real ROS 2
+/// introspection serializer (rmw_serialize) — no node/context/participant.
+/// Each covariance pointer must reference exactly 9 doubles. On success writes
+/// a malloc'd CDR buffer (incl. the 4-byte encapsulation header) to *out_buf
+/// and its length to *out_len, and returns 0; the caller must crcl_free(*out_buf).
+/// Returns a non-zero rmw_ret_t on failure (see crcl_last_error()).
+int crcl_serialize_imu(
+    int32_t stamp_sec, uint32_t stamp_nanosec, const char *frame_id,
+    double orientation_x, double orientation_y, double orientation_z, double orientation_w,
+    const double *orientation_covariance,
+    double angular_velocity_x, double angular_velocity_y, double angular_velocity_z,
+    const double *angular_velocity_covariance,
+    double linear_acceleration_x, double linear_acceleration_y, double linear_acceleration_z,
+    const double *linear_acceleration_covariance,
+    uint8_t **out_buf, size_t *out_len);
+
+/// Free a buffer returned by crcl_serialize_imu.
+void crcl_free(uint8_t *buf);
+
 /// Last error from the rcutils error stack; "" if none.
 const char *crcl_last_error(void);
 

--- a/Sources/CRclBridge/rcl_bridge.c
+++ b/Sources/CRclBridge/rcl_bridge.c
@@ -16,6 +16,7 @@
 #include <rosidl_runtime_c/message_type_support_struct.h>
 #include <rmw/rmw.h>                              // rmw_serialize
 #include <rosidl_runtime_c/string_functions.h>   // rosidl_runtime_c__String__assign / __fini
+#include <rosidl_runtime_c/type_hash.h>          // rosidl_type_hash_t, rosidl_stringify_type_hash
 // Use the rosidl_typesupport_c symbol (T in the static lib).
 // ROSIDL_GET_MSG_TYPE_SUPPORT expands to
 //   rosidl_typesupport_c__get_message_type_support_handle__sensor_msgs__msg__Imu()
@@ -172,6 +173,37 @@ int crcl_publish_serialized(crcl_publisher_t *p, const uint8_t *data, size_t len
 }
 
 void crcl_free(uint8_t *buf) { free(buf); }
+
+int crcl_type_hash(const char *ros_type_name, char *out, size_t cap) {
+    if (!out || cap == 0) return -1;
+    out[0] = '\0';
+    const rosidl_message_type_support_t *ts = resolve_typesupport(ros_type_name);
+    if (!ts) {
+        snprintf(g_err, sizeof(g_err), "unsupported type: %s", ros_type_name ? ros_type_name : "(null)");
+        return -1;
+    }
+    // Jazzy's rosidl_message_type_support_t carries the type hash via get_type_hash_func.
+    if (!ts->get_type_hash_func) {
+        snprintf(g_err, sizeof(g_err), "type support for %s carries no get_type_hash_func", ros_type_name);
+        return -1;  // R2 fallback: caller drops the in-process hash gate (live `ros2 topic info`).
+    }
+    const rosidl_type_hash_t *type_hash = ts->get_type_hash_func(ts);
+    if (!type_hash) {
+        snprintf(g_err, sizeof(g_err), "type support for %s carries no type_hash", ros_type_name);
+        return -1;
+    }
+    rcutils_allocator_t alloc = rcutils_get_default_allocator();
+    char *s = NULL;
+    rcutils_ret_t rc = rosidl_stringify_type_hash(type_hash, alloc, &s);
+    if (rc != RCUTILS_RET_OK || !s) {
+        snprintf(g_err, sizeof(g_err), "rosidl_stringify_type_hash failed (%d)", (int)rc);
+        return -1;
+    }
+    strncpy(out, s, cap - 1);
+    out[cap - 1] = '\0';
+    alloc.deallocate(s, alloc.state);
+    return 0;
+}
 
 int crcl_serialize_imu(
     int32_t stamp_sec, uint32_t stamp_nanosec, const char *frame_id,

--- a/Sources/CRclBridge/rcl_bridge.c
+++ b/Sources/CRclBridge/rcl_bridge.c
@@ -14,6 +14,8 @@
 #include <rmw/serialized_message.h>
 #include <rcutils/allocator.h>
 #include <rosidl_runtime_c/message_type_support_struct.h>
+#include <rmw/rmw.h>                              // rmw_serialize
+#include <rosidl_runtime_c/string_functions.h>   // rosidl_runtime_c__String__assign / __fini
 // Use the rosidl_typesupport_c symbol (T in the static lib).
 // ROSIDL_GET_MSG_TYPE_SUPPORT expands to
 //   rosidl_typesupport_c__get_message_type_support_handle__sensor_msgs__msg__Imu()
@@ -166,5 +168,78 @@ int crcl_publish_serialized(crcl_publisher_t *p, const uint8_t *data, size_t len
         capture_error();
         return (int)ret;
     }
+    return 0;
+}
+
+void crcl_free(uint8_t *buf) { free(buf); }
+
+int crcl_serialize_imu(
+    int32_t stamp_sec, uint32_t stamp_nanosec, const char *frame_id,
+    double orientation_x, double orientation_y, double orientation_z, double orientation_w,
+    const double *orientation_covariance,
+    double angular_velocity_x, double angular_velocity_y, double angular_velocity_z,
+    const double *angular_velocity_covariance,
+    double linear_acceleration_x, double linear_acceleration_y, double linear_acceleration_z,
+    const double *linear_acceleration_covariance,
+    uint8_t **out_buf, size_t *out_len) {
+    const rosidl_message_type_support_t *ts = resolve_typesupport("sensor_msgs/msg/Imu");
+    if (!ts) {
+        snprintf(g_err, sizeof(g_err), "unsupported type: sensor_msgs/msg/Imu");
+        return -1;
+    }
+
+    // Zero-init on the stack; only header.frame_id needs heap (via __assign).
+    sensor_msgs__msg__Imu msg;
+    memset(&msg, 0, sizeof(msg));
+    msg.header.stamp.sec = stamp_sec;
+    msg.header.stamp.nanosec = stamp_nanosec;
+    if (!rosidl_runtime_c__String__assign(&msg.header.frame_id, frame_id ? frame_id : "")) {
+        snprintf(g_err, sizeof(g_err), "String__assign failed for frame_id");
+        return -1;
+    }
+    msg.orientation.x = orientation_x;
+    msg.orientation.y = orientation_y;
+    msg.orientation.z = orientation_z;
+    msg.orientation.w = orientation_w;
+    memcpy(msg.orientation_covariance, orientation_covariance, 9 * sizeof(double));
+    msg.angular_velocity.x = angular_velocity_x;
+    msg.angular_velocity.y = angular_velocity_y;
+    msg.angular_velocity.z = angular_velocity_z;
+    memcpy(msg.angular_velocity_covariance, angular_velocity_covariance, 9 * sizeof(double));
+    msg.linear_acceleration.x = linear_acceleration_x;
+    msg.linear_acceleration.y = linear_acceleration_y;
+    msg.linear_acceleration.z = linear_acceleration_z;
+    memcpy(msg.linear_acceleration_covariance, linear_acceleration_covariance, 9 * sizeof(double));
+
+    rcutils_allocator_t alloc = rcutils_get_default_allocator();
+    rmw_serialized_message_t ser = rmw_get_zero_initialized_serialized_message();
+    rmw_ret_t rc = rmw_serialized_message_init(&ser, 0u, &alloc);
+    if (rc != RMW_RET_OK) {
+        capture_error();
+        rosidl_runtime_c__String__fini(&msg.header.frame_id);
+        return (int)rc;
+    }
+
+    rc = rmw_serialize(&msg, ts, &ser);
+    if (rc != RMW_RET_OK) {
+        capture_error();
+        (void)rmw_serialized_message_fini(&ser);
+        rosidl_runtime_c__String__fini(&msg.header.frame_id);
+        return (int)rc;
+    }
+
+    uint8_t *copy = malloc(ser.buffer_length);
+    if (!copy) {
+        snprintf(g_err, sizeof(g_err), "out-of-memory copying %zu serialized bytes", ser.buffer_length);
+        (void)rmw_serialized_message_fini(&ser);
+        rosidl_runtime_c__String__fini(&msg.header.frame_id);
+        return -1;
+    }
+    memcpy(copy, ser.buffer, ser.buffer_length);
+    *out_buf = copy;
+    *out_len = ser.buffer_length;
+
+    (void)rmw_serialized_message_fini(&ser);
+    rosidl_runtime_c__String__fini(&msg.header.frame_id);
     return 0;
 }

--- a/Sources/Examples/CrclGolden/main.swift
+++ b/Sources/Examples/CrclGolden/main.swift
@@ -1,0 +1,69 @@
+// crcl-golden — M2 serialization-validation gate.
+//
+// Builds a fixed sensor_msgs/Imu, then asserts:
+//   1. SwiftROS2CDR wire bytes == real ROS 2 introspection serialization
+//      (rmw_serialize, via rclSerializeImu) — byte-for-byte.
+//   2. Imu.typeInfo.typeHash == crcl_type_hash (when available; spec risk R2).
+// Prints "crcl_golden OK: …" + flush on success, then exits 0. On a byte
+// mismatch it prints a diff and exits 1. Run by ci-rcl, SIGALRM-bounded, with
+// success decided on the OK line (consistent with crcl-smoke).
+
+import Foundation
+import SwiftROS2
+import SwiftROS2RCL
+
+func hex(_ bytes: [UInt8]) -> String { bytes.map { String(format: "%02x", $0) }.joined() }
+
+// Fixed, fully finite Imu so the byte compare is deterministic.
+let imu = Imu(
+    header: Header(stamp: Time(sec: 1234, nanosec: 567_890_000), frameId: "imu_link"),
+    orientation: Quaternion(x: 0.1, y: 0.2, z: 0.3, w: 0.4),
+    orientationCovariance: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+    angularVelocity: Vector3(x: 1.5, y: 2.5, z: 3.5),
+    angularVelocityCovariance: [9, 10, 11, 12, 13, 14, 15, 16, 17],
+    linearAcceleration: Vector3(x: 9.8, y: 0.0, z: -9.8),
+    linearAccelerationCovariance: [18, 19, 20, 21, 22, 23, 24, 25, 26]
+)
+
+// 1. Wire bytes via the production SwiftROS2CDR path (Jazzy is non-legacy).
+let encoder = CDREncoder(isLegacySchema: false)
+encoder.writeEncapsulationHeader()
+do {
+    try imu.encode(to: encoder)
+} catch {
+    print("crcl_golden FAIL: SwiftROS2CDR encode threw: \(error)")
+    exit(1)
+}
+let wire = [UInt8](encoder.getData())
+
+// 2. Real ROS 2 introspection serialization via rmw_serialize.
+let rcl: [UInt8]
+do {
+    rcl = try rclSerializeImu(imu)
+} catch {
+    print("crcl_golden FAIL: rclSerializeImu threw: \(error)")
+    exit(1)
+}
+
+guard wire == rcl else {
+    print("crcl_golden FAIL: byte mismatch (wire \(wire.count)B vs rcl \(rcl.count)B)")
+    print("  wire: \(hex(wire))")
+    print("  rcl : \(hex(rcl))")
+    exit(1)
+}
+
+// 3. Type-hash gate (hard when available; R2 fallback = warn + continue).
+if let h = rclTypeHash("sensor_msgs/msg/Imu") {
+    guard h == Imu.typeInfo.typeHash else {
+        print("crcl_golden FAIL: type hash mismatch")
+        print("  swift: \(Imu.typeInfo.typeHash)")
+        print("  rcl  : \(h)")
+        exit(1)
+    }
+} else {
+    print("crcl_golden WARN: type hash unavailable from handle (R2) — byte gate only")
+}
+
+print("crcl_golden OK: SwiftROS2CDR == rmw_serialize for sensor_msgs/Imu (\(wire.count) bytes)")
+fflush(stdout)
+exit(0)

--- a/Sources/SwiftROS2RCL/RclImuMarshal.swift
+++ b/Sources/SwiftROS2RCL/RclImuMarshal.swift
@@ -1,0 +1,51 @@
+// RclImuMarshal.swift
+// M2: hand-written sensor_msgs/Imu marshalling for the RCL serialization-
+// validation gate. Unpacks an `Imu` value into the flat `crcl_serialize_imu`
+// FFI (the C side builds the C struct and runs the real rmw_serialize), and
+// wraps `crcl_type_hash`. Validation-only — not on the production publish path.
+
+import CRclBridge
+import Foundation
+import SwiftROS2Messages
+
+/// Serialize `imu` via the real ROS 2 introspection serializer (rmw_serialize),
+/// returning the on-wire CDR bytes (incl. the 4-byte encapsulation header).
+package func rclSerializeImu(_ imu: Imu) throws -> [UInt8] {
+    precondition(imu.orientationCovariance.count == 9, "orientationCovariance needs 9 elements")
+    precondition(imu.angularVelocityCovariance.count == 9, "angularVelocityCovariance needs 9 elements")
+    precondition(
+        imu.linearAccelerationCovariance.count == 9, "linearAccelerationCovariance needs 9 elements")
+
+    var outBuf: UnsafeMutablePointer<UInt8>?
+    var outLen: Int = 0
+    let rc: Int32 = imu.orientationCovariance.withUnsafeBufferPointer { oc in
+        imu.angularVelocityCovariance.withUnsafeBufferPointer { ac in
+            imu.linearAccelerationCovariance.withUnsafeBufferPointer { lc in
+                crcl_serialize_imu(
+                    imu.header.stamp.sec, imu.header.stamp.nanosec, imu.header.frameId,
+                    imu.orientation.x, imu.orientation.y, imu.orientation.z, imu.orientation.w,
+                    oc.baseAddress,
+                    imu.angularVelocity.x, imu.angularVelocity.y, imu.angularVelocity.z,
+                    ac.baseAddress,
+                    imu.linearAcceleration.x, imu.linearAcceleration.y, imu.linearAcceleration.z,
+                    lc.baseAddress,
+                    &outBuf, &outLen)
+            }
+        }
+    }
+    guard rc == 0, let outBuf else {
+        throw TransportError.publishFailed(String(cString: crcl_last_error()))
+    }
+    defer { crcl_free(outBuf) }
+    return Array(UnsafeBufferPointer(start: outBuf, count: outLen))
+}
+
+/// Canonical RIHS01 type-hash string for `rosTypeName` (e.g. "sensor_msgs/msg/Imu"),
+/// or `nil` if the bundled type support carries no hash (spec risk R2).
+package func rclTypeHash(_ rosTypeName: String) -> String? {
+    var buf = [CChar](repeating: 0, count: 128)
+    let rc = buf.withUnsafeMutableBufferPointer { p in
+        crcl_type_hash(rosTypeName, p.baseAddress, p.count)
+    }
+    return rc == 0 ? String(cString: buf) : nil
+}


### PR DESCRIPTION
M2 of the native RCL DDS backend (spec §16). **Validation-only** — proves byte-for-byte that the production `SwiftROS2CDR` encoder matches the real ROS 2 introspection serializer (`rmw_serialize`, the exact codec `rmw_cyclonedds_cpp` uses on publish) and that swift-ros2's RIHS01 type hash matches the canonical `rosidl` hash baked into the xcframework, for `sensor_msgs/Imu`, as an in-process `ci-rcl` gate.

## Result (verified locally, Mac Catalyst)
```
crcl_golden OK: SwiftROS2CDR == rmw_serialize for sensor_msgs/Imu (324 bytes)
```
- **Byte gate passed** — identical across all 324 bytes.
- **Type-hash gate passed** — `Imu.typeInfo.typeHash` == `crcl_type_hash` (`RIHS01_7d9a00ff…`). R2 did not bite.

## What's in it
- `crcl_serialize_imu` + `crcl_free` + `crcl_type_hash` in `CRclBridge` (rmw_serialize, no node/context/participant; standalone).
- `rclSerializeImu` + `rclTypeHash` Swift marshalling in `SwiftROS2RCL` (unpacks `Imu` → flat C fields; no C structs in Swift).
- `crcl-golden` executable: fixed `Imu` → wire-vs-rmw_serialize byte compare + type-hash check; prints `crcl_golden OK:`.
- `ci-rcl` builds + runs `crcl-golden` (SIGALRM-bounded, grep the OK line), like `crcl-smoke`.

## Not in scope (→ M3)
Generalized `swift-ros2-gen` marshalling generator; typed `rcl_publish` production path; full publish type set; all 6 slices; Conduit wiring; size/CPU/battery.

## Notes
- No public API or transport-seam change; all targets gated behind `SWIFT_ROS2_ENABLE_RCL` → 1.x freeze preserved (ships 1.3.x).
- As-built vs spec §16: marshalling is in C (not Swift) fed flat fields; per-type `crcl_serialize_imu` (not a generic `crcl_serialize`); the gate is the `crcl-golden` executable (not an XCTest) — all match the established M1 pattern. The type hash is read via `ts->get_type_hash_func(ts)` (Jazzy has no direct `type_hash` member).