### PR TITLE
feat(rcl): native RCL DDS backend — M3a typed rcl_publish (sensor_msgs/Imu)

### DIFF
--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -79,7 +79,7 @@ jobs:
           # (possibly killed) exit code.
           out="$(perl -e 'alarm 60; exec @ARGV' "$bin" 2>&1)" || true
           printf '%s\n' "$out"
-          printf '%s\n' "$out" | grep -q "crcl_smoke OK: publish path exercised"
+          printf '%s\n' "$out" | grep -q "crcl_smoke OK"
 
       # In-process serialization validation: SwiftROS2CDR wire bytes vs the real
       # ROS 2 introspection serializer (rmw_serialize) for sensor_msgs/Imu, plus

--- a/Sources/CRclBridge/include/rcl_bridge.h
+++ b/Sources/CRclBridge/include/rcl_bridge.h
@@ -55,6 +55,21 @@ int crcl_serialize_imu(
     const double *linear_acceleration_covariance,
     uint8_t **out_buf, size_t *out_len);
 
+/// Marshal a sensor_msgs/msg/Imu from flat fields into its rosidl C struct and
+/// publish it via rcl_publish (real ROS 2 introspection serialization happens
+/// inside rmw_cyclonedds_cpp). `pub` must come from crcl_publisher_create with
+/// ros_type_name "sensor_msgs/msg/Imu". Each covariance pointer references 9
+/// doubles. Returns 0 on success, non-zero rcl_ret_t otherwise (crcl_last_error()).
+int crcl_publish_imu(
+    crcl_publisher_t *pub,
+    int32_t stamp_sec, uint32_t stamp_nanosec, const char *frame_id,
+    double orientation_x, double orientation_y, double orientation_z, double orientation_w,
+    const double *orientation_covariance,
+    double angular_velocity_x, double angular_velocity_y, double angular_velocity_z,
+    const double *angular_velocity_covariance,
+    double linear_acceleration_x, double linear_acceleration_y, double linear_acceleration_z,
+    const double *linear_acceleration_covariance);
+
 /// Free a buffer returned by crcl_serialize_imu.
 void crcl_free(uint8_t *buf);
 

--- a/Sources/CRclBridge/rcl_bridge.c
+++ b/Sources/CRclBridge/rcl_bridge.c
@@ -205,6 +205,35 @@ int crcl_type_hash(const char *ros_type_name, char *out, size_t cap) {
     return 0;
 }
 
+// Fill a zero-initialized Imu struct from flat fields. header.frame_id is the
+// only heap member (via __assign); the caller must rosidl_runtime_c__String__fini
+// it (use fini_imu). Returns 1 on success, 0 on String__assign failure.
+static int fill_imu(
+    sensor_msgs__msg__Imu *msg,
+    int32_t stamp_sec, uint32_t stamp_nanosec, const char *frame_id,
+    double ox, double oy, double oz, double ow, const double *o_cov,
+    double avx, double avy, double avz, const double *av_cov,
+    double lax, double lay, double laz, const double *la_cov) {
+    memset(msg, 0, sizeof(*msg));
+    msg->header.stamp.sec = stamp_sec;
+    msg->header.stamp.nanosec = stamp_nanosec;
+    if (!rosidl_runtime_c__String__assign(&msg->header.frame_id, frame_id ? frame_id : "")) {
+        snprintf(g_err, sizeof(g_err), "String__assign failed for frame_id");
+        return 0;
+    }
+    msg->orientation.x = ox; msg->orientation.y = oy; msg->orientation.z = oz; msg->orientation.w = ow;
+    memcpy(msg->orientation_covariance, o_cov, 9 * sizeof(double));
+    msg->angular_velocity.x = avx; msg->angular_velocity.y = avy; msg->angular_velocity.z = avz;
+    memcpy(msg->angular_velocity_covariance, av_cov, 9 * sizeof(double));
+    msg->linear_acceleration.x = lax; msg->linear_acceleration.y = lay; msg->linear_acceleration.z = laz;
+    memcpy(msg->linear_acceleration_covariance, la_cov, 9 * sizeof(double));
+    return 1;
+}
+
+static void fini_imu(sensor_msgs__msg__Imu *msg) {
+    rosidl_runtime_c__String__fini(&msg->header.frame_id);
+}
+
 int crcl_serialize_imu(
     int32_t stamp_sec, uint32_t stamp_nanosec, const char *frame_id,
     double orientation_x, double orientation_y, double orientation_z, double orientation_w,
@@ -220,35 +249,21 @@ int crcl_serialize_imu(
         return -1;
     }
 
-    // Zero-init on the stack; only header.frame_id needs heap (via __assign).
     sensor_msgs__msg__Imu msg;
-    memset(&msg, 0, sizeof(msg));
-    msg.header.stamp.sec = stamp_sec;
-    msg.header.stamp.nanosec = stamp_nanosec;
-    if (!rosidl_runtime_c__String__assign(&msg.header.frame_id, frame_id ? frame_id : "")) {
-        snprintf(g_err, sizeof(g_err), "String__assign failed for frame_id");
-        return -1;
+    if (!fill_imu(&msg, stamp_sec, stamp_nanosec, frame_id,
+                  orientation_x, orientation_y, orientation_z, orientation_w, orientation_covariance,
+                  angular_velocity_x, angular_velocity_y, angular_velocity_z, angular_velocity_covariance,
+                  linear_acceleration_x, linear_acceleration_y, linear_acceleration_z,
+                  linear_acceleration_covariance)) {
+        return -1;  // g_err set by fill_imu
     }
-    msg.orientation.x = orientation_x;
-    msg.orientation.y = orientation_y;
-    msg.orientation.z = orientation_z;
-    msg.orientation.w = orientation_w;
-    memcpy(msg.orientation_covariance, orientation_covariance, 9 * sizeof(double));
-    msg.angular_velocity.x = angular_velocity_x;
-    msg.angular_velocity.y = angular_velocity_y;
-    msg.angular_velocity.z = angular_velocity_z;
-    memcpy(msg.angular_velocity_covariance, angular_velocity_covariance, 9 * sizeof(double));
-    msg.linear_acceleration.x = linear_acceleration_x;
-    msg.linear_acceleration.y = linear_acceleration_y;
-    msg.linear_acceleration.z = linear_acceleration_z;
-    memcpy(msg.linear_acceleration_covariance, linear_acceleration_covariance, 9 * sizeof(double));
 
     rcutils_allocator_t alloc = rcutils_get_default_allocator();
     rmw_serialized_message_t ser = rmw_get_zero_initialized_serialized_message();
     rmw_ret_t rc = rmw_serialized_message_init(&ser, 0u, &alloc);
     if (rc != RMW_RET_OK) {
         capture_error();
-        rosidl_runtime_c__String__fini(&msg.header.frame_id);
+        fini_imu(&msg);
         return (int)rc;
     }
 
@@ -256,7 +271,7 @@ int crcl_serialize_imu(
     if (rc != RMW_RET_OK) {
         capture_error();
         (void)rmw_serialized_message_fini(&ser);
-        rosidl_runtime_c__String__fini(&msg.header.frame_id);
+        fini_imu(&msg);
         return (int)rc;
     }
 
@@ -264,7 +279,7 @@ int crcl_serialize_imu(
     if (!copy) {
         snprintf(g_err, sizeof(g_err), "out-of-memory copying %zu serialized bytes", ser.buffer_length);
         (void)rmw_serialized_message_fini(&ser);
-        rosidl_runtime_c__String__fini(&msg.header.frame_id);
+        fini_imu(&msg);
         return -1;
     }
     memcpy(copy, ser.buffer, ser.buffer_length);
@@ -272,6 +287,36 @@ int crcl_serialize_imu(
     *out_len = ser.buffer_length;
 
     (void)rmw_serialized_message_fini(&ser);
-    rosidl_runtime_c__String__fini(&msg.header.frame_id);
+    fini_imu(&msg);
+    return 0;
+}
+
+int crcl_publish_imu(
+    crcl_publisher_t *pub,
+    int32_t stamp_sec, uint32_t stamp_nanosec, const char *frame_id,
+    double orientation_x, double orientation_y, double orientation_z, double orientation_w,
+    const double *orientation_covariance,
+    double angular_velocity_x, double angular_velocity_y, double angular_velocity_z,
+    const double *angular_velocity_covariance,
+    double linear_acceleration_x, double linear_acceleration_y, double linear_acceleration_z,
+    const double *linear_acceleration_covariance) {
+    if (!pub) {
+        snprintf(g_err, sizeof(g_err), "crcl_publish_imu: null publisher");
+        return -1;
+    }
+    sensor_msgs__msg__Imu msg;
+    if (!fill_imu(&msg, stamp_sec, stamp_nanosec, frame_id,
+                  orientation_x, orientation_y, orientation_z, orientation_w, orientation_covariance,
+                  angular_velocity_x, angular_velocity_y, angular_velocity_z, angular_velocity_covariance,
+                  linear_acceleration_x, linear_acceleration_y, linear_acceleration_z,
+                  linear_acceleration_covariance)) {
+        return -1;  // g_err set by fill_imu
+    }
+    rcl_ret_t ret = rcl_publish(&pub->pub, &msg, NULL);
+    fini_imu(&msg);
+    if (ret != RCL_RET_OK) {
+        capture_error();
+        return (int)ret;
+    }
     return 0;
 }

--- a/Sources/Examples/CrclSmoke/main.c
+++ b/Sources/Examples/CrclSmoke/main.c
@@ -18,13 +18,23 @@ int main(void) {
     int rc = crcl_publish_serialized(pub, cdr, sizeof(cdr));
     if (rc != 0) { printf("publish FAIL (%d): %s\n", rc, crcl_last_error()); return 1; }
 
+    // Typed publish path (M3a): marshal an Imu into its C struct and rcl_publish.
+    double cov[9] = {0};
+    int rc2 = crcl_publish_imu(
+        pub,
+        1234, 567890000, "imu_link",
+        0.1, 0.2, 0.3, 0.4, cov,
+        1.5, 2.5, 3.5, cov,
+        9.8, 0.0, -9.8, cov);
+    if (rc2 != 0) { printf("typed publish FAIL (%d): %s\n", rc2, crcl_last_error()); return 1; }
+
     // The publish path is what this smoke validates, and it has now succeeded.
     // Print + flush the result BEFORE teardown: on a headless CI runner with no
     // working multicast, CycloneDDS participant teardown can block indefinitely
     // on failed discovery writes, and stdout to a pipe is fully buffered, so a
     // teardown hang would otherwise swallow this line. Teardown still runs after
     // (best-effort; the OS reclaims everything on process exit).
-    printf("crcl_smoke OK: publish path exercised\n");
+    printf("crcl_smoke OK: serialized + typed publish paths exercised\n");
     fflush(stdout);
 
     crcl_publisher_destroy(pub);

--- a/Sources/SwiftROS2/Publisher.swift
+++ b/Sources/SwiftROS2/Publisher.swift
@@ -57,6 +57,16 @@ public final class ROS2Publisher<M: CDREncodable & ROS2MessageType>: @unchecked 
     ///     (the default) this publisher's own monotonic counter is used, exactly
     ///     as ``publish(_:)`` does.
     public func publish(_ message: M, timestamp: UInt64, sequenceNumber: Int64? = nil) throws {
+        // Typed-publish fast path: when the transport implements rcl_publish and
+        // the message has a typed marshaller (SwiftROS2RCL conformance), publish
+        // the C struct directly. rcl assigns the source timestamp and sequence,
+        // so timestamp/sequenceNumber are not consumed on this path (parity with
+        // the serialized seam, which also ignores them).
+        if transportPublisher.supportsTypedPublish, let typed = message as? RclTypedPublishable {
+            try transportPublisher.publishTyped(typed)
+            return
+        }
+
         let encoder = CDREncoder(isLegacySchema: isLegacySchema)
         encoder.writeEncapsulationHeader()
         try message.encode(to: encoder)

--- a/Sources/SwiftROS2RCL/RclClient.swift
+++ b/Sources/SwiftROS2RCL/RclClient.swift
@@ -13,7 +13,7 @@ private final class RclNodeBox: RclNodeHandle, @unchecked Sendable {
 }
 
 /// Per-box lock serializes destroy vs. publish on the same publisher pointer.
-private final class RclPublisherBox: RclPublisherHandle, @unchecked Sendable {
+final class RclPublisherBox: RclPublisherHandle, @unchecked Sendable {
     private var ptr: OpaquePointer?
     private let lock = NSLock()
 

--- a/Sources/SwiftROS2RCL/RclImuMarshal.swift
+++ b/Sources/SwiftROS2RCL/RclImuMarshal.swift
@@ -7,6 +7,7 @@
 import CRclBridge
 import Foundation
 import SwiftROS2Messages
+import SwiftROS2Transport
 
 /// Serialize `imu` via the real ROS 2 introspection serializer (rmw_serialize),
 /// returning the on-wire CDR bytes (incl. the 4-byte encapsulation header).
@@ -48,4 +49,38 @@ package func rclTypeHash(_ rosTypeName: String) -> String? {
         crcl_type_hash(rosTypeName, p.baseAddress, p.count)
     }
     return rc == 0 ? String(cString: buf) : nil
+}
+
+extension Imu: RclTypedPublishable {
+    /// Marshal this Imu into its rosidl C struct and publish via rcl_publish.
+    /// Mirrors `rclSerializeImu`'s flat-field unpack, but targets the typed
+    /// production path (crcl_publish_imu) instead of the validation serializer.
+    package func rclTypedPublish(into handle: any RclPublisherHandle) throws {
+        guard let box = handle as? RclPublisherBox else {
+            throw TransportError.publishFailed("rclTypedPublish: unexpected publisher handle type")
+        }
+        precondition(orientationCovariance.count == 9, "orientationCovariance needs 9 elements")
+        precondition(angularVelocityCovariance.count == 9, "angularVelocityCovariance needs 9 elements")
+        precondition(linearAccelerationCovariance.count == 9, "linearAccelerationCovariance needs 9 elements")
+
+        let rc: Int32? = orientationCovariance.withUnsafeBufferPointer { oc in
+            angularVelocityCovariance.withUnsafeBufferPointer { ac in
+                linearAccelerationCovariance.withUnsafeBufferPointer { lc in
+                    box.withPtr { p in
+                        crcl_publish_imu(
+                            p,
+                            header.stamp.sec, header.stamp.nanosec, header.frameId,
+                            orientation.x, orientation.y, orientation.z, orientation.w,
+                            oc.baseAddress,
+                            angularVelocity.x, angularVelocity.y, angularVelocity.z,
+                            ac.baseAddress,
+                            linearAcceleration.x, linearAcceleration.y, linearAcceleration.z,
+                            lc.baseAddress)
+                    }
+                }
+            }
+        }
+        guard let rc else { throw TransportError.publisherClosed }
+        if rc != 0 { throw TransportError.publishFailed(String(cString: crcl_last_error())) }
+    }
 }

--- a/Sources/SwiftROS2Transport/RclTransportSession+Publisher.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession+Publisher.swift
@@ -60,6 +60,20 @@ final class RclTransportPublisher: TransportPublisher, @unchecked Sendable {
         try client.publishSerialized(h, data: data)
     }
 
+    public var supportsTypedPublish: Bool { true }
+
+    public func publishTyped(_ publishable: any RclTypedPublishable) throws {
+        lock.lock()
+        guard !closed, let h = handle else {
+            lock.unlock()
+            throw TransportError.publisherClosed
+        }
+        lock.unlock()
+        // The conformance (SwiftROS2RCL) downcasts `h` to its publisher box and
+        // calls the per-type C marshaller; nothing C-specific leaks into this target.
+        try publishable.rclTypedPublish(into: h)
+    }
+
     public func close() throws {
         lock.lock()
         guard !closed else {

--- a/Sources/SwiftROS2Transport/RclTypedPublishable.swift
+++ b/Sources/SwiftROS2Transport/RclTypedPublishable.swift
@@ -1,0 +1,19 @@
+// RclTypedPublishable.swift
+// A message that can be published via the real-rcl typed path (rcl_publish over
+// a marshalled rosidl C struct), instead of the byte-oriented serialized seam.
+//
+// C-free on purpose: this protocol lives in SwiftROS2Transport so ROS2Publisher
+// (SwiftROS2) and RclTransportPublisher (here) can both refer to it. The actual
+// conformances are emitted into the gated SwiftROS2RCL target (which imports
+// CRclBridge) — a type is typed-publishable iff SwiftROS2RCL is linked AND a
+// conformance exists for it. Types without a conformance (AudioData,
+// CompressedPointCloud2, anything on Zenoh/wire-DDS) fall back to the byte seam.
+
+/// A message whose Swift value can be marshalled into its rosidl C struct and
+/// published through `rcl_publish` by an `RclTransportPublisher`.
+package protocol RclTypedPublishable: Sendable {
+    /// Marshal `self` into its C struct and publish it through `handle`.
+    /// Implemented in SwiftROS2RCL (imports CRclBridge); the body downcasts
+    /// `handle` to the concrete publisher box and calls the per-type C marshaller.
+    func rclTypedPublish(into handle: any RclPublisherHandle) throws
+}

--- a/Sources/SwiftROS2Transport/TransportPublisher+TypedDefault.swift
+++ b/Sources/SwiftROS2Transport/TransportPublisher+TypedDefault.swift
@@ -1,0 +1,11 @@
+// TransportPublisher+TypedDefault.swift
+// Default typed-publish behavior: unsupported. Only RclTransportPublisher overrides.
+
+extension TransportPublisher {
+    package var supportsTypedPublish: Bool { false }
+
+    package func publishTyped(_ publishable: any RclTypedPublishable) throws {
+        throw TransportError.unsupportedFeature(
+            "typed publish is only supported on the .rcl transport")
+    }
+}

--- a/Sources/SwiftROS2Transport/TransportSession.swift
+++ b/Sources/SwiftROS2Transport/TransportSession.swift
@@ -150,6 +150,11 @@ package protocol TransportPublisher: Sendable {
     func close() throws
     var topic: String { get }
     var isActive: Bool { get }
+
+    /// Whether this publisher implements the typed `rcl_publish` path. Default `false`.
+    var supportsTypedPublish: Bool { get }
+    /// Publish a typed-publishable message via `rcl_publish`. Default throws.
+    func publishTyped(_ publishable: any RclTypedPublishable) throws
 }
 
 // MARK: - Transport Subscriber Protocol

--- a/Tests/SwiftROS2IntegrationTests/RclPublishIntegrationTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/RclPublishIntegrationTests.swift
@@ -35,6 +35,11 @@ final class RclPublishIntegrationTests: XCTestCase {
 
             await ctx.shutdown()
 
+        // M3a: pub.publish(imu) now takes the TYPED rcl_publish path
+        // (Imu: RclTypedPublishable + RclTransportPublisher.supportsTypedPublish),
+        // not the P1 serialized seam. The on-wire result is identical (M2 proved
+        // SwiftROS2CDR == rmw_serialize); this confirms it end-to-end on a host.
+        //
         // Host-side verification (run on the Jazzy host while this publishes):
         //   ros2 node list            -> shows /swift_ros2_rcl/swift_ros2_rcl_test
         //   ros2 topic echo /swift_ros2_rcl/imu

--- a/Tests/SwiftROS2Tests/TypedPublishDispatchTests.swift
+++ b/Tests/SwiftROS2Tests/TypedPublishDispatchTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import SwiftROS2CDR
+import SwiftROS2Messages
+import XCTest
+
+@testable import SwiftROS2
+@testable import SwiftROS2Transport
+
+/// A message that is both encodable and typed-publishable, for dispatch testing.
+private struct FakeTypedMessage: ROS2Message, RclTypedPublishable, Equatable {
+    static let typeInfo = ROS2MessageTypeInfo(typeName: "test_msgs/msg/Fake", typeHash: "RIHS01_fake")
+    var value: Int32 = 7
+    func encode(to encoder: CDREncoder) throws { encoder.writeInt32(value) }
+    init() {}
+    init(value: Int32) { self.value = value }
+    init(from decoder: CDRDecoder) throws { self.value = try decoder.readInt32() }
+    func rclTypedPublish(into handle: any RclPublisherHandle) throws {}  // unused in dispatch test
+}
+
+/// Records which path ROS2Publisher took.
+private final class SpyPublisher: TransportPublisher, @unchecked Sendable {
+    let supportsTyped: Bool
+    let topic = "fake"
+    var isActive = true
+    private(set) var byteCount = 0
+    private(set) var typedCount = 0
+    init(supportsTyped: Bool) { self.supportsTyped = supportsTyped }
+    var supportsTypedPublish: Bool { supportsTyped }
+    func publish(data: Data, timestamp: UInt64, sequenceNumber: Int64) throws { byteCount += 1 }
+    func publishTyped(_ publishable: any RclTypedPublishable) throws { typedCount += 1 }
+    func close() throws {}
+}
+
+final class TypedPublishDispatchTests: XCTestCase {
+    func testRoutesToTypedWhenSupported() throws {
+        let spy = SpyPublisher(supportsTyped: true)
+        let pub = ROS2Publisher<FakeTypedMessage>(transportPublisher: spy)
+        try pub.publish(FakeTypedMessage(value: 1))
+        XCTAssertEqual(spy.typedCount, 1)
+        XCTAssertEqual(spy.byteCount, 0)
+    }
+
+    func testFallsBackToByteWhenUnsupported() throws {
+        let spy = SpyPublisher(supportsTyped: false)
+        let pub = ROS2Publisher<FakeTypedMessage>(transportPublisher: spy)
+        try pub.publish(FakeTypedMessage(value: 1))
+        XCTAssertEqual(spy.typedCount, 0)
+        XCTAssertEqual(spy.byteCount, 1)
+    }
+}


### PR DESCRIPTION
## Summary
Flips production `sensor_msgs/Imu` publishing on the `.rcl` transport from the M1 P1 serialized seam to **typed `rcl_publish`** (Swift value → rosidl C struct → `rcl_publish`, serialized by `rmw_cyclonedds_cpp` via introspection — real ROS 2 serialization), behind a new `package`-level typed-publish seam. **No public API change** (1.x SemVer freeze preserved).

Detailed design: spec §17 (M3a row, §17.1 typed seam, §17.2 Approach 1 flat-SoA marshalling, §17.4 validation).

## What's in M3a (vertical slice, Imu only)
- New C-free seam: `RclTypedPublishable` protocol + `TransportPublisher.supportsTypedPublish`/`publishTyped` (default no-op/throw).
- `ROS2Publisher.publish` routes typed-first when the transport supports it **and** the message conforms; otherwise the existing CDR byte path is unchanged (hybrid — non-bundled types like `AudioData`/`CompressedPointCloud2` stay on P1).
- C bridge: `crcl_publish_imu` (typed `rcl_publish`) sharing a `fill_imu`/`fini_imu` struct-fill with the M2 `crcl_serialize_imu`, so the golden gate keeps validating the fill.
- `extension Imu: RclTypedPublishable` (gated `SwiftROS2RCL`); `RclTransportPublisher` implements the capability.

## Scope note
The **hand-written** Imu marshalling here is the vertical-slice proof; the generalized `swift-ros2-gen` marshalling generator (which regenerates this + the sequence-bearing types) lands in **M3b** — generating Imu-only now then re-touching the generator in M3b is wasteful. Spec §17.3 updated accordingly.

## Validation
- Ordinary CI: `swift build` + 111 tests + lint green; new TDD dispatch test (`TypedPublishDispatchTests`) proves typed-vs-byte routing with mocks (no xcframework).
- `ci-rcl`: `crcl-golden` (struct-fill byte gate, `SwiftROS2CDR == rmw_serialize`, unchanged) + `crcl-smoke` (now runtime-exercises `crcl_publish_imu`).
- LAN integration (`LINUX_IP` + Jazzy host): `pub.publish(imu)` now takes the typed path; `ros2 topic echo` confirms on a host.

## Notes
- All new symbols are `package`-level → API-stability gate unaffected (no allowlist edit, unlike M1's `TransportType.rcl`).
- Layering preserved: no Swift target imports `CRos2Jazzy`; `SwiftROS2Transport` stays C-free; only `SwiftROS2RCL` touches `CRclBridge`.