### PR TITLE
fix(ci): make ci-rcl regen-drift guard self-contained

### DIFF
--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -20,6 +20,11 @@ jobs:
       SWIFT_ROS2_ENABLE_RCL: "1"
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The regen-drift guard reads the vendor IDL submodules
+          # (common_interfaces-jazzy, rcl_interfaces-jazzy); the xcframework
+          # build does its own `vcs import` and needs none of them.
+          submodules: recursive
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app
       - uses: actions/setup-python@v5
@@ -39,6 +44,13 @@ jobs:
       # toolchain + vendor IDL only — no xcframework), so it runs before the
       # expensive cross-build and fails fast if the generated tree is stale.
       - name: RCL marshalling regen-drift guard
+        env:
+          # Clear the job-level opt-in for this step only: with it set,
+          # `swift run swift-ros2-gen` would resolve the CRos2Jazzy binary
+          # target at build/ros2/CRos2Jazzy.xcframework, which is not built
+          # until the cross-build step below. The generator itself needs no
+          # RCL target.
+          SWIFT_ROS2_ENABLE_RCL: ""
         run: |
           bash Scripts/regen-rcl-marshalling.sh
           git diff --exit-code Sources/CRclBridge/Generated \


### PR DESCRIPTION
## Problem

The `ci-rcl` run on `feat/native-rcl-m3b` (run 27170283379) failed at the **RCL marshalling regen-drift guard** step, which was added in #123:

```
error: local binary target 'CRos2Jazzy' at '.../build/ros2/CRos2Jazzy.xcframework' does not contain a binary artifact.
```

Two independent bugs, both invisible locally (where the xcframework and submodules already exist):

1. **Job-level `SWIFT_ROS2_ENABLE_RCL=1` leaks into the guard step.** `swift run swift-ros2-gen` then parses `Package.swift` with the RCL arm enabled and tries to resolve the `CRos2Jazzy` binary target at `build/ros2/CRos2Jazzy.xcframework` — which the cross-build step only produces *later* (the guard intentionally runs first to fail fast).
2. **No submodules in the checkout.** The generator reads the vendor IDL submodules (`common_interfaces-jazzy`, `rcl_interfaces-jazzy`); without them the regen would fail right after fixing (1).

## Fix

- Clear `SWIFT_ROS2_ENABLE_RCL` for the guard step only (the generator needs no RCL target; the rest of the job keeps the opt-in).
- Check out submodules recursively, matching `ci.yml`'s build jobs.

## Validation

- Locally: `env -u SWIFT_ROS2_ENABLE_RCL bash Scripts/regen-rcl-marshalling.sh` → regenerates drift-free.
- `ci-rcl` dispatched on this branch (link in comments once running).