### PR TITLE
feat(rcl): native RCL DDS backend — M4 subscribe (wait-set thread + byte seam)

### DIFF
--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -125,3 +125,25 @@ jobs:
           printf '%s\n' "$out"
           printf '%s\n' "$out" | grep -q "crcl_golden OK:"
           ! printf '%s\n' "$out" | grep -qi "AddressSanitizer\|runtime error\|detected memory leaks"
+
+      # In-process pub/sub round-trip (M4): typed rcl_publish -> CycloneDDS
+      # local delivery -> rcl_take_serialized_message -> CDRDecoder for
+      # sensor_msgs/Imu, through the public createPublisher /
+      # createSubscription API — the per-subscription wait-set thread and the
+      # Unmanaged handler trampoline run under AddressSanitizer. The loopback
+      # spins up a real DDS participant, so discovery settle + teardown can
+      # block on a headless runner: bound the run (alarm 120 — 2 s settle +
+      # 15 s receive deadline + ASan slowdown) and decide success on the OK
+      # line + the absence of any ASan/leak report.
+      - name: Build + run crcl-loopback (Catalyst, ASan)
+        run: |
+          xcodebuild -scheme crcl-loopback \
+            -destination 'platform=macOS,variant=Mac Catalyst,arch=arm64' \
+            -derivedDataPath build/dd-ci-crclloopback -enableAddressSanitizer YES \
+            build CODE_SIGNING_ALLOWED=NO
+          bin="$(find build/dd-ci-crclloopback -name crcl-loopback -type f -perm +111 | head -1)"
+          echo "Running loopback: $bin"
+          out="$(perl -e 'alarm 120; exec @ARGV' "$bin" 2>&1)" || true
+          printf '%s\n' "$out"
+          printf '%s\n' "$out" | grep -q "crcl_loopback OK:"
+          ! printf '%s\n' "$out" | grep -qi "AddressSanitizer\|runtime error\|detected memory leaks"

--- a/Package.swift
+++ b/Package.swift
@@ -542,7 +542,7 @@ if enableRcl {
             name: "CRclBridge",
             dependencies: ["CRos2Jazzy"],
             path: "Sources/CRclBridge",
-            sources: ["rcl_bridge.c", "Generated"],
+            sources: ["rcl_bridge.c", "rcl_subscription.c", "Generated"],
             publicHeadersPath: "include",
             // rmw_cyclonedds_cpp / rcpputils in CRos2Jazzy are C++.
             linkerSettings: [.linkedLibrary("c++")]

--- a/Package.swift
+++ b/Package.swift
@@ -564,6 +564,14 @@ if enableRcl {
         ))
     products.append(.executable(name: "crcl-golden", targets: ["crcl-golden"]))
     targets.append(
+        .executableTarget(
+            name: "crcl-loopback",
+            dependencies: ["SwiftROS2"],
+            path: "Sources/Examples/CrclLoopback",
+            linkerSettings: [.linkedLibrary("c++")]
+        ))
+    products.append(.executable(name: "crcl-loopback", targets: ["crcl-loopback"]))
+    targets.append(
         .target(
             name: "SwiftROS2RCL",
             dependencies: ["CRclBridge", "SwiftROS2Transport", "SwiftROS2Messages"],

--- a/Sources/CRclBridge/include/crcl_internal.h
+++ b/Sources/CRclBridge/include/crcl_internal.h
@@ -1,10 +1,11 @@
 //
 // crcl_internal.h
-// Internal (non-public-API) surface shared between rcl_bridge.c and the
-// generated marshaller C sources: the publisher struct body and the error
-// helpers. The `crcl_publisher_t` typedef itself stays in rcl_bridge.h; this
-// header only supplies the struct *body* so generated code can dereference
-// `pub->pub` without re-declaring the typedef.
+// Internal (non-public-API) surface shared between the bridge C sources
+// (rcl_bridge.c, rcl_subscription.c) and the generated marshaller C sources:
+// the node / publisher struct bodies and the error helpers. The typedefs
+// themselves stay in rcl_bridge.h; this header only supplies the struct
+// *bodies* so the other TUs can dereference them without re-declaring the
+// typedefs.
 //
 #ifndef CRCL_INTERNAL_H
 #define CRCL_INTERNAL_H
@@ -16,14 +17,23 @@
 extern "C" {
 #endif
 
-// The crcl_publisher_t typedef is also declared in rcl_bridge.h. Repeating an
-// identical typedef of an incomplete struct is legal in C11, and the generated
-// marshaller headers reach the typedef through this header (they never include
-// rcl_bridge.h).
+// The crcl_publisher_t / crcl_node_t typedefs are also declared in
+// rcl_bridge.h. Repeating an identical typedef of an incomplete struct is
+// legal in C11, and the generated marshaller headers reach the typedefs
+// through this header (they never include rcl_bridge.h).
 typedef struct crcl_publisher_s crcl_publisher_t;
 struct crcl_publisher_s {
     rcl_publisher_t pub;
     rcl_node_t *node;  // borrowed; node must outlive the publisher
+};
+
+// Stored `ctx` exists because Jazzy's rcl has no rcl_node_get_context();
+// rcl_subscription.c needs the owning context to init its guard condition and
+// wait set, so crcl_node_create records it here at node-create time.
+typedef struct crcl_node_s crcl_node_t;
+struct crcl_node_s {
+    rcl_node_t node;
+    rcl_context_t *ctx;  // borrowed; context must outlive the node
 };
 
 /// Copy `msg` into the thread-local error buffer surfaced by crcl_last_error().

--- a/Sources/CRclBridge/include/rcl_bridge.h
+++ b/Sources/CRclBridge/include/rcl_bridge.h
@@ -16,6 +16,7 @@ extern "C" {
 typedef struct crcl_context_s crcl_context_t;
 typedef struct crcl_node_s crcl_node_t;
 typedef struct crcl_publisher_s crcl_publisher_t;
+typedef struct crcl_subscription_s crcl_subscription_t;
 
 // Generated per-type marshalling decls (crcl_serialize_<snake> /
 // crcl_publish_<snake> / crcl_typesupport_<snake>) plus the typesupport
@@ -44,6 +45,27 @@ void crcl_publisher_destroy(crcl_publisher_t *pub);
 
 /// Publish pre-serialized CDR bytes. Returns 0 on success, non-zero rcl_ret_t otherwise.
 int crcl_publish_serialized(crcl_publisher_t *pub, const uint8_t *data, size_t len);
+
+/// Invoked from the subscription's dedicated wait thread once per taken
+/// message. `buf` points at the raw CDR bytes (incl. the 4-byte encapsulation
+/// header) and is valid only for the duration of the call — copy if needed.
+/// `source_timestamp_ns` is rmw's publisher-side timestamp; 0 when the
+/// middleware reports none (or an invalid/negative value).
+typedef void (*crcl_take_callback_t)(
+    void *ctx, const uint8_t *buf, size_t len, int64_t source_timestamp_ns);
+
+/// Create a subscription on `node` and spawn its wait thread. `cb` fires on
+/// that thread for every message until crcl_subscription_destroy. Returns
+/// NULL on failure; call crcl_last_error().
+crcl_subscription_t *crcl_subscription_create(
+    crcl_node_t *node, const char *ros_type_name, const char *topic, const crcl_qos_t *qos,
+    crcl_take_callback_t cb, void *ctx);
+
+/// Destroy a subscription. Blocks until the wait thread has exited — and thus
+/// until any in-flight callback has returned — before finalizing the rcl
+/// entities. Returns 0 on success, non-zero if any fini failed (resources are
+/// freed regardless; see crcl_last_error()).
+int crcl_subscription_destroy(crcl_subscription_t *sub);
 
 /// Free a buffer returned by a generated crcl_serialize_<type>.
 void crcl_free(uint8_t *buf);

--- a/Sources/CRclBridge/include/rcl_bridge.h
+++ b/Sources/CRclBridge/include/rcl_bridge.h
@@ -63,8 +63,15 @@ crcl_subscription_t *crcl_subscription_create(
 
 /// Destroy a subscription. Blocks until the wait thread has exited — and thus
 /// until any in-flight callback has returned — before finalizing the rcl
-/// entities. Returns 0 on success, non-zero if any fini failed (resources are
-/// freed regardless; see crcl_last_error()).
+/// entities. MUST NOT be called from the take callback (i.e. from the
+/// subscription's own wait thread): the join would be a self-join, so the
+/// call fails and the subscription is intentionally leaked rather than freed
+/// under the running thread. Returns 0 on success; positive if a fini failed
+/// (resources are still freed and the callback will never fire again);
+/// negative if the subscription could NOT be destroyed (self-call from the
+/// take callback, or the join failed) — the wait thread may still be running,
+/// the subscription leaks, and the caller MUST NOT free `ctx`. See
+/// crcl_last_error() for non-zero returns.
 int crcl_subscription_destroy(crcl_subscription_t *sub);
 
 /// Free a buffer returned by a generated crcl_serialize_<type>.

--- a/Sources/CRclBridge/rcl_bridge.c
+++ b/Sources/CRclBridge/rcl_bridge.c
@@ -29,9 +29,7 @@ struct crcl_context_s {
     rcl_context_t ctx;
     rcl_init_options_t opts;
 };
-struct crcl_node_s {
-    rcl_node_t node;
-};
+// struct crcl_node_s lives in crcl_internal.h (shared with rcl_subscription.c).
 
 #ifdef _Thread_local
 #define CRCL_THREAD_LOCAL _Thread_local
@@ -105,6 +103,7 @@ crcl_node_t *crcl_node_create(crcl_context_t *c, const char *name, const char *n
     crcl_node_t *n = calloc(1, sizeof(*n));
     if (!n) return NULL;
     n->node = rcl_get_zero_initialized_node();
+    n->ctx = &c->ctx;  // Jazzy has no rcl_node_get_context(); see crcl_internal.h.
     rcl_node_options_t nopts = rcl_node_get_default_options();
     if (rcl_node_init(&n->node, name, ns, &c->ctx, &nopts) != RCL_RET_OK) {
         capture_error();

--- a/Sources/CRclBridge/rcl_subscription.c
+++ b/Sources/CRclBridge/rcl_subscription.c
@@ -1,0 +1,190 @@
+#include "rcl_bridge.h"
+
+#include <rcl/rcl.h>
+#include <rcl/subscription.h>
+#include <rcl/guard_condition.h>
+#include <rcl/wait.h>
+// rcl_reset_error for the wait-thread loop (rcl/rcutils error state is
+// thread-local, so failures on the wait thread only need a reset there).
+#include <rcl/error_handling.h>
+#include <rmw/qos_profiles.h>
+#include <rmw/serialized_message.h>
+#include <rmw/types.h>
+#include <rcutils/allocator.h>
+#include <rosidl_runtime_c/message_type_support_struct.h>
+// crcl_node_s body (stored rcl_context_t*) + crcl__set_error / crcl__capture_rcl_error.
+#include "crcl_internal.h"
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct crcl_subscription_s {
+    rcl_subscription_t sub;
+    rcl_node_t *node;  // borrowed; node must outlive the subscription
+    rcl_guard_condition_t stop_gc;
+    rcl_wait_set_t wait_set;
+    pthread_t thread;
+    atomic_bool stop;
+    crcl_take_callback_t cb;
+    void *cb_ctx;
+};
+
+// Per-subscription wait thread: rcl_wait on {subscription, stop guard
+// condition} with a 100 ms timeout, then drain every pending message via
+// rcl_take_serialized_message. The wait set and subscription are touched by
+// this thread only while it runs; crcl_subscription_destroy joins it before
+// any fini, so there is no concurrent access to rcl entities.
+static void *crcl__sub_thread_main(void *arg) {
+    crcl_subscription_t *s = arg;
+    const int64_t timeout_ns = 100LL * 1000 * 1000;  // 100 ms
+    while (!atomic_load(&s->stop)) {
+        if (rcl_wait_set_clear(&s->wait_set) != RCL_RET_OK) {
+            rcl_reset_error();
+            break;  // wait set unusable — stop delivering rather than spin
+        }
+        if (rcl_wait_set_add_subscription(&s->wait_set, &s->sub, NULL) != RCL_RET_OK) {
+            rcl_reset_error();
+            break;
+        }
+        if (rcl_wait_set_add_guard_condition(&s->wait_set, &s->stop_gc, NULL) != RCL_RET_OK) {
+            rcl_reset_error();
+            break;
+        }
+        rcl_ret_t ret = rcl_wait(&s->wait_set, timeout_ns);
+        if (ret == RCL_RET_TIMEOUT) continue;
+        if (ret != RCL_RET_OK) {
+            rcl_reset_error();
+            continue;
+        }
+        if (atomic_load(&s->stop)) break;
+        // Drain: take until the middleware reports nothing pending. A fresh
+        // zero-capacity serialized message per take is acceptable (M4 plan);
+        // rcl_take_serialized_message grows it as needed.
+        for (;;) {
+            rcl_serialized_message_t msg = rmw_get_zero_initialized_serialized_message();
+            rcutils_allocator_t alloc = rcutils_get_default_allocator();
+            if (rmw_serialized_message_init(&msg, 0, &alloc) != RMW_RET_OK) {
+                rcl_reset_error();
+                break;
+            }
+            rmw_message_info_t info = rmw_get_zero_initialized_message_info();
+            rcl_ret_t take = rcl_take_serialized_message(&s->sub, &msg, &info, NULL);
+            if (take == RCL_RET_OK) {
+                int64_t ts = info.source_timestamp > 0 ? (int64_t)info.source_timestamp : 0;
+                s->cb(s->cb_ctx, msg.buffer, msg.buffer_length, ts);
+                (void)rmw_serialized_message_fini(&msg);
+                continue;
+            }
+            (void)rmw_serialized_message_fini(&msg);
+            // RCL_RET_SUBSCRIPTION_TAKE_FAILED == nothing pending (not an
+            // error); anything else is a real failure — either way stop
+            // draining and go back to waiting.
+            rcl_reset_error();
+            break;
+        }
+    }
+    return NULL;
+}
+
+crcl_subscription_t *crcl_subscription_create(
+    crcl_node_t *n, const char *ros_type_name, const char *topic, const crcl_qos_t *q,
+    crcl_take_callback_t cb, void *ctx) {
+    if (!n || !q || !cb) {
+        crcl__set_error("crcl_subscription_create: NULL node/qos/callback");
+        return NULL;
+    }
+    const rosidl_message_type_support_t *ts = crcl_marshal_resolve_typesupport(ros_type_name);
+    if (!ts) {
+        // Not an rcl error — no rcl error state to capture; set the message directly.
+        char msg[256];
+        snprintf(msg, sizeof(msg), "unsupported type: %s", ros_type_name ? ros_type_name : "(null)");
+        crcl__set_error(msg);
+        return NULL;
+    }
+    crcl_subscription_t *s = calloc(1, sizeof(*s));
+    if (!s) {
+        crcl__set_error("crcl_subscription_create: out of memory");
+        return NULL;
+    }
+    s->node = &n->node;
+    s->cb = cb;
+    s->cb_ctx = ctx;
+    atomic_init(&s->stop, false);
+
+    s->sub = rcl_get_zero_initialized_subscription();
+    rcl_subscription_options_t sopts = rcl_subscription_get_default_options();
+    sopts.qos = rmw_qos_profile_default;
+    sopts.qos.reliability =
+        q->reliability ? RMW_QOS_POLICY_RELIABILITY_RELIABLE : RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+    sopts.qos.durability =
+        q->durability ? RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL : RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    sopts.qos.history =
+        q->history ? RMW_QOS_POLICY_HISTORY_KEEP_ALL : RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+    sopts.qos.depth = q->depth;
+    if (rcl_subscription_init(&s->sub, &n->node, ts, topic, &sopts) != RCL_RET_OK) {
+        crcl__capture_rcl_error();
+        free(s);
+        return NULL;
+    }
+
+    s->stop_gc = rcl_get_zero_initialized_guard_condition();
+    if (rcl_guard_condition_init(&s->stop_gc, n->ctx, rcl_guard_condition_get_default_options())
+        != RCL_RET_OK) {
+        crcl__capture_rcl_error();
+        (void)rcl_subscription_fini(&s->sub, s->node);
+        free(s);
+        return NULL;
+    }
+
+    s->wait_set = rcl_get_zero_initialized_wait_set();
+    if (rcl_wait_set_init(&s->wait_set, 1, 1, 0, 0, 0, 0, n->ctx, rcl_get_default_allocator())
+        != RCL_RET_OK) {
+        crcl__capture_rcl_error();
+        (void)rcl_guard_condition_fini(&s->stop_gc);
+        (void)rcl_subscription_fini(&s->sub, s->node);
+        free(s);
+        return NULL;
+    }
+
+    if (pthread_create(&s->thread, NULL, crcl__sub_thread_main, s) != 0) {
+        crcl__set_error("crcl_subscription_create: pthread_create failed");
+        (void)rcl_wait_set_fini(&s->wait_set);
+        (void)rcl_guard_condition_fini(&s->stop_gc);
+        (void)rcl_subscription_fini(&s->sub, s->node);
+        free(s);
+        return NULL;
+    }
+    return s;
+}
+
+int crcl_subscription_destroy(crcl_subscription_t *s) {
+    if (!s) return 0;
+    // Join BEFORE any fini: rcl take / fini are not thread-safe, and the wait
+    // thread reads `sub` / `wait_set` until it exits. The guard condition is
+    // the sanctioned cross-thread wakeup for rcl_wait, so the thread observes
+    // the stop flag within one wakeup (or the 100 ms timeout). Because the
+    // join happens first, this function blocks until any in-flight callback
+    // has returned — the guarantee the Swift side relies on before releasing
+    // the retained handler context.
+    atomic_store(&s->stop, true);
+    (void)rcl_trigger_guard_condition(&s->stop_gc);
+    (void)pthread_join(s->thread, NULL);
+    int rc = 0;
+    if (rcl_subscription_fini(&s->sub, s->node) != RCL_RET_OK) {
+        crcl__capture_rcl_error();
+        rc = -1;
+    }
+    if (rcl_guard_condition_fini(&s->stop_gc) != RCL_RET_OK) {
+        crcl__capture_rcl_error();
+        rc = -1;
+    }
+    if (rcl_wait_set_fini(&s->wait_set) != RCL_RET_OK) {
+        crcl__capture_rcl_error();
+        rc = -1;
+    }
+    free(s);
+    return rc;
+}

--- a/Sources/CRclBridge/rcl_subscription.c
+++ b/Sources/CRclBridge/rcl_subscription.c
@@ -60,10 +60,13 @@ static void *crcl__sub_thread_main(void *arg) {
             continue;
         }
         if (atomic_load(&s->stop)) break;
-        // Drain: take until the middleware reports nothing pending. A fresh
-        // zero-capacity serialized message per take is acceptable (M4 plan);
+        // Drain: take until the middleware reports nothing pending, or a stop
+        // request arrives — re-checking the flag per take bounds destroy
+        // latency under sustained load (a fast publisher could otherwise keep
+        // this loop busy indefinitely). A fresh zero-capacity serialized
+        // message per take is acceptable (M4 plan);
         // rcl_take_serialized_message grows it as needed.
-        for (;;) {
+        while (!atomic_load(&s->stop)) {
             rcl_serialized_message_t msg = rmw_get_zero_initialized_serialized_message();
             rcutils_allocator_t alloc = rcutils_get_default_allocator();
             if (rmw_serialized_message_init(&msg, 0, &alloc) != RMW_RET_OK) {
@@ -162,6 +165,17 @@ crcl_subscription_t *crcl_subscription_create(
 
 int crcl_subscription_destroy(crcl_subscription_t *s) {
     if (!s) return 0;
+    // Refuse a self-destroy from the take callback: pthread_join on the
+    // calling thread cannot block on itself (Darwin/glibc return EDEADLK
+    // immediately), so proceeding to fini/free would leave the wait thread
+    // dereferencing freed memory the moment the callback returns. Leak the
+    // subscription instead and surface an error — destroy must be called
+    // from another thread.
+    if (pthread_equal(pthread_self(), s->thread)) {
+        crcl__set_error(
+            "crcl_subscription_destroy called from the take callback; destroy from another thread");
+        return -1;
+    }
     // Join BEFORE any fini: rcl take / fini are not thread-safe, and the wait
     // thread reads `sub` / `wait_set` until it exits. The guard condition is
     // the sanctioned cross-thread wakeup for rcl_wait, so the thread observes
@@ -171,19 +185,24 @@ int crcl_subscription_destroy(crcl_subscription_t *s) {
     // the retained handler context.
     atomic_store(&s->stop, true);
     (void)rcl_trigger_guard_condition(&s->stop_gc);
-    (void)pthread_join(s->thread, NULL);
+    if (pthread_join(s->thread, NULL) != 0) {
+        // The wait thread may still be running; fini/free now would race it.
+        // Leak instead of crash.
+        crcl__set_error("crcl_subscription_destroy: pthread_join failed");
+        return -1;
+    }
     int rc = 0;
     if (rcl_subscription_fini(&s->sub, s->node) != RCL_RET_OK) {
         crcl__capture_rcl_error();
-        rc = -1;
+        rc = 1;
     }
     if (rcl_guard_condition_fini(&s->stop_gc) != RCL_RET_OK) {
         crcl__capture_rcl_error();
-        rc = -1;
+        rc = 1;
     }
     if (rcl_wait_set_fini(&s->wait_set) != RCL_RET_OK) {
         crcl__capture_rcl_error();
-        rc = -1;
+        rc = 1;
     }
     free(s);
     return rc;

--- a/Sources/Examples/CrclLoopback/main.swift
+++ b/Sources/Examples/CrclLoopback/main.swift
@@ -1,0 +1,159 @@
+// crcl-loopback — M4 subscribe round-trip gate.
+//
+// One process, one rcl context: a typed rcl publisher and an rcl subscription
+// on sensor_msgs/Imu share the topic "loopback_imu". The publisher sends the
+// crcl-golden Imu fixture; every received message has travelled
+// typed rcl_publish -> CycloneDDS in-process delivery ->
+// rcl_take_serialized_message -> CDRDecoder, i.e. the full public
+// createPublisher / createSubscription surface end-to-end. On success prints
+// "crcl_loopback OK: …" + flush, then exits 0 (before context teardown, which
+// can block on headless runners — ci-rcl bounds the run with SIGALRM and
+// decides success on the OK line, consistent with crcl-smoke / crcl-golden).
+
+import Foundation
+import SwiftROS2
+
+func fail(_ reason: String) -> Never {
+    print("crcl_loopback FAIL: \(reason)")
+    fflush(stdout)
+    exit(1)
+}
+
+// Deterministic fixture — same values as crcl-golden, so the byte gate and
+// the round-trip gate exercise the same message.
+let fixture = Imu(
+    header: Header(stamp: Time(sec: 1234, nanosec: 567_890_000), frameId: "imu_link"),
+    orientation: Quaternion(x: 0.1, y: 0.2, z: 0.3, w: 0.4),
+    orientationCovariance: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+    angularVelocity: Vector3(x: 1.5, y: 2.5, z: 3.5),
+    angularVelocityCovariance: [9, 10, 11, 12, 13, 14, 15, 16, 17],
+    linearAcceleration: Vector3(x: 9.8, y: 0.0, z: -9.8),
+    linearAccelerationCovariance: [18, 19, 20, 21, 22, 23, 24, 25, 26]
+)
+
+/// Lock-protected receive counter + last-message capture, fed from the
+/// AsyncStream consumer task and polled from the publish loop.
+final class ReceiveBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    private var last: Imu?
+
+    func record(_ message: Imu) {
+        lock.lock()
+        count += 1
+        last = message
+        lock.unlock()
+    }
+
+    var snapshot: (count: Int, last: Imu?) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (count, last)
+    }
+}
+
+let ctx: ROS2Context
+do {
+    ctx = try await ROS2Context(transport: .rcl(domainId: 0))
+} catch {
+    fail("ROS2Context creation threw: \(error)")
+}
+
+let node: ROS2Node
+do {
+    node = try await ctx.createNode(
+        name: "crcl_loopback",
+        namespace: "/loopback",
+        options: ROS2NodeOptions(startParameterServices: false)
+    )
+} catch {
+    fail("createNode threw: \(error)")
+}
+
+// Reliable + deep history so the gate is deterministic once the reader and
+// writer have matched; .sensorData (best-effort) would make drops legal.
+let qos = QoSProfile(reliability: .reliable, durability: .volatile, history: .keepLast(50))
+
+// Subscription first so the reader is advertised before the writer matches.
+let sub: ROS2Subscription<Imu>
+do {
+    sub = try await node.createSubscription(Imu.self, topic: "loopback_imu", qos: qos)
+} catch {
+    fail("createSubscription threw: \(error)")
+}
+
+let box = ReceiveBox()
+let consumer = Task {
+    for await message in sub.messages {
+        box.record(message)
+    }
+}
+
+let pub: ROS2Publisher<Imu>
+do {
+    pub = try await node.createPublisher(Imu.self, topic: "loopback_imu", qos: qos)
+} catch {
+    fail("createPublisher threw: \(error)")
+}
+
+// DDS endpoint discovery (SPDP/SEDP) needs a moment even in-process — repo
+// precedent is the 2 s settle in DDSRoundTripTests.testLoopbackPubSubSameProcess.
+try? await Task.sleep(nanoseconds: 2_000_000_000)
+
+// Publish at ~50 Hz until at least `target` messages went out AND at least
+// `target` came back, or the deadline passes. Publishing keeps going during
+// the receive window so a late reader-writer match cannot starve the gate.
+let target = 20
+let deadline = Date().addingTimeInterval(15)
+var published = 0
+while Date() < deadline {
+    if published >= target && box.snapshot.count >= target { break }
+    do {
+        try pub.publish(fixture)
+    } catch {
+        fail("publish #\(published + 1) threw: \(error)")
+    }
+    published += 1
+    try? await Task.sleep(nanoseconds: 20_000_000)
+}
+
+let (received, lastMessage) = box.snapshot
+guard received >= target else {
+    fail("received \(received)/\(target) messages within 15 s (published \(published))")
+}
+guard let last = lastMessage else {
+    fail("received \(received) messages but captured none")
+}
+
+// Field-identity gate on discriminating fields of the last received message.
+guard
+    last.header.stamp.sec == fixture.header.stamp.sec,
+    last.header.stamp.nanosec == fixture.header.stamp.nanosec
+else {
+    fail("stamp mismatch: \(last.header.stamp) != \(fixture.header.stamp)")
+}
+guard last.header.frameId == fixture.header.frameId else {
+    fail("frame_id mismatch: \(last.header.frameId) != \(fixture.header.frameId)")
+}
+guard
+    last.linearAcceleration.x == fixture.linearAcceleration.x,
+    last.linearAcceleration.y == fixture.linearAcceleration.y,
+    last.linearAcceleration.z == fixture.linearAcceleration.z
+else {
+    fail("linear_acceleration mismatch: \(last.linearAcceleration) != \(fixture.linearAcceleration)")
+}
+guard last.linearAccelerationCovariance.first == fixture.linearAccelerationCovariance.first else {
+    fail(
+        "linear_acceleration_covariance[0] mismatch: "
+            + "\(String(describing: last.linearAccelerationCovariance.first)) != "
+            + "\(String(describing: fixture.linearAccelerationCovariance.first))")
+}
+
+print("crcl_loopback OK: \(received) messages round-tripped (typed rcl_publish -> rcl_take_serialized -> CDRDecoder)")
+fflush(stdout)
+
+// Best-effort teardown after the OK line: on a headless runner CycloneDDS
+// teardown can block, and ci-rcl's SIGALRM bound + OK-line grep absorb that.
+consumer.cancel()
+await ctx.shutdown()
+exit(0)

--- a/Sources/SwiftROS2RCL/RclClient.swift
+++ b/Sources/SwiftROS2RCL/RclClient.swift
@@ -42,6 +42,78 @@ final class RclPublisherBox: RclPublisherHandle, @unchecked Sendable {
     }
 }
 
+/// Retained by `RclSubscriptionBox.contextBox` while the subscription is
+/// alive. The `@unchecked Sendable` is justified: the class holds an
+/// immutable `@Sendable` closure reference; the closure captures are the only
+/// state shared across threads, and Swift's concurrency model already
+/// requires those to be Sendable.
+private final class RclSubscriptionContext: @unchecked Sendable {
+    let handler: @Sendable (Data, UInt64) -> Void
+    init(handler: @escaping @Sendable (Data, UInt64) -> Void) {
+        self.handler = handler
+    }
+}
+
+/// C-callable bridge matching `crcl_take_callback_t`.
+/// The `ctx` pointer is an `Unmanaged<RclSubscriptionContext>` opaque pointer
+/// created via `passRetained` in `createSubscription`; here we only borrow it
+/// (`takeUnretainedValue`) — retention is released in `RclSubscriptionBox.close()`.
+private func rclTakeCallbackBridge(
+    ctx: UnsafeMutableRawPointer?,
+    buf: UnsafePointer<UInt8>?,
+    len: Int,
+    sourceTimestampNs: Int64
+) {
+    guard let ctx else { return }
+    let subscriptionContext = Unmanaged<RclSubscriptionContext>.fromOpaque(ctx).takeUnretainedValue()
+
+    let payload: Data
+    if let buf, len > 0 {
+        payload = Data(bytes: buf, count: len)
+    } else {
+        payload = Data()
+    }
+
+    subscriptionContext.handler(payload, sourceTimestampNs > 0 ? UInt64(sourceTimestampNs) : 0)
+}
+
+/// Per-box lock serializes destroy vs. isActive checks for the same
+/// subscription. Different subscriptions hold different locks.
+private final class RclSubscriptionBox: RclSubscriptionHandle, @unchecked Sendable {
+    private var ptr: OpaquePointer?
+    private var contextBox: Unmanaged<RclSubscriptionContext>?
+    private let lock = NSLock()
+
+    init(_ ptr: OpaquePointer, contextBox: Unmanaged<RclSubscriptionContext>) {
+        self.ptr = ptr
+        self.contextBox = contextBox
+    }
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return ptr != nil
+    }
+
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        if let p = ptr {
+            // crcl_subscription_destroy joins the wait thread before any fini,
+            // so it blocks until any in-flight callback has returned. Only
+            // after it returns is it safe to release the retained closure
+            // context, because no further callback invocations will
+            // dereference it.
+            _ = crcl_subscription_destroy(p)
+            ptr = nil
+        }
+        if let box = contextBox {
+            box.release()
+            contextBox = nil
+        }
+    }
+}
+
 // MARK: - Client
 
 /// Concrete implementation of ``RclClientProtocol`` wrapping the `CRclBridge` C FFI.
@@ -50,8 +122,12 @@ final class RclPublisherBox: RclPublisherHandle, @unchecked Sendable {
 /// `crcl_context_create` runs outside the lock (one-time init); the guard rejects
 /// a second `createContext` call with `alreadyConnected`. `destroyContext`
 /// snapshots and nils `ctx` under lock, then calls `crcl_context_destroy` outside.
-/// Publisher create/destroy delegates thread-safety to the per-`RclPublisherBox` lock,
-/// mirroring the `DDSClient` pattern.
+/// Publisher and subscription create/destroy delegate thread-safety to the
+/// per-`RclPublisherBox` / per-`RclSubscriptionBox` locks, mirroring the
+/// `DDSClient` pattern. The retained `Unmanaged<RclSubscriptionContext>`
+/// holding the user handler is released only *after* `crcl_subscription_destroy`
+/// returns — the C bridge joins the wait thread before any fini, so a racing
+/// callback can never dereference a freed closure context.
 public final class RclClient: RclClientProtocol, @unchecked Sendable {
     private var ctx: OpaquePointer?
     private let lock = NSLock()
@@ -105,21 +181,41 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         guard let b = node as? RclNodeBox else {
             throw TransportError.publisherCreationFailed("invalid node handle")
         }
-        var q = crcl_qos_t()
-        q.reliability = qos.reliability == .reliable ? Int32(1) : Int32(0)
-        q.durability = qos.durability == .transientLocal ? Int32(1) : Int32(0)
-        switch qos.history {
-        case .keepLast(let depth):
-            q.history = Int32(0)
-            q.depth = depth
-        case .keepAll:
-            q.history = Int32(1)
-            q.depth = 0
-        }
+        let q = makeCrclQoS(qos)
         guard let p = crcl_publisher_create(b.ptr, typeName, topic, q) else {
             throw TransportError.publisherCreationFailed(lastError())
         }
         return RclPublisherBox(p)
+    }
+
+    package func createSubscription(
+        node: any RclNodeHandle,
+        typeName: String,
+        topic: String,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any RclSubscriptionHandle {
+        guard let b = node as? RclNodeBox else {
+            throw TransportError.subscriberCreationFailed("invalid node handle")
+        }
+        var q = makeCrclQoS(qos)
+
+        let contextBox = Unmanaged.passRetained(RclSubscriptionContext(handler: handler))
+        let contextPtr = UnsafeMutableRawPointer(contextBox.toOpaque())
+
+        guard
+            let s = crcl_subscription_create(
+                b.ptr, typeName, topic, &q, rclTakeCallbackBridge, contextPtr)
+        else {
+            contextBox.release()
+            throw TransportError.subscriberCreationFailed(lastError())
+        }
+        return RclSubscriptionBox(s, contextBox: contextBox)
+    }
+
+    package func destroySubscription(_ subscription: any RclSubscriptionHandle) {
+        guard let box = subscription as? RclSubscriptionBox else { return }
+        box.close()
     }
 
     package func publishSerialized(_ publisher: any RclPublisherHandle, data: Data) throws {
@@ -134,6 +230,21 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         }
         guard let rc else { throw TransportError.publisherClosed }
         if rc != 0 { throw TransportError.publishFailed(lastError()) }
+    }
+
+    private func makeCrclQoS(_ qos: TransportQoS) -> crcl_qos_t {
+        var q = crcl_qos_t()
+        q.reliability = qos.reliability == .reliable ? Int32(1) : Int32(0)
+        q.durability = qos.durability == .transientLocal ? Int32(1) : Int32(0)
+        switch qos.history {
+        case .keepLast(let depth):
+            q.history = Int32(0)
+            q.depth = depth
+        case .keepAll:
+            q.history = Int32(1)
+            q.depth = 0
+        }
+        return q
     }
 
     private func lastError() -> String { String(cString: crcl_last_error()) }

--- a/Sources/SwiftROS2RCL/RclClient.swift
+++ b/Sources/SwiftROS2RCL/RclClient.swift
@@ -104,8 +104,17 @@ private final class RclSubscriptionBox: RclSubscriptionHandle, @unchecked Sendab
             // after it returns is it safe to release the retained closure
             // context, because no further callback invocations will
             // dereference it.
-            _ = crcl_subscription_destroy(p)
+            let rc = crcl_subscription_destroy(p)
             ptr = nil
+            if rc < 0 {
+                // The C side refused to destroy (self-destroy from the take
+                // callback, or a failed join): the wait thread may still
+                // invoke the callback, so the retained handler context must
+                // leak alongside the C subscription rather than be released
+                // under a live thread.
+                contextBox = nil
+                return
+            }
         }
         if let box = contextBox {
             box.release()

--- a/Sources/SwiftROS2Transport/RclClientProtocol.swift
+++ b/Sources/SwiftROS2Transport/RclClientProtocol.swift
@@ -14,7 +14,12 @@ package protocol RclPublisherHandle: AnyObject, Sendable {
     func close()
 }
 
-/// Lifecycle + publish operations the rcl C bridge exposes.
+/// Opaque handle to an rcl subscription owned by the client.
+package protocol RclSubscriptionHandle: AnyObject, Sendable {
+    var isActive: Bool { get }
+}
+
+/// Lifecycle + publish + subscribe operations the rcl C bridge exposes.
 package protocol RclClientProtocol: Sendable {
     /// Whether the native rcl stack is linked and usable.
     var isAvailable: Bool { get }
@@ -34,4 +39,19 @@ package protocol RclClientProtocol: Sendable {
 
     /// Publish pre-serialized CDR bytes (XCDR1 incl. the 4-byte encapsulation header).
     func publishSerialized(_ publisher: any RclPublisherHandle, data: Data) throws
+
+    /// Create a subscription whose receive thread invokes `handler` once per
+    /// taken message with the raw CDR bytes (XCDR1 incl. the 4-byte
+    /// encapsulation header) and the rmw source timestamp in nanoseconds
+    /// (0 when the middleware reports none).
+    func createSubscription(
+        node: any RclNodeHandle,
+        typeName: String,
+        topic: String,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any RclSubscriptionHandle
+
+    /// Destroy a subscription. Blocks until any in-flight handler invocation completes.
+    func destroySubscription(_ subscription: any RclSubscriptionHandle)
 }

--- a/Sources/SwiftROS2Transport/RclTransportSession+Subscriber.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession+Subscriber.swift
@@ -24,7 +24,7 @@ extension RclTransportSession {
         let handle = try client.createSubscription(
             node: node, typeName: typeName, topic: topic, qos: qos, handler: handler)
         let sub = RclTransportSubscriber(client: client, handle: handle, topic: topic)
-        appendSubscriber(sub)
+        try appendSubscriber(sub)
         return sub
     }
 }

--- a/Sources/SwiftROS2Transport/RclTransportSession+Subscriber.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession+Subscriber.swift
@@ -1,0 +1,67 @@
+// RclTransportSession+Subscriber.swift
+// Subscriber creation and the RclTransportSubscriber concrete type.
+
+import Foundation
+
+extension RclTransportSession {
+    package func createSubscriber(
+        topic: String,
+        typeName: String,
+        typeHash: String?,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any TransportSubscriber {
+        guard !topic.isEmpty else {
+            throw TransportError.invalidConfiguration("Topic name cannot be empty")
+        }
+        guard !typeName.isEmpty else {
+            throw TransportError.invalidConfiguration("Type name cannot be empty")
+        }
+        // typeHash is unused on this backend: rcl derives the hash from the
+        // typesupport handle, so the wire-level pin the Zenoh/DDS sessions
+        // need does not apply here.
+        let node = try preflightSubscriber()
+        let handle = try client.createSubscription(
+            node: node, typeName: typeName, topic: topic, qos: qos, handler: handler)
+        let sub = RclTransportSubscriber(client: client, handle: handle, topic: topic)
+        appendSubscriber(sub)
+        return sub
+    }
+}
+
+final class RclTransportSubscriber: TransportSubscriber, @unchecked Sendable {
+    private let client: any RclClientProtocol
+    private var handle: (any RclSubscriptionHandle)?
+    public let topic: String
+    private let lock = NSLock()
+    private var closed = false
+
+    public var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if closed { return false }
+        return handle?.isActive ?? false
+    }
+
+    init(client: any RclClientProtocol, handle: any RclSubscriptionHandle, topic: String) {
+        self.client = client
+        self.handle = handle
+        self.topic = topic
+    }
+
+    public func close() throws {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let h = handle
+        handle = nil
+        lock.unlock()
+        if let h {
+            // Blocks until any in-flight handler invocation has returned.
+            client.destroySubscription(h)
+        }
+    }
+}

--- a/Sources/SwiftROS2Transport/RclTransportSession.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession.swift
@@ -138,8 +138,18 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
         lock.unlock()
     }
 
-    func appendSubscriber(_ sub: RclTransportSubscriber) {
+    /// Register a created subscriber, re-checking that the session is still
+    /// open: if `close()` interleaved between `preflightSubscriber()` and the
+    /// client create call, the new subscription would escape teardown — its
+    /// wait thread never joined, its handler context leaked. Destroy it here
+    /// (joins the wait thread) and surface `notConnected` instead.
+    func appendSubscriber(_ sub: RclTransportSubscriber) throws {
         lock.lock()
+        guard isOpen else {
+            lock.unlock()
+            try? sub.close()
+            throw TransportError.notConnected
+        }
         subscribers.append(sub)
         lock.unlock()
     }

--- a/Sources/SwiftROS2Transport/RclTransportSession.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession.swift
@@ -1,11 +1,11 @@
 // RclTransportSession.swift
 // TransportSession backed by the real rcl + rmw_cyclonedds_cpp stack via
-// RclClientProtocol. M1 is publish-only and assumes a single node.
+// RclClientProtocol. Publish (M1) + subscribe (M4); assumes a single node.
 
 import Foundation
 
 /// `TransportSession` backed by the real `rcl` + `rmw_cyclonedds_cpp` stack via
-/// `RclClientProtocol`. M1 is publish-only and assumes a single node.
+/// `RclClientProtocol`. Publish (M1) + subscribe (M4); assumes a single node.
 public final class RclTransportSession: TransportSession, @unchecked Sendable {
     let client: any RclClientProtocol
     private let lock = NSLock()
@@ -14,6 +14,7 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
     private var nodes: [String: any RclNodeHandle] = [:]
     private var currentNode: (any RclNodeHandle)?
     var publishers: [String: RclTransportPublisher] = [:]
+    var subscribers: [RclTransportSubscriber] = []
 
     public var transportType: TransportType { .rcl }
 
@@ -89,19 +90,23 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
         return node
     }
 
-    package func createSubscriber(
-        topic: String,
-        typeName: String,
-        typeHash: String?,
-        qos: TransportQoS,
-        handler: @escaping @Sendable (Data, UInt64) -> Void
-    ) throws -> any TransportSubscriber {
-        throw TransportError.unsupportedFeature("createSubscriber (transport: rcl) — M1 is publish-only")
+    /// Atomically validate the session is open and a node exists; returns the
+    /// node a new subscriber attaches to (inherits the M1 single-node binding).
+    func preflightSubscriber() throws -> any RclNodeHandle {
+        lock.lock()
+        defer { lock.unlock() }
+        guard isOpen else { throw TransportError.notConnected }
+        guard let node = currentNode else {
+            throw TransportError.subscriberCreationFailed("no node registered — create a node first")
+        }
+        return node
     }
 
     public func close() throws {
         lock.lock()
         let wasOpen = isOpen
+        let subs = subscribers
+        subscribers.removeAll()
         let pubs = Array(publishers.values)
         publishers.removeAll()
         let ns = Array(nodes.values)
@@ -110,6 +115,9 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
         isOpen = false
         _sessionId = ""
         lock.unlock()
+        // Subscribers first: each close joins the subscription's wait thread,
+        // so no handler can fire against a node/context being torn down below.
+        for s in subs { try? s.close() }
         for p in pubs { try? p.close() }
         for n in ns { client.destroyNode(n) }
         if wasOpen { client.destroyContext() }
@@ -127,6 +135,12 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
     func appendPublisher(_ pub: RclTransportPublisher, for topic: String) {
         lock.lock()
         publishers[topic] = pub
+        lock.unlock()
+    }
+
+    func appendSubscriber(_ sub: RclTransportSubscriber) {
+        lock.lock()
+        subscribers.append(sub)
         lock.unlock()
     }
 

--- a/Tests/SwiftROS2IntegrationTests/RclSubscribeIntegrationTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/RclSubscribeIntegrationTests.swift
@@ -1,0 +1,62 @@
+import SwiftROS2Messages
+import XCTest
+
+@testable import SwiftROS2
+
+/// Subscribes to sensor_msgs/Temperature through the real rcl +
+/// rmw_cyclonedds_cpp stack and asserts receipt + decoded field values
+/// (plan task T5: host publishes a registry type, macOS asserts receipt).
+/// Gated: requires the RCL backend built (SWIFT_ROS2_RCL) and a reachable
+/// Jazzy host (LINUX_IP) that is actively publishing — start the host-side
+/// publisher BEFORE running this test:
+///
+///   ros2 topic pub -r 10 /swift_ros2_rcl/temperature sensor_msgs/msg/Temperature \
+///     "{header: {frame_id: probe}, temperature: 36.5, variance: 0.25}"
+final class RclSubscribeIntegrationTests: XCTestCase {
+    func testSubscribeTemperatureOverRcl() async throws {
+        #if !SWIFT_ROS2_RCL
+            throw XCTSkip("RCL backend not built (set SWIFT_ROS2_ENABLE_RCL=1)")
+        #else
+            guard ProcessInfo.processInfo.environment["LINUX_IP"] != nil else {
+                throw XCTSkip("LINUX_IP not set — skipping LAN integration test")
+            }
+
+            let ctx = try await ROS2Context(transport: .rcl(domainId: 0))
+            let node = try await ctx.createNode(
+                name: "swift_ros2_rcl_sub_test", namespace: "/swift_ros2_rcl",
+                options: ROS2NodeOptions(startParameterServices: false)
+            )
+            // Reliable to match the `ros2 topic pub` default writer QoS.
+            let qos = QoSProfile(
+                reliability: .reliable, durability: .volatile, history: .keepLast(10))
+            let sub = try await node.createSubscription(
+                Temperature.self, topic: "temperature", qos: qos)
+
+            // First message within 30 s — covers discovery + one publish period.
+            let receiveTask = Task { () -> Temperature? in
+                for await message in sub.messages { return message }
+                return nil
+            }
+            let timeoutTask = Task {
+                try? await Task.sleep(for: .seconds(30))
+                receiveTask.cancel()
+            }
+            let received = await receiveTask.value
+            timeoutTask.cancel()
+
+            guard let received else {
+                await ctx.shutdown()
+                return XCTFail(
+                    "no Temperature received within 30 s — is the host publishing on "
+                        + "/swift_ros2_rcl/temperature? (see the header of this file)")
+            }
+
+            // Decode gate: values must match the documented host-side command.
+            XCTAssertEqual(received.temperature, 36.5, accuracy: 1e-9)
+            XCTAssertEqual(received.variance, 0.25, accuracy: 1e-9)
+            XCTAssertEqual(received.header.frameId, "probe")
+
+            await ctx.shutdown()
+        #endif
+    }
+}

--- a/Tests/SwiftROS2TransportTests/Mocks/MockRclClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockRclClient.swift
@@ -33,6 +33,7 @@ final class MockRclPublisher: RclPublisherHandle, @unchecked Sendable {
 }
 
 final class MockRclSubscription: RclSubscriptionHandle, @unchecked Sendable {
+    let node: any RclNodeHandle
     let topic: String
     let typeName: String
     let qos: TransportQoS
@@ -41,9 +42,10 @@ final class MockRclSubscription: RclSubscriptionHandle, @unchecked Sendable {
     private var destroyed = false
 
     init(
-        topic: String, typeName: String, qos: TransportQoS,
+        node: any RclNodeHandle, topic: String, typeName: String, qos: TransportQoS,
         handler: @escaping @Sendable (Data, UInt64) -> Void
     ) {
+        self.node = node
         self.topic = topic
         self.typeName = typeName
         self.qos = qos
@@ -82,6 +84,9 @@ final class MockRclClient: RclClientProtocol, @unchecked Sendable {
     private(set) var contextDestroyed = false
     private(set) var lastDomainId: Int32 = -1
     private(set) var nodesCreated: [(name: String, namespace: String)] = []
+    /// Handles returned by createNode, in creation order — lets tests assert
+    /// entity-to-node attachment by identity.
+    private(set) var nodeHandles: [MockRclNode] = []
     private(set) var nodesDestroyed: [(name: String, namespace: String)] = []
     private(set) var publishersCreated: [(topic: String, typeName: String)] = []
     private(set) var publishedPayloads: [Data] = []
@@ -92,6 +97,10 @@ final class MockRclClient: RclClientProtocol, @unchecked Sendable {
 
     var createPublisherShouldThrow: TransportError?
     var createSubscriptionShouldThrow: TransportError?
+    /// Test hook: runs inside createSubscription before the handle is
+    /// returned — lets tests interleave a session close() into the
+    /// preflight-create-append window.
+    var onCreateSubscription: (() -> Void)?
 
     func createContext(domainId: Int32) throws {
         sync {
@@ -107,8 +116,12 @@ final class MockRclClient: RclClientProtocol, @unchecked Sendable {
     }
 
     func createNode(name: String, namespace: String) throws -> any RclNodeHandle {
-        sync { nodesCreated.append((name, namespace)) }
-        return MockRclNode(name: name, namespace: namespace)
+        let node = MockRclNode(name: name, namespace: namespace)
+        sync {
+            nodesCreated.append((name, namespace))
+            nodeHandles.append(node)
+        }
+        return node
     }
     func destroyNode(_ node: any RclNodeHandle) {
         guard let n = node as? MockRclNode else { return }
@@ -138,7 +151,9 @@ final class MockRclClient: RclClientProtocol, @unchecked Sendable {
         handler: @escaping @Sendable (Data, UInt64) -> Void
     ) throws -> any RclSubscriptionHandle {
         if let e = createSubscriptionShouldThrow { throw e }
-        let sub = MockRclSubscription(topic: topic, typeName: typeName, qos: qos, handler: handler)
+        onCreateSubscription?()
+        let sub = MockRclSubscription(
+            node: node, topic: topic, typeName: typeName, qos: qos, handler: handler)
         sync { subscriptionsCreated.append(sub) }
         return sub
     }

--- a/Tests/SwiftROS2TransportTests/Mocks/MockRclClient.swift
+++ b/Tests/SwiftROS2TransportTests/Mocks/MockRclClient.swift
@@ -32,6 +32,42 @@ final class MockRclPublisher: RclPublisherHandle, @unchecked Sendable {
     }
 }
 
+final class MockRclSubscription: RclSubscriptionHandle, @unchecked Sendable {
+    let topic: String
+    let typeName: String
+    let qos: TransportQoS
+    private let handler: @Sendable (Data, UInt64) -> Void
+    private let lock = NSLock()
+    private var destroyed = false
+
+    init(
+        topic: String, typeName: String, qos: TransportQoS,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) {
+        self.topic = topic
+        self.typeName = typeName
+        self.qos = qos
+        self.handler = handler
+    }
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !destroyed
+    }
+
+    func markDestroyed() {
+        lock.lock()
+        defer { lock.unlock() }
+        destroyed = true
+    }
+
+    /// Test hook: simulate the wait thread delivering one taken message.
+    func fire(_ data: Data, timestamp: UInt64) {
+        handler(data, timestamp)
+    }
+}
+
 final class MockRclClient: RclClientProtocol, @unchecked Sendable {
     private let lock = NSLock()
     private func sync<T>(_ b: () -> T) -> T {
@@ -49,8 +85,13 @@ final class MockRclClient: RclClientProtocol, @unchecked Sendable {
     private(set) var nodesDestroyed: [(name: String, namespace: String)] = []
     private(set) var publishersCreated: [(topic: String, typeName: String)] = []
     private(set) var publishedPayloads: [Data] = []
+    private(set) var subscriptionsCreated: [MockRclSubscription] = []
+    private(set) var subscriptionsDestroyed: [(topic: String, typeName: String)] = []
+    /// Teardown order log: "subscription:<topic>" / "node:<name>" / "context".
+    private(set) var teardownEvents: [String] = []
 
     var createPublisherShouldThrow: TransportError?
+    var createSubscriptionShouldThrow: TransportError?
 
     func createContext(domainId: Int32) throws {
         sync {
@@ -58,7 +99,12 @@ final class MockRclClient: RclClientProtocol, @unchecked Sendable {
             lastDomainId = domainId
         }
     }
-    func destroyContext() { sync { contextDestroyed = true } }
+    func destroyContext() {
+        sync {
+            contextDestroyed = true
+            teardownEvents.append("context")
+        }
+    }
 
     func createNode(name: String, namespace: String) throws -> any RclNodeHandle {
         sync { nodesCreated.append((name, namespace)) }
@@ -66,7 +112,10 @@ final class MockRclClient: RclClientProtocol, @unchecked Sendable {
     }
     func destroyNode(_ node: any RclNodeHandle) {
         guard let n = node as? MockRclNode else { return }
-        sync { nodesDestroyed.append((n.name, n.namespace)) }
+        sync {
+            nodesDestroyed.append((n.name, n.namespace))
+            teardownEvents.append("node:\(n.name)")
+        }
     }
 
     func createPublisher(
@@ -79,5 +128,27 @@ final class MockRclClient: RclClientProtocol, @unchecked Sendable {
 
     func publishSerialized(_ publisher: any RclPublisherHandle, data: Data) throws {
         sync { publishedPayloads.append(data) }
+    }
+
+    func createSubscription(
+        node: any RclNodeHandle,
+        typeName: String,
+        topic: String,
+        qos: TransportQoS,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any RclSubscriptionHandle {
+        if let e = createSubscriptionShouldThrow { throw e }
+        let sub = MockRclSubscription(topic: topic, typeName: typeName, qos: qos, handler: handler)
+        sync { subscriptionsCreated.append(sub) }
+        return sub
+    }
+
+    func destroySubscription(_ subscription: any RclSubscriptionHandle) {
+        guard let s = subscription as? MockRclSubscription else { return }
+        s.markDestroyed()
+        sync {
+            subscriptionsDestroyed.append((s.topic, s.typeName))
+            teardownEvents.append("subscription:\(s.topic)")
+        }
     }
 }

--- a/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
+++ b/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
@@ -90,6 +90,9 @@ final class RclTransportSessionTests: XCTestCase {
         XCTAssertEqual(client.subscriptionsCreated.first?.topic, "/imu")
         XCTAssertEqual(client.subscriptionsCreated.first?.typeName, "sensor_msgs/msg/Imu")
         XCTAssertEqual(client.subscriptionsCreated.first?.qos, qos)
+        // Node attachment by identity: the subscription must be created on the
+        // exact node handle registerNode produced, not a stale or wrong one.
+        XCTAssertTrue(client.subscriptionsCreated.first?.node === client.nodeHandles.first)
         XCTAssertEqual(sub.topic, "/imu")
         XCTAssertTrue(sub.isActive)
     }
@@ -133,6 +136,25 @@ final class RclTransportSessionTests: XCTestCase {
         try s.close()
         XCTAssertEqual(
             client.teardownEvents, ["subscription:/imu", "node:imu_node", "context"])
+    }
+
+    func testCreateSubscriberDuringCloseDestroysSubscriptionAndThrows() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        // Interleave close() into the preflight-create-append window: the
+        // just-created subscription must not escape teardown (wait thread
+        // joined via destroy) and the caller must see notConnected.
+        client.onCreateSubscription = { try? s.close() }
+        XCTAssertThrowsError(
+            try s.createSubscriber(
+                topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil,
+                qos: .sensorData, handler: { _, _ in })
+        ) { error in
+            guard case TransportError.notConnected = error else { return XCTFail("got \(error)") }
+        }
+        XCTAssertEqual(client.subscriptionsDestroyed.count, 1)
+        XCTAssertEqual(client.subscriptionsDestroyed.first?.topic, "/imu")
     }
 
     func testCreateSubscriberSurfacesUnsupportedTypeError() async throws {

--- a/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
+++ b/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
@@ -62,16 +62,94 @@ final class RclTransportSessionTests: XCTestCase {
         XCTAssertEqual(client.nodesDestroyed.first?.name, "imu_node")
     }
 
-    func testCreateSubscriberUnsupported() async throws {
+    // MARK: - Subscriber (M4)
+
+    func testCreateSubscriberRequiresNode() async throws {
         let s = try await openSession()
         XCTAssertThrowsError(
             try s.createSubscriber(
-                topic: "/t", typeName: "std_msgs/msg/String", typeHash: nil,
+                topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil,
                 qos: .sensorData, handler: { _, _ in })
         ) { error in
-            guard case TransportError.unsupportedFeature = error else {
+            guard case TransportError.subscriberCreationFailed = error else {
                 return XCTFail("got \(error)")
             }
+        }
+    }
+
+    func testCreateSubscriberAttachesToCurrentNodeAndPassesQoS() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        let qos = TransportQoS(
+            reliability: .bestEffort, durability: .transientLocal, history: .keepLast(5))
+        let sub = try s.createSubscriber(
+            topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil,
+            qos: qos, handler: { _, _ in })
+        XCTAssertEqual(client.subscriptionsCreated.count, 1)
+        XCTAssertEqual(client.subscriptionsCreated.first?.topic, "/imu")
+        XCTAssertEqual(client.subscriptionsCreated.first?.typeName, "sensor_msgs/msg/Imu")
+        XCTAssertEqual(client.subscriptionsCreated.first?.qos, qos)
+        XCTAssertEqual(sub.topic, "/imu")
+        XCTAssertTrue(sub.isActive)
+    }
+
+    func testSubscriberHandlerReceivesDataAndTimestamp() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        let received = Box<[(Data, UInt64)]>([])
+        _ = try s.createSubscriber(
+            topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil,
+            qos: .sensorData, handler: { data, ts in received.value.append((data, ts)) })
+        let cdr = Data([0x00, 0x01, 0x00, 0x00, 0xBE, 0xEF])
+        client.subscriptionsCreated[0].fire(cdr, timestamp: 42)
+        XCTAssertEqual(received.value.count, 1)
+        XCTAssertEqual(received.value.first?.0, cdr)
+        XCTAssertEqual(received.value.first?.1, 42)
+    }
+
+    func testSubscriberCloseDestroysExactlyOnce() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        let sub = try s.createSubscriber(
+            topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil,
+            qos: .sensorData, handler: { _, _ in })
+        try sub.close()
+        try sub.close()  // idempotent
+        XCTAssertFalse(sub.isActive)
+        XCTAssertEqual(client.subscriptionsDestroyed.count, 1)
+        XCTAssertEqual(client.subscriptionsDestroyed.first?.topic, "/imu")
+    }
+
+    func testCloseDestroysSubscribersBeforeNodesAndContext() async throws {
+        let client = MockRclClient()
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        _ = try s.createSubscriber(
+            topic: "/imu", typeName: "sensor_msgs/msg/Imu", typeHash: nil,
+            qos: .sensorData, handler: { _, _ in })
+        try s.close()
+        XCTAssertEqual(
+            client.teardownEvents, ["subscription:/imu", "node:imu_node", "context"])
+    }
+
+    func testCreateSubscriberSurfacesUnsupportedTypeError() async throws {
+        let client = MockRclClient()
+        client.createSubscriptionShouldThrow =
+            .subscriberCreationFailed("unsupported type: foo_msgs/msg/Bar")
+        let s = try await openSession(client)
+        try s.registerNode(name: "imu_node", namespace: "/ios")
+        XCTAssertThrowsError(
+            try s.createSubscriber(
+                topic: "/bar", typeName: "foo_msgs/msg/Bar", typeHash: nil,
+                qos: .sensorData, handler: { _, _ in })
+        ) { error in
+            guard case TransportError.subscriberCreationFailed(let msg) = error else {
+                return XCTFail("got \(error)")
+            }
+            XCTAssertTrue(msg.contains("unsupported type"))
         }
     }
 


### PR DESCRIPTION
## Summary

M4 (spec §19.3): subscription support on the `.rcl` backend — the largest wire-path parity gap. Received messages flow through the **existing byte seam**: `rcl_take_serialized_message` returns raw CDR (incl. encapsulation header) which feeds the existing `CDRDecoder` path in `Node.swift` untouched — the exact mirror of the M1 P1 publish decision. **No public API change** (all additions are `package`-level); 1.x freeze preserved.

### Design

- **C bridge** (`Sources/CRclBridge/rcl_subscription.c`): per-subscription pthread looping `rcl_wait` (100 ms) over a wait set (1 subscription + 1 stop guard condition), draining `rcl_take_serialized_message` until `TAKE_FAILED`, invoking the callback with bytes + `source_timestamp` (invalid → 0). Teardown: stop flag → trigger guard → `pthread_join` → fini → free (join-before-fini; destroy blocks until any in-flight callback returns). `crcl_node_s` stores its `rcl_context_t*` (Jazzy has no `rcl_node_get_context`).
- **Swift seam**: `RclClientProtocol.createSubscription/destroySubscription` + `RclSubscriptionHandle`; `RclClient` uses the `Unmanaged` C-trampoline + blocking-destroy pattern from `DDSClient`; `RclTransportSession.createSubscriber` with the publisher-style `currentNode` preflight; session `close()` destroys subscribers first.
- QoS: same four rmw assignments as the publisher path, on subscription default options.

### Review hardening (3-lens adversarial review, all findings fixed)

- **Self-destroy UAF (major):** `sub.cancel()` from an `onMessage` callback runs on the C wait thread; `pthread_join` would self-join (EDEADLK) and proceed to fini/free under the live thread. Now guarded via `pthread_equal` (error return, documented contract: negative = not destroyed, context must not be freed); `RclSubscriptionBox.close()` leaks the retained context instead of freeing it under a live thread when destroy fails.
- Drain loop now re-checks the stop flag per take, bounding destroy latency under sustained load.
- `createSubscriber` vs concurrent `close()` race: `appendSubscriber` re-checks `isOpen` under the lock and tears the orphan down (wait thread joined) before throwing — regression-tested with a close-during-create mock hook.

### Validation

- Ordinary CI surface: 157 tests green (new mock-based lifecycle/dispatch/QoS/close-ordering/race tests); swift-format clean.
- **`crcl-loopback` (new in-process gate, also wired into ci-rcl with ASan):** typed `rcl_publish` → `rcl_take_serialized` → `CDRDecoder` round-trip, 20/20 messages field-identical — green native + Mac Catalyst.
- **Live LAN verification (native macOS ⇄ Ubuntu 24.04 Jazzy host):** `RclSubscribeIntegrationTests` passed in 0.297 s — host `ros2 topic pub` `sensor_msgs/Temperature` at 10 Hz, macOS `.rcl` subscription received + decoded exact values (36.5 / 0.25 / "probe"). Combined with M3c's publish verification, both directions are now live-verified.
- `ci-rcl` dispatched on this branch (link in comments).

### Known limitations (documented, unchanged)

- Single-node binding (M1 `currentNode`) — seam carries no node identity; shared with the publisher path.
- Subscribable types = the generated typesupport registry (11 types post-M3c).
- Default `createNode` still requires `startParameterServices: false` on `.rcl` until services land (M7).