### PR TITLE
feat(rcl): zenoh rmw variant — rcl + rmw_zenoh_cpp + zenoh-c on Apple (M9)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -521,11 +521,27 @@ if canBuildDDS {
 
 // M0-only native-rcl spike: local CRos2Jazzy xcframework + rcl_init smoke
 // executable, gated behind SWIFT_ROS2_ENABLE_RCL=1 (Apple only).
+//
+// SWIFT_ROS2_RCL_RMW selects the rmw variant baked into the binary target:
+// "cyclonedds" (default) -> build/ros2/CRos2Jazzy.xcframework, or "zenoh" ->
+// build/ros2zenoh/CRos2JazzyZenoh.xcframework (rmw_zenoh_cpp + fastrtps
+// typesupport; build with `RMW_VARIANT=zenoh Scripts/build-ros2-xcframework.sh`).
+// Both variants expose the identical rcl C API under the same module name, so
+// every Swift target is variant-agnostic.
+let rclRmwVariant: String = {
+    let raw = Context.environment["SWIFT_ROS2_RCL_RMW"] ?? "cyclonedds"
+    guard ["cyclonedds", "zenoh"].contains(raw) else {
+        fatalError("SWIFT_ROS2_RCL_RMW must be 'cyclonedds' or 'zenoh'; got '\(raw)'")
+    }
+    return raw
+}()
 if enableRcl {
     targets.append(
         .binaryTarget(
             name: "CRos2Jazzy",
-            path: "build/ros2/CRos2Jazzy.xcframework"
+            path: rclRmwVariant == "zenoh"
+                ? "build/ros2zenoh/CRos2JazzyZenoh.xcframework"
+                : "build/ros2/CRos2Jazzy.xcframework"
         ))
     targets.append(
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -88,6 +88,29 @@ let releaseBaseURL = "https://github.com/youtalk/swift-ros2/releases/download/1.
 // smoke executable. Replaced by a URL+checksum binaryTarget in M3.
 let enableRcl = Context.environment["SWIFT_ROS2_ENABLE_RCL"] == "1" && targetOS == "apple"
 
+// SWIFT_ROS2_RCL_RMW selects the rmw variant baked into the RCL binary
+// target: "cyclonedds" (default) -> build/ros2/CRos2Jazzy.xcframework, or
+// "zenoh" -> build/ros2zenoh/CRos2JazzyZenoh.xcframework (rmw_zenoh_cpp +
+// fastrtps typesupport; build with
+// `RMW_VARIANT=zenoh Scripts/build-ros2-xcframework.sh`). Both variants
+// expose the identical rcl C API under the same module name, so every Swift
+// target is variant-agnostic.
+let rclRmwVariant: String = {
+    let raw = Context.environment["SWIFT_ROS2_RCL_RMW"] ?? "cyclonedds"
+    guard ["cyclonedds", "zenoh"].contains(raw) else {
+        fatalError("SWIFT_ROS2_RCL_RMW must be 'cyclonedds' or 'zenoh'; got '\(raw)'")
+    }
+    return raw
+}()
+
+// zenoh-pico (the wire path) and zenoh-c (bundled inside CRos2JazzyZenoh)
+// both export the standard zenoh C API, so they cannot link into one binary.
+// Selecting the zenoh rmw variant therefore carves the zenoh-pico wire family
+// (CZenohPico / CZenohBridge / SwiftROS2Zenoh + its tests) out of the build
+// graph; the umbrella's `.zenoh` transport arm compiles out via
+// `#if canImport(SwiftROS2Zenoh)` and throws unsupportedFeature at runtime.
+let dropZenohWire = enableRcl && rclRmwVariant == "zenoh"
+
 // Non-unix zenoh-pico platform backends shared between the Linux and
 // Android arms — both use the unix backend inside `src/system/unix`.
 let zenohPicoNonUnixBackends = [
@@ -167,7 +190,6 @@ var products: [Product] = [
     .library(name: "SwiftROS2Messages", targets: ["SwiftROS2Messages"]),
     .library(name: "SwiftROS2Wire", targets: ["SwiftROS2Wire"]),
     .library(name: "SwiftROS2Transport", targets: ["SwiftROS2Transport"]),
-    .library(name: "SwiftROS2Zenoh", targets: ["SwiftROS2Zenoh"]),
     .library(name: "SwiftROS2Gen", targets: ["SwiftROS2Gen"]),
     .executable(name: "swift-ros2-gen", targets: ["swift-ros2-gen"]),
     .plugin(name: "SwiftROS2GenPlugin", targets: ["SwiftROS2GenPlugin"]),
@@ -203,40 +225,6 @@ var targets: [Target] = [
         path: "Sources/SwiftROS2Transport"
     ),
 
-    // Native C FFI for zenoh-pico. Apple platforms receive the pre-built
-    // xcframework; Linux, Windows, and Android compile from source using
-    // the matching platform backend inside vendor/zenoh-pico.
-    cZenohPico,
-
-    // C bridge for zenoh-pico (Conduit-authored FFI shim).
-    .target(
-        name: "CZenohBridge",
-        dependencies: ["CZenohPico"],
-        path: "Sources/CZenohBridge",
-        sources: ["zenoh_bridge.c"],
-        publicHeadersPath: "include",
-        cSettings: [
-            .define("ZENOH_MACOS", to: "1", .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS])),
-            .define("ZENOH_LINUX", to: "1", .when(platforms: [.linux])),
-            .define("ZENOH_WINDOWS", to: "1", .when(platforms: [.windows])),
-            .define("ZENOH_ANDROID", to: "1", .when(platforms: [.android])),
-            .define("Z_FEATURE_LINK_TCP", to: "1"),
-            .define("Z_FEATURE_LIVELINESS", to: "1"),
-        ],
-        linkerSettings: [
-            .linkedLibrary("Ws2_32", .when(platforms: [.windows])),
-            .linkedLibrary("Iphlpapi", .when(platforms: [.windows])),
-        ]
-    ),
-
-    // Swift-facing Zenoh module — hosts ZenohClient, the default
-    // implementation of ZenohClientProtocol defined in SwiftROS2Transport.
-    .target(
-        name: "SwiftROS2Zenoh",
-        dependencies: ["CZenohBridge", "SwiftROS2Transport", "SwiftROS2Wire"],
-        path: "Sources/SwiftROS2Zenoh"
-    ),
-
     // Pure-Swift and Zenoh-path tests (available on every platform)
     .testTarget(
         name: "SwiftROS2CDRTests",
@@ -247,11 +235,6 @@ var targets: [Target] = [
         name: "SwiftROS2WireTests",
         dependencies: ["SwiftROS2Wire"],
         path: "Tests/SwiftROS2WireTests"
-    ),
-    .testTarget(
-        name: "SwiftROS2ZenohTests",
-        dependencies: ["SwiftROS2Zenoh"],
-        path: "Tests/SwiftROS2ZenohTests"
     ),
     .testTarget(
         name: "SwiftROS2TransportTests",
@@ -337,6 +320,54 @@ var targets: [Target] = [
         path: "Tests/SwiftROS2GenPluginTests"
     ),
 ]
+
+// zenoh-pico wire family — every platform EXCEPT the zenoh-rmw RCL variant
+// (symbol collision with zenoh-c; see `dropZenohWire` above).
+if !dropZenohWire {
+    products.append(.library(name: "SwiftROS2Zenoh", targets: ["SwiftROS2Zenoh"]))
+    targets.append(contentsOf: [
+        // Native C FFI for zenoh-pico. Apple platforms receive the pre-built
+        // xcframework; Linux, Windows, and Android compile from source using
+        // the matching platform backend inside vendor/zenoh-pico.
+        cZenohPico,
+
+        // C bridge for zenoh-pico (Conduit-authored FFI shim).
+        .target(
+            name: "CZenohBridge",
+            dependencies: ["CZenohPico"],
+            path: "Sources/CZenohBridge",
+            sources: ["zenoh_bridge.c"],
+            publicHeadersPath: "include",
+            cSettings: [
+                .define(
+                    "ZENOH_MACOS", to: "1",
+                    .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS])),
+                .define("ZENOH_LINUX", to: "1", .when(platforms: [.linux])),
+                .define("ZENOH_WINDOWS", to: "1", .when(platforms: [.windows])),
+                .define("ZENOH_ANDROID", to: "1", .when(platforms: [.android])),
+                .define("Z_FEATURE_LINK_TCP", to: "1"),
+                .define("Z_FEATURE_LIVELINESS", to: "1"),
+            ],
+            linkerSettings: [
+                .linkedLibrary("Ws2_32", .when(platforms: [.windows])),
+                .linkedLibrary("Iphlpapi", .when(platforms: [.windows])),
+            ]
+        ),
+
+        // Swift-facing Zenoh module — hosts ZenohClient, the default
+        // implementation of ZenohClientProtocol defined in SwiftROS2Transport.
+        .target(
+            name: "SwiftROS2Zenoh",
+            dependencies: ["CZenohBridge", "SwiftROS2Transport", "SwiftROS2Wire"],
+            path: "Sources/SwiftROS2Zenoh"
+        ),
+        .testTarget(
+            name: "SwiftROS2ZenohTests",
+            dependencies: ["SwiftROS2Zenoh"],
+            path: "Tests/SwiftROS2ZenohTests"
+        ),
+    ])
+}
 
 // DDS path + the SwiftROS2 umbrella + examples + umbrella-level tests.
 // These are only included on platforms where CycloneDDS is consumable
@@ -430,8 +461,11 @@ if canBuildDDS {
     ])
 
     var swiftROS2Deps: [Target.Dependency] = [
-        "SwiftROS2Messages", "SwiftROS2Transport", "SwiftROS2Wire", "SwiftROS2Zenoh", "SwiftROS2DDS",
+        "SwiftROS2Messages", "SwiftROS2Transport", "SwiftROS2Wire", "SwiftROS2DDS",
     ]
+    if !dropZenohWire {
+        swiftROS2Deps.append("SwiftROS2Zenoh")
+    }
     var swiftROS2SwiftSettings: [SwiftSetting] = []
     if enableRcl {
         swiftROS2Deps.append("SwiftROS2RCL")
@@ -522,19 +556,6 @@ if canBuildDDS {
 // M0-only native-rcl spike: local CRos2Jazzy xcframework + rcl_init smoke
 // executable, gated behind SWIFT_ROS2_ENABLE_RCL=1 (Apple only).
 //
-// SWIFT_ROS2_RCL_RMW selects the rmw variant baked into the binary target:
-// "cyclonedds" (default) -> build/ros2/CRos2Jazzy.xcframework, or "zenoh" ->
-// build/ros2zenoh/CRos2JazzyZenoh.xcframework (rmw_zenoh_cpp + fastrtps
-// typesupport; build with `RMW_VARIANT=zenoh Scripts/build-ros2-xcframework.sh`).
-// Both variants expose the identical rcl C API under the same module name, so
-// every Swift target is variant-agnostic.
-let rclRmwVariant: String = {
-    let raw = Context.environment["SWIFT_ROS2_RCL_RMW"] ?? "cyclonedds"
-    guard ["cyclonedds", "zenoh"].contains(raw) else {
-        fatalError("SWIFT_ROS2_RCL_RMW must be 'cyclonedds' or 'zenoh'; got '\(raw)'")
-    }
-    return raw
-}()
 if enableRcl {
     targets.append(
         .binaryTarget(
@@ -543,14 +564,28 @@ if enableRcl {
                 ? "build/ros2zenoh/CRos2JazzyZenoh.xcframework"
                 : "build/ros2/CRos2Jazzy.xcframework"
         ))
+    // rmw_cyclonedds_cpp / rcpputils in CRos2Jazzy are C++, so every target
+    // that links the merged archive needs the C++ runtime. The zenoh variant
+    // additionally bundles zenoh-c's Rust staticlib, whose rustls/ring TLS,
+    // network monitoring, and serialport (transport_serial feature) code
+    // require these system frameworks at final link. Applied to CRclBridge
+    // AND to targets that depend on CRos2Jazzy directly (rcl-smoke).
+    let rclBridgeLinkerSettings: [LinkerSetting] =
+        rclRmwVariant == "zenoh"
+        ? [
+            .linkedLibrary("c++"),
+            .linkedFramework("Security"),
+            .linkedFramework("SystemConfiguration"),
+            .linkedFramework("CoreFoundation"),
+            .linkedFramework("IOKit"),
+        ]
+        : [.linkedLibrary("c++")]
     targets.append(
         .executableTarget(
             name: "rcl-smoke",
             dependencies: ["CRos2Jazzy"],
             path: "Sources/Examples/RclSmoke",
-            // rmw_cyclonedds_cpp / rcpputils / rmw_dds_common in CRos2Jazzy are
-            // C++; a C executable target must link the C++ runtime explicitly.
-            linkerSettings: [.linkedLibrary("c++")]
+            linkerSettings: rclBridgeLinkerSettings
         ))
     products.append(.executable(name: "rcl-smoke", targets: ["rcl-smoke"]))
     targets.append(
@@ -560,8 +595,7 @@ if enableRcl {
             path: "Sources/CRclBridge",
             sources: ["rcl_bridge.c", "rcl_subscription.c", "Generated"],
             publicHeadersPath: "include",
-            // rmw_cyclonedds_cpp / rcpputils in CRos2Jazzy are C++.
-            linkerSettings: [.linkedLibrary("c++")]
+            linkerSettings: rclBridgeLinkerSettings
         ))
     targets.append(
         .executableTarget(

--- a/Scripts/build-ros2-xcframework.sh
+++ b/Scripts/build-ros2-xcframework.sh
@@ -1,25 +1,58 @@
 #!/usr/bin/env bash
-# Build the real ROS 2 (rcl + rmw_cyclonedds_cpp + rosidl introspection)
-# C/C++ stack for Apple slices and assemble CRos2Jazzy.xcframework.
-# Usage: Scripts/build-ros2-xcframework.sh maccatalyst iphoneos
+# Build the real ROS 2 C/C++ stack for Apple slices and assemble an
+# xcframework. Two rmw variants (select with RMW_VARIANT):
+#   cyclonedds (default) — rcl + rmw_cyclonedds_cpp + rosidl introspection
+#                          typesupport -> build/ros2/CRos2Jazzy.xcframework
+#   zenoh                — rcl + rmw_zenoh_cpp (no-SHM patch set under
+#                          Scripts/ros2/patches/rmw_zenoh) + rosidl fastrtps
+#                          typesupport (rmw_zenoh hard-codes it) + prebuilt
+#                          zenoh-c staticlib (Rust; needs rustup/cargo on
+#                          PATH) -> build/ros2zenoh/CRos2JazzyZenoh.xcframework
+# Usage: [RMW_VARIANT=zenoh] Scripts/build-ros2-xcframework.sh maccatalyst iphoneos
 set -euo pipefail
 
 # Use BASH_SOURCE (not $0) so ROOT resolves correctly whether the script is
 # executed directly or `source`d (e.g. the verification commands that run
 # individual functions via `bash -c 'source ...; cross_build ...'`).
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BUILD="$ROOT/build/ros2"
+RMW_VARIANT="${RMW_VARIANT:-cyclonedds}"
+case "$RMW_VARIANT" in
+  cyclonedds)
+    BUILD="$ROOT/build/ros2"
+    XCFW_NAME="CRos2Jazzy"
+    RMW_PKG=rmw_cyclonedds_cpp
+    TS_C=rosidl_typesupport_introspection_c
+    TS_CPP=rosidl_typesupport_introspection_cpp
+    META="$ROOT/Scripts/ros2/colcon-defaults.meta"
+    ;;
+  zenoh)
+    BUILD="$ROOT/build/ros2zenoh"
+    XCFW_NAME="CRos2JazzyZenoh"
+    RMW_PKG=rmw_zenoh_cpp
+    # rmw_zenoh_cpp resolves message types through the fastrtps typesupport
+    # only (type_support_common.hpp hard-codes the identifier), so the single
+    # static typesupport pin flips from introspection to fastrtps. The Swift
+    # bridge is unaffected — it resolves handles via the rosidl_typesupport_c
+    # dispatcher macros, which statically bind to whichever backend is pinned.
+    TS_C=rosidl_typesupport_fastrtps_c
+    TS_CPP=rosidl_typesupport_fastrtps_cpp
+    META="$ROOT/Scripts/ros2/colcon-defaults-zenoh.meta"
+    ;;
+  *) echo "RMW_VARIANT must be 'cyclonedds' or 'zenoh'; got '$RMW_VARIANT'" >&2; exit 1 ;;
+esac
 SRC="$BUILD/src_ws"
-HOST="$BUILD/host_ws"
+# The host generators and the python venv are rmw-agnostic; both variants
+# share the cyclonedds tree's copies so the zenoh variant never rebuilds them.
+HOST="$ROOT/build/ros2/host_ws"
+VENV="$ROOT/build/ros2/venv"
 TOOLCHAIN="$ROOT/Scripts/ros2/ios-cmake/ios.toolchain.cmake"
-META="$ROOT/Scripts/ros2/colcon-defaults.meta"
 DEPLOY_IOS=16.0
 # leetal ios-cmake enforces a Mac Catalyst minimum deployment target of 13.1.
 DEPLOY_MAC=13.1
 # visionOS versions are 1.x — passing the iOS target (16.0) to the xros /
 # xrsimulator slices would be rejected by the visionOS SDK.
 DEPLOY_VISIONOS=1.0
-PKGS_UP_TO=(rcl rmw_cyclonedds_cpp builtin_interfaces std_msgs geometry_msgs sensor_msgs)
+PKGS_UP_TO=(rcl "$RMW_PKG" builtin_interfaces std_msgs geometry_msgs sensor_msgs)
 # C++ test-only / lint vendor packages get dragged into the --packages-up-to
 # closure via <test_depend>, but never link into the runtime libraries. They
 # build shared libs / executables (e.g. osrf_testing_tools_cpp's malloc
@@ -70,8 +103,15 @@ IGNORE_SUBTREES=(
 ignore_unbuildable() {
   local rel
   for rel in "${IGNORE_SUBTREES[@]}"; do
-    [[ -d "$SRC/$rel" ]] && touch "$SRC/$rel/COLCON_IGNORE"
+    if [[ -d "$SRC/$rel" ]]; then touch "$SRC/$rel/COLCON_IGNORE"; fi
   done
+  if [[ "$RMW_VARIANT" == zenoh ]]; then
+    # The zenoh variant carries no CycloneDDS at all — drop the rmw and the
+    # middleware so the slice build never compiles them.
+    for rel in ros2/rmw_cyclonedds eclipse-cyclonedds/cyclonedds; do
+      if [[ -d "$SRC/$rel" ]]; then touch "$SRC/$rel/COLCON_IGNORE"; fi
+    done
+  fi
 }
 
 # CycloneDDS's POSIX ifaddrs backend includes <net/if_media.h> on Apple to
@@ -105,18 +145,48 @@ mkdir -p "$BUILD"
 export CMAKE_POLICY_VERSION_MINIMUM=3.5
 
 setup_venv() {
-  [[ -d "$BUILD/venv" ]] && return 0
-  python3.11 -m venv "$BUILD/venv"
+  [[ -d "$VENV" ]] && return 0
+  python3.11 -m venv "$VENV"
   # shellcheck disable=SC1091
-  source "$BUILD/venv/bin/activate"
+  source "$VENV/bin/activate"
   pip install -r "$ROOT/Scripts/ros2/requirements.txt"
 }
 
 import_sources() {
-  [[ -d "$SRC/ros2/rcl" ]] && return 0
-  mkdir -p "$SRC"
-  git clone --depth 1 --branch release-jazzy-20250430 https://github.com/ros2/ros2.git "$BUILD/ros2-meta"
-  ( cd "$SRC" && vcs import < "$BUILD/ros2-meta/ros2.repos" )
+  if [[ ! -d "$SRC/ros2/rcl" ]]; then
+    mkdir -p "$SRC"
+    git clone --depth 1 --branch release-jazzy-20250430 https://github.com/ros2/ros2.git "$BUILD/ros2-meta"
+    ( cd "$SRC" && vcs import < "$BUILD/ros2-meta/ros2.repos" )
+  fi
+  import_zenoh_sources
+}
+
+# rmw_zenoh jazzy pin (0.2.9 line) — the commit the no-SHM patch set under
+# Scripts/ros2/patches/rmw_zenoh was authored against.
+RMW_ZENOH_PIN=fe3553c7c127273280617d3d778859f22c4c3eb7
+
+import_zenoh_sources() {
+  [[ "$RMW_VARIANT" == zenoh ]] || return 0
+  local rz="$SRC/ros2/rmw_zenoh"
+  [[ -d "$rz" ]] && return 0
+  # rmw_zenoh is not in the jazzy ros2.repos set — clone + pin it explicitly.
+  git clone --branch jazzy --single-branch https://github.com/ros2/rmw_zenoh.git "$rz"
+  git -C "$rz" checkout "$RMW_ZENOH_PIN"
+  # zenoh's shared-memory subsystem hard-fails to compile for target_os=ios
+  # and rmw_zenoh_cpp has no no-SHM build mode; the patch set guards every
+  # SHM use behind Z_FEATURE_SHARED_MEMORY (absent in our zenoh-c build),
+  # makes the library static, and skips the rmw_zenohd executable when
+  # cross-compiling.
+  local p
+  for p in "$ROOT/Scripts/ros2/patches/rmw_zenoh"/*.patch; do
+    git -C "$rz" apply "$p"
+  done
+  # zenoh_cpp_vendor (an ament_vendor cargo wrapper) is replaced by the
+  # prebuilt per-slice zenoh-c prefix (build_zenohc). COLCON_IGNORE makes
+  # colcon treat it as external, so rmw_zenoh_cpp's
+  # find_package(zenoh_cpp_vendor) resolves through CMAKE_PREFIX_PATH to the
+  # hand-assembled config instead of driving cargo inside the colcon graph.
+  touch "$rz/zenoh_cpp_vendor/COLCON_IGNORE"
 }
 
 build_host_tools() {
@@ -142,12 +212,66 @@ slice_platform() { case "$1" in
   xrsimulator) echo "SIMULATOR_VISIONOS $DEPLOY_VISIONOS" ;;
   *) echo "unknown slice: $1" >&2; return 1 ;; esac; }
 
+# zenoh-c / zenoh-cpp pins from rmw_zenoh jazzy's zenoh_cpp_vendor
+# (zenoh-c 1.8.0 + fixes; zenoh-cpp is the header-only C++ API).
+ZENOHC_PIN=05bd370343b5161ca9269649b9a914c9c2dc4170
+ZENOHCPP_PIN=af381b420cc8837ac7da42c9984594ef8f110e90
+
+zenohc_triple() { case "$1" in
+  maccatalyst) echo aarch64-apple-ios-macabi ;;
+  macosx)      echo aarch64-apple-darwin ;;
+  iphoneos)    echo aarch64-apple-ios ;;
+  iphonesimulator) echo aarch64-apple-ios-sim ;;
+  *) echo "zenoh variant: no stable Rust std for slice '$1'" >&2; return 1 ;; esac; }
+
+# Cross-build zenoh-c (Rust staticlib) and assemble the CMake prefix that
+# satisfies rmw_zenoh_cpp's find_package(zenoh_cpp_vendor / zenohc /
+# zenohcxx). The feature set is rmw_zenoh's pin minus shared-memory: zenoh-shm
+# gates platform support and compile_error!s for iOS targets, which is exactly
+# what the patch set compensates for on the C++ side.
+build_zenohc() {  # $1 = slice -> $BUILD/$slice/zenohc-install
+  local slice="$1"
+  local triple; triple="$(zenohc_triple "$slice")"
+  local zc="$BUILD/zenoh-c" zcpp="$BUILD/zenoh-cpp"
+  local out="$BUILD/$slice/zenohc-install"
+  [[ -f "$out/lib/libzenohc.a" ]] && return 0
+  if [[ ! -d "$zc" ]]; then
+    git clone https://github.com/eclipse-zenoh/zenoh-c.git "$zc"
+    git -C "$zc" checkout "$ZENOHC_PIN"
+  fi
+  if [[ ! -d "$zcpp" ]]; then
+    git clone https://github.com/eclipse-zenoh/zenoh-cpp.git "$zcpp"
+    git -C "$zcpp" checkout "$ZENOHCPP_PIN"
+  fi
+  rustup target add "$triple"
+  ( cd "$zc" && cargo build --release -j 4 --target "$triple" \
+      --features unstable --features transport_serial )
+  rm -rf "$out"
+  mkdir -p "$out/lib/cmake" "$out/share/zenoh_cpp_vendor/cmake"
+  # cargo's build.rs regenerates the header set (zenoh_configure.h carries the
+  # feature macros — Z_FEATURE_SHARED_MEMORY must be absent) into the target
+  # dir; zenoh-cpp contributes the header-only C++ API.
+  cp -R "$zc/target/$triple/release/include" "$out/include"
+  cp -R "$zcpp/include/zenoh" "$out/include/zenoh"
+  cp "$zcpp/include/zenoh.hxx" "$out/include/"
+  cp "$zc/target/$triple/release/libzenohc.a" "$out/lib/"
+  cp -R "$ROOT/Scripts/ros2/zenohc-cmake/zenohc" "$out/lib/cmake/zenohc"
+  cp -R "$ROOT/Scripts/ros2/zenohc-cmake/zenohcxx" "$out/lib/cmake/zenohcxx"
+  cp "$ROOT/Scripts/ros2/zenohc-cmake/zenoh_cpp_vendor/zenoh_cpp_vendorConfig.cmake" \
+     "$out/share/zenoh_cpp_vendor/cmake/"
+}
+
 cross_build() {  # $1 = slice, $2... = extra --packages-up-to
   local slice="$1"; shift
   read -r platform deploy < <(slice_platform "$slice")
   local sb="$BUILD/$slice"
   ignore_unbuildable
   patch_sources
+  local extra_cmake=()
+  if [[ "$RMW_VARIANT" == zenoh ]]; then
+    build_zenohc "$slice"
+    extra_cmake+=(-DCMAKE_PREFIX_PATH="$sb/zenohc-install")
+  fi
   # ament_vendor forwards CMAKE_TOOLCHAIN_FILE to its nested ExternalProject
   # builds (e.g. libyaml) but NOT the toolchain's required PLATFORM var, so the
   # nested cmake bails with "PLATFORM argument not set". The leetal toolchain
@@ -155,15 +279,15 @@ cross_build() {  # $1 = slice, $2... = extra --packages-up-to
   # variable — it propagates through colcon -> make -> ExternalProject -> cmake.
   export _PLATFORM="$platform"
   # shellcheck disable=SC1091
-  source "$BUILD/venv/bin/activate"
+  source "$VENV/bin/activate"
   # colcon-generated setup.sh references unbound vars (COLCON_CURRENT_PREFIX);
   # relax `set -u` only while sourcing it, then restore strict mode.
   set +u
   # shellcheck disable=SC1091
   source "$HOST/install/setup.sh"
   set -u
-  STATIC_ROSIDL_TYPESUPPORT_C=rosidl_typesupport_introspection_c \
-  STATIC_ROSIDL_TYPESUPPORT_CPP=rosidl_typesupport_introspection_cpp \
+  STATIC_ROSIDL_TYPESUPPORT_C="$TS_C" \
+  STATIC_ROSIDL_TYPESUPPORT_CPP="$TS_CPP" \
   colcon --log-base "$sb/log" build \
     --base-paths "$SRC" \
     --build-base "$sb/build" --install-base "$sb/install" \
@@ -177,7 +301,8 @@ cross_build() {  # $1 = slice, $2... = extra --packages-up-to
       -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
       -DCMAKE_MAKE_PROGRAM=/usr/bin/make \
       -DFORCE_BUILD_VENDOR_PKG=ON \
-      -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+      -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release \
+      ${extra_cmake[@]+"${extra_cmake[@]}"}
 }
 
 merge_slice() {  # $1 = slice -> build/ros2/<slice>/merged/{librclros.a,include}
@@ -202,6 +327,11 @@ merge_slice() {  # $1 = slice -> build/ros2/<slice>/merged/{librclros.a,include}
   shopt -s nullglob
   for a in "$sb/install/lib/"*.a "$sb/install/opt/"*/lib/*.a; do archives+=("$a"); done
   shopt -u nullglob
+  # The zenoh variant links the prebuilt Rust staticlib into the merged
+  # archive so consumers still link exactly one library.
+  if [[ "$RMW_VARIANT" == zenoh ]]; then
+    archives+=("$sb/zenohc-install/lib/libzenohc.a")
+  fi
   libtool -static -o "$out/librclros.a" "${archives[@]}"
   cp -R "$sb/install/include" "$out/include"
   # ROS 2 installs headers doubled: include/<pkg>/<pkg>/foo.h, consumed as
@@ -244,7 +374,7 @@ merge_slice() {  # $1 = slice -> build/ros2/<slice>/merged/{librclros.a,include}
 }
 
 assemble_xcframework() {  # $@ = slices
-  local out="$BUILD/CRos2Jazzy.xcframework"
+  local out="$BUILD/$XCFW_NAME.xcframework"
   rm -rf "$out"
   local args=()
   local slice m
@@ -257,6 +387,19 @@ assemble_xcframework() {  # $@ = slices
   xcodebuild -create-xcframework "${args[@]}" -output "$out"
 }
 
+# rmw_zenoh_cpp resolves its default session config through the ament index
+# at runtime; apps and the local smoke point AMENT_PREFIX_PATH at this mini
+# prefix (index marker + the json5 configs).
+assemble_zenoh_ament_prefix() {
+  [[ "$RMW_VARIANT" == zenoh ]] || return 0
+  local ap="$BUILD/ament-prefix"
+  mkdir -p "$ap/share/ament_index/resource_index/packages" \
+           "$ap/share/rmw_zenoh_cpp/config"
+  touch "$ap/share/ament_index/resource_index/packages/rmw_zenoh_cpp"
+  cp "$SRC/ros2/rmw_zenoh/rmw_zenoh_cpp/config/"*.json5 \
+     "$ap/share/rmw_zenoh_cpp/config/"
+}
+
 # Top-level dispatch when invoked directly (not sourced) with slice args.
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   setup_venv
@@ -267,4 +410,5 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     merge_slice "$slice"
   done
   assemble_xcframework "$@"
+  assemble_zenoh_ament_prefix
 fi

--- a/Scripts/ros2/colcon-defaults-zenoh.meta
+++ b/Scripts/ros2/colcon-defaults-zenoh.meta
@@ -1,0 +1,13 @@
+{
+  "names": {
+    "rmw_implementation": {
+      "cmake-args": [
+        "-DRMW_IMPLEMENTATION=rmw_zenoh_cpp",
+        "-DRMW_IMPLEMENTATION_DISABLE_RUNTIME_SELECTION=ON"
+      ]
+    },
+    "rcl": {
+      "cmake-args": ["-DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop"]
+    }
+  }
+}

--- a/Scripts/ros2/patches/rmw_zenoh/0001-cmakelists-static-lib-and-skip-zenohd-when-crosscompiling.patch
+++ b/Scripts/ros2/patches/rmw_zenoh/0001-cmakelists-static-lib-and-skip-zenohd-when-crosscompiling.patch
@@ -1,0 +1,71 @@
+diff --git a/rmw_zenoh_cpp/CMakeLists.txt b/rmw_zenoh_cpp/CMakeLists.txt
+index 80f3751..ec36ba8 100644
+--- a/rmw_zenoh_cpp/CMakeLists.txt
++++ b/rmw_zenoh_cpp/CMakeLists.txt
+@@ -24,7 +24,10 @@ find_package(rmw REQUIRED)
+ find_package(tracetools REQUIRED)
+ find_package(zenoh_cpp_vendor REQUIRED)
+ 
+-add_library(rmw_zenoh_cpp SHARED
++# No explicit SHARED/STATIC keyword: let BUILD_SHARED_LIBS decide so the
++# library can be built as a static archive for platforms that disallow
++# runtime-loaded shared libraries (e.g. iOS / Mac Catalyst).
++add_library(rmw_zenoh_cpp
+   src/detail/attachment_helpers.cpp
+   src/detail/cdr.cpp
+   src/detail/event.cpp
+@@ -124,27 +127,32 @@ install(
+   DESTINATION include
+ )
+ 
+-add_executable(rmw_zenohd
+-  src/detail/liveliness_utils.cpp
+-  src/detail/logging.cpp
+-  src/detail/qos.cpp
+-  src/detail/simplified_xxhash3.cpp
+-  src/detail/zenoh_config.cpp
+-  src/zenohd/main.cpp
+-)
+-
+-target_link_libraries(rmw_zenohd
+-  PRIVATE
+-    ament_index_cpp::ament_index_cpp
+-    rcutils::rcutils
+-    rcpputils::rcpputils
+-    rmw::rmw
+-    zenohcxx::zenohc
+-)
+-
+-install(
+-  TARGETS rmw_zenohd
+-  DESTINATION lib/${PROJECT_NAME}
+-)
++# The rmw_zenohd router executable is a host-side tool; skip it when
++# cross-compiling (e.g. for iOS / Mac Catalyst, where standalone
++# executables cannot be deployed anyway).
++if(NOT CMAKE_CROSSCOMPILING)
++  add_executable(rmw_zenohd
++    src/detail/liveliness_utils.cpp
++    src/detail/logging.cpp
++    src/detail/qos.cpp
++    src/detail/simplified_xxhash3.cpp
++    src/detail/zenoh_config.cpp
++    src/zenohd/main.cpp
++  )
++
++  target_link_libraries(rmw_zenohd
++    PRIVATE
++      ament_index_cpp::ament_index_cpp
++      rcutils::rcutils
++      rcpputils::rcpputils
++      rmw::rmw
++      zenohcxx::zenohc
++  )
++
++  install(
++    TARGETS rmw_zenohd
++    DESTINATION lib/${PROJECT_NAME}
++  )
++endif()
+ 
+ ament_package()

--- a/Scripts/ros2/patches/rmw_zenoh/0001-cmakelists-static-lib-and-skip-zenohd-when-crosscompiling.patch
+++ b/Scripts/ros2/patches/rmw_zenoh/0001-cmakelists-static-lib-and-skip-zenohd-when-crosscompiling.patch
@@ -1,5 +1,5 @@
 diff --git a/rmw_zenoh_cpp/CMakeLists.txt b/rmw_zenoh_cpp/CMakeLists.txt
-index 80f3751..ec36ba8 100644
+index 80f3751..8f914a2 100644
 --- a/rmw_zenoh_cpp/CMakeLists.txt
 +++ b/rmw_zenoh_cpp/CMakeLists.txt
 @@ -24,7 +24,10 @@ find_package(rmw REQUIRED)
@@ -14,7 +14,30 @@ index 80f3751..ec36ba8 100644
    src/detail/attachment_helpers.cpp
    src/detail/cdr.cpp
    src/detail/event.cpp
-@@ -124,27 +127,32 @@ install(
+@@ -87,6 +90,22 @@ target_compile_definitions(rmw_zenoh_cpp
+ )
+ 
+ ament_export_targets(export_rmw_zenoh_cpp)
++# Static-build addition: with BUILD_SHARED_LIBS=OFF the PRIVATE link
++# dependencies above surface in the exported link interface (as
++# $<LINK_ONLY:...>), so consumers must be able to resolve those imported
++# targets. Exporting the dependencies makes the generated package config
++# find_dependency() each of them.
++ament_export_dependencies(
++  ament_index_cpp
++  fastcdr
++  rcpputils
++  rcutils
++  rosidl_typesupport_fastrtps_c
++  rosidl_typesupport_fastrtps_cpp
++  rmw
++  tracetools
++  zenoh_cpp_vendor
++)
+ 
+ register_rmw_implementation(
+   "c:rosidl_typesupport_c:rosidl_typesupport_fastrtps_c:rosidl_typesupport_introspection_c"
+@@ -124,27 +143,32 @@ install(
    DESTINATION include
  )
  

--- a/Scripts/ros2/patches/rmw_zenoh/0002-zenoh_utils-hpp-guard-ShmContext-decl.patch
+++ b/Scripts/ros2/patches/rmw_zenoh/0002-zenoh_utils-hpp-guard-ShmContext-decl.patch
@@ -1,0 +1,27 @@
+diff --git a/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp b/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp
+index 216421f..687118c 100644
+--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp
++++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp
+@@ -102,6 +102,7 @@ private:
+ };
+ 
+ ///=============================================================================
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+ struct ShmContext
+ {
+   size_t msgsize_threshold;
+@@ -110,6 +111,14 @@ struct ShmContext
+ 
+   std::optional<zenoh::SharedShmProvider> get_shm_provider(zenoh::Session & session);
+ };
++#else
++// Shared memory is not available in this zenoh-c build (e.g. iOS / Mac
++// Catalyst, where zenoh-shm does not compile). Keep an opaque forward
++// declaration so `ShmContext *` parameters and
++// `std::shared_ptr<ShmContext>` members still compile; the pointer is
++// always null and never dereferenced when SHM is compiled out.
++struct ShmContext;
++#endif
+ 
+ ///=============================================================================
+ class BufferPool

--- a/Scripts/ros2/patches/rmw_zenoh/0003-zenoh_utils-cpp-guard-ShmContext-impl.patch
+++ b/Scripts/ros2/patches/rmw_zenoh/0003-zenoh_utils-cpp-guard-ShmContext-impl.patch
@@ -1,0 +1,20 @@
+diff --git a/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp b/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
+index c54b8a8..be72d54 100644
+--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
++++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
+@@ -126,6 +126,7 @@ bool Payload::empty() const
+ }
+ 
+ ///=============================================================================
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+ // Create Layout for provider's memory
+ // Provider's alignment is 1 (=2^0) bytes as we are going to make only 1-byte aligned allocations
+ // TODO(yellowhatter): use zenoh_shm_message_size_threshold as base for alignment
+@@ -141,6 +142,7 @@ std::optional<zenoh::SharedShmProvider> ShmContext::get_shm_provider(zenoh::Sess
+   }
+   return std::nullopt;
+ }
++#endif  // Z_FEATURE_SHARED_MEMORY && Z_FEATURE_UNSTABLE_API
+ 
+ 
+ ///=============================================================================

--- a/Scripts/ros2/patches/rmw_zenoh/0004-rmw_publisher_data-cpp-guard-shm-alloc-paths.patch
+++ b/Scripts/ros2/patches/rmw_zenoh/0004-rmw_publisher_data-cpp-guard-shm-alloc-paths.patch
@@ -1,0 +1,81 @@
+diff --git a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+index a7262bb..f0d379a 100644
+--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
++++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+@@ -235,7 +235,14 @@ rmw_ret_t PublisherData::publish(
+   rcutils_allocator_t * allocator = &rmw_node_->context->options.allocator;
+ 
+   // Optional shared memory buffer
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+   std::optional<zenoh::ZShmMut> shm_buf = std::nullopt;
++#else
++  // SHM compiled out: keep a never-engaged placeholder so the surrounding
++  // allocation / cleanup logic stays identical.
++  std::optional<std::nullptr_t> shm_buf = std::nullopt;
++  static_cast<void>(shm);
++#endif
+   // Optional buffer reused for serialization from the buffer pool
+   std::optional<BufferPool::Buffer> pool_buf = std::nullopt;
+ 
+@@ -247,6 +254,7 @@ rmw_ret_t PublisherData::publish(
+       allocator->deallocate(msg_bytes, allocator->state);
+     });
+ 
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+   // Get memory from SHM buffer if available.
+   if (shm && max_data_length >= shm->msgsize_threshold) {
+     if (auto shm_provider = shm->get_shm_provider(*sess_)) {
+@@ -269,6 +277,7 @@ rmw_ret_t PublisherData::publish(
+         "rmw_zenoh_cpp", "SHM provider is not yet available, fallback to non-SHM");
+     }
+   }
++#endif  // Z_FEATURE_SHARED_MEMORY && Z_FEATURE_UNSTABLE_API
+ 
+   if (!shm_buf.has_value()) {
+     // Try to get memory from the serialization buffer pool.
+@@ -312,9 +321,13 @@ rmw_ret_t PublisherData::publish(
+     sequence_number_++, source_timestamp, entity_->copy_gid()).serialize_to_zbytes();
+ 
+   zenoh::Bytes payload;
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+   if (shm_buf.has_value()) {
+     payload = zenoh::Bytes(std::move(*shm_buf));
+   } else if (pool_buf.has_value() && pool_buf.value().data) {
++#else
++  if (pool_buf.has_value() && pool_buf.value().data) {
++#endif
+     auto deleter = [buffer_pool = context_impl->serialization_buffer_pool(),
+         buffer = pool_buf](uint8_t *) {
+         buffer_pool->deallocate(buffer.value());
+@@ -359,8 +372,12 @@ rmw_ret_t PublisherData::publish_serialized_message(
+     return RMW_RET_ERROR;
+   }
+ 
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+   // Optional shared memory buffer
+   std::optional<zenoh::ZShmMut> shm_buf = std::nullopt;
++#else
++  static_cast<void>(shm);
++#endif
+ 
+   std::lock_guard<std::mutex> lock(mutex_);
+ 
+@@ -374,6 +391,7 @@ rmw_ret_t PublisherData::publish_serialized_message(
+   opts.put_options.attachment = rmw_zenoh_cpp::AttachmentData(
+     sequence_number_++, source_timestamp, entity_->copy_gid()).serialize_to_zbytes();
+ 
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+   // Get memory from SHM buffer if available.
+   if (shm && data_length >= shm->msgsize_threshold) {
+     if (auto shm_provider = shm->get_shm_provider(*sess_)) {
+@@ -406,7 +424,9 @@ rmw_ret_t PublisherData::publish_serialized_message(
+       source_timestamp);
+ 
+     pub_.put(std::move(payload), std::move(opts), &result);
+-  } else {
++  } else
++#endif  // Z_FEATURE_SHARED_MEMORY && Z_FEATURE_UNSTABLE_API
++  {
+     std::vector<uint8_t> raw_image(
+       serialized_message->buffer,
+       serialized_message->buffer + data_length);

--- a/Scripts/ros2/patches/rmw_zenoh/0005-rmw_context_impl_s-cpp-guard-shm-config-and-init.patch
+++ b/Scripts/ros2/patches/rmw_zenoh/0005-rmw_context_impl_s-cpp-guard-shm-config-and-init.patch
@@ -1,0 +1,67 @@
+diff --git a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+index 5c64982..308e1f7 100644
+--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
++++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+@@ -40,6 +40,7 @@
+ #include "rmw/error_handling.h"
+ #include "zenoh_utils.hpp"
+ 
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+ // Megabytes of SHM to reserve.
+ // TODO(clalancette): Make this configurable, or get it from the configuration
+ #define SHM_BUFFER_SIZE_MB 10
+@@ -51,6 +52,7 @@ static const char * CONFIG_KEY_SHM_POOL_SIZE =
+ // Zenoh config key for SHM threshold size
+ static const char * CONFIG_KEY_SHM_THRESHOLD_SIZE =
+   "transport/shared_memory/transport_optimization/message_size_threshold";
++#endif  // Z_FEATURE_SHARED_MEMORY && Z_FEATURE_UNSTABLE_API
+ 
+ 
+ // Bundle all class members into a data struct which can be passed as a
+@@ -259,6 +261,7 @@ private:
+     }
+ 
+     // Insert or replace some Config parameters based on environment variables.
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+     {
+       // Handle SHM allocation size.
+       if (const auto shm_alloc_size = rmw_zenoh_cpp::zenoh_shm_alloc_size() ) {
+@@ -282,9 +285,11 @@ private:
+           std::to_string(shm_threshold.value()));
+       }
+     }
++#endif  // Z_FEATURE_SHARED_MEMORY && Z_FEATURE_UNSTABLE_API
+ 
+     zenoh::ZResult result;
+ 
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+     // Get shm configuration.
+     bool shm_enabled = false;
+     std::size_t shm_pool_size = 0;
+@@ -356,6 +361,7 @@ private:
+           CONFIG_KEY_SHM_POOL_SIZE);
+       }
+     }
++#endif  // Z_FEATURE_SHARED_MEMORY && Z_FEATURE_UNSTABLE_API
+ 
+     // Initialize the zenoh session.
+     session_ = std::make_shared<zenoh::Session>(
+@@ -451,6 +457,7 @@ private:
+       }
+     }
+ 
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+     // Initialize the shm subsystem if shared_memory is enabled in the config
+     if (shm_enabled) {
+       RMW_ZENOH_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
+@@ -464,6 +471,10 @@ private:
+     } else {
+       RMW_ZENOH_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "SHM is disabled");
+     }
++#else
++    RMW_ZENOH_LOG_DEBUG_NAMED(
++      "rmw_zenoh_cpp", "SHM is not available in this build");
++#endif  // Z_FEATURE_SHARED_MEMORY && Z_FEATURE_UNSTABLE_API
+ 
+     graph_guard_condition_ = std::make_unique<rmw_guard_condition_t>();
+     graph_guard_condition_->implementation_identifier = rmw_zenoh_cpp::rmw_zenoh_identifier;

--- a/Scripts/ros2/patches/rmw_zenoh/0006-rmw_zenoh-cpp-null-shm-at-publish-call-sites.patch
+++ b/Scripts/ros2/patches/rmw_zenoh/0006-rmw_zenoh-cpp-null-shm-at-publish-call-sites.patch
@@ -1,0 +1,28 @@
+diff --git a/rmw_zenoh_cpp/src/rmw_zenoh.cpp b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+index 2d0be13..d427656 100644
+--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
++++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+@@ -621,7 +621,11 @@ rmw_publish(
+ 
+   return pub_data->publish(
+     ros_message,
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+     context_impl->shm().get()
++#else
++    nullptr
++#endif
+   );
+ }
+ 
+@@ -729,7 +733,11 @@ rmw_publish_serialized_message(
+ 
+   return publisher_data->publish_serialized_message(
+     serialized_message,
++#if defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API)
+     context_impl->shm().get()
++#else
++    nullptr
++#endif
+   );
+ }
+ 

--- a/Scripts/ros2/zenohc-cmake/zenoh_cpp_vendor/zenoh_cpp_vendorConfig.cmake
+++ b/Scripts/ros2/zenohc-cmake/zenoh_cpp_vendor/zenoh_cpp_vendorConfig.cmake
@@ -1,0 +1,10 @@
+# Hand-assembled stand-in for the ament zenoh_cpp_vendor package.
+# The real package is an ament_vendor wrapper whose only consumer-visible
+# effect is `ament_export_dependencies(zenohc zenohcxx)`; replicate that by
+# forwarding to the hand-assembled zenohc / zenohcxx configs.
+
+include(CMakeFindDependencyMacro)
+find_dependency(zenohc)
+find_dependency(zenohcxx)
+
+set(zenoh_cpp_vendor_FOUND TRUE)

--- a/Scripts/ros2/zenohc-cmake/zenohc/zenohcConfig.cmake
+++ b/Scripts/ros2/zenohc-cmake/zenohc/zenohcConfig.cmake
@@ -16,7 +16,7 @@ if(NOT TARGET __zenohc_static)
     add_library(zenohc::static ALIAS __zenohc_static)
     # Frameworks the Rust staticlib needs at final link on Apple platforms.
     target_link_libraries(__zenohc_static INTERFACE
-        "-framework Security" "-framework SystemConfiguration" "-framework CoreFoundation")
+        "-framework Security" "-framework SystemConfiguration" "-framework CoreFoundation" "-framework IOKit")
     set_target_properties(__zenohc_static PROPERTIES
         IMPORTED_LOCATION "${_zenohc_prefix}/lib/libzenohc.a"
         INTERFACE_INCLUDE_DIRECTORIES "${_zenohc_prefix}/include"

--- a/Scripts/ros2/zenohc-cmake/zenohc/zenohcConfig.cmake
+++ b/Scripts/ros2/zenohc-cmake/zenohc/zenohcConfig.cmake
@@ -1,0 +1,30 @@
+# Hand-assembled zenohc package config for the M9 Apple spike.
+# Mirrors the zenohc::static / zenohc::lib targets that zenoh-c's
+# install/PackageConfig.cmake.in would generate for a static,
+# no-shared-memory build (BUILD_SHARED_LIBS=OFF).
+
+set(ZENOHC_BUILD_WITH_UNSTABLE_API TRUE)
+set(ZENOHC_BUILD_WITH_SHARED_MEMORY FALSE)
+
+get_filename_component(_zenohc_prefix "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_zenohc_prefix "${_zenohc_prefix}" PATH)
+get_filename_component(_zenohc_prefix "${_zenohc_prefix}" PATH)
+get_filename_component(_zenohc_prefix "${_zenohc_prefix}" PATH)
+
+if(NOT TARGET __zenohc_static)
+    add_library(__zenohc_static STATIC IMPORTED GLOBAL)
+    add_library(zenohc::static ALIAS __zenohc_static)
+    # Frameworks the Rust staticlib needs at final link on Apple platforms.
+    target_link_libraries(__zenohc_static INTERFACE
+        "-framework Security" "-framework SystemConfiguration" "-framework CoreFoundation")
+    set_target_properties(__zenohc_static PROPERTIES
+        IMPORTED_LOCATION "${_zenohc_prefix}/lib/libzenohc.a"
+        INTERFACE_INCLUDE_DIRECTORIES "${_zenohc_prefix}/include"
+    )
+endif()
+
+if(NOT TARGET zenohc::lib)
+    add_library(zenohc::lib ALIAS __zenohc_static)
+endif()
+
+set(zenohc_FOUND TRUE)

--- a/Scripts/ros2/zenohc-cmake/zenohcxx/zenohcxxConfig.cmake
+++ b/Scripts/ros2/zenohc-cmake/zenohcxx/zenohcxxConfig.cmake
@@ -1,0 +1,26 @@
+# Hand-assembled zenohcxx package config for the M9 Apple spike.
+# Mirrors zenoh-cpp's install/PackageConfig.cmake.in: an INTERFACE target
+# zenohcxx::zenohc wrapping the header-only C++ API over zenohc::lib.
+
+include(CMakeFindDependencyMacro)
+find_dependency(zenohc)
+
+get_filename_component(_zenohcxx_prefix "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_zenohcxx_prefix "${_zenohcxx_prefix}" PATH)
+get_filename_component(_zenohcxx_prefix "${_zenohcxx_prefix}" PATH)
+get_filename_component(_zenohcxx_prefix "${_zenohcxx_prefix}" PATH)
+
+if(NOT TARGET zenohcxx)
+    add_library(zenohcxx INTERFACE IMPORTED)
+    target_include_directories(zenohcxx INTERFACE "${_zenohcxx_prefix}/include")
+endif()
+
+if(TARGET zenohc::lib AND NOT TARGET zenohcxx_zenohc)
+    add_library(zenohcxx_zenohc INTERFACE IMPORTED)
+    target_compile_definitions(zenohcxx_zenohc INTERFACE ZENOHCXX_ZENOHC)
+    target_include_directories(zenohcxx_zenohc INTERFACE "${_zenohcxx_prefix}/include")
+    target_link_libraries(zenohcxx_zenohc INTERFACE zenohc::lib)
+    add_library(zenohcxx::zenohc ALIAS zenohcxx_zenohc)
+endif()
+
+set(zenohcxx_FOUND TRUE)

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -5,7 +5,13 @@ import Foundation
 import SwiftROS2DDS
 import SwiftROS2Transport
 import SwiftROS2Wire
-import SwiftROS2Zenoh
+
+// Absent when the zenoh-rmw RCL variant is selected (SWIFT_ROS2_RCL_RMW=zenoh):
+// zenoh-pico and the variant's bundled zenoh-c export the same zenoh C API and
+// cannot link into one binary, so the manifest carves the wire family out.
+#if canImport(SwiftROS2Zenoh)
+    import SwiftROS2Zenoh
+#endif
 
 #if SWIFT_ROS2_RCL
     import SwiftROS2RCL
@@ -172,7 +178,13 @@ extension ROS2Context {
     static func makeDefaultSession(for config: TransportConfig) throws -> any TransportSession {
         switch config.type {
         case .zenoh:
-            return ZenohTransportSession(client: ZenohClient())
+            #if canImport(SwiftROS2Zenoh)
+                return ZenohTransportSession(client: ZenohClient())
+            #else
+                throw TransportError.unsupportedFeature(
+                    "zenoh wire transport is carved out of the zenoh-rmw RCL build "
+                        + "(SWIFT_ROS2_RCL_RMW=zenoh) — use .rcl, or build without the variant")
+            #endif
         case .dds:
             return DDSTransportSession(client: DDSClient())
         case .rcl:


### PR DESCRIPTION
## Summary

M9 (spec §19.2/§19.3): the design doc's §4 claim — *"Zenoh cannot pivot to rcl/rmw"* — is now **overturned with a working implementation**. `RMW_VARIANT=zenoh Scripts/build-ros2-xcframework.sh` builds **`CRos2JazzyZenoh.xcframework`** = rcl + **rmw_zenoh_cpp** (jazzy `fe3553c`, 0.2.9) + **fastrtps typesupport** + **zenoh-c 1.8.0** (`05bd370`, Rust staticlib, cargo cross-build) for Apple slices, selected at the Swift level by `SWIFT_ROS2_RCL_RMW=zenoh` — **zero Swift source change** (same rcl C API, same module name).

### What was wrong with the §4 dismissal (re-verified with primary evidence)

1. *"Full Rust zenoh-c via cargo"* — zenoh-c builds as a `staticlib` with a cross-compile hook; Tier-2 Rust targets cover macOS/Catalyst/iOS.
2. *"Requires a separate rmw_zenohd router"* — the router may be **remote** (client mode, `connect/endpoints`), the exact topology Conduit already uses for zenoh-pico.
3. The **real** blocker (new finding): zenoh-shm `compile_error!`s for `target_os=ios` and rmw_zenoh_cpp has no no-SHM mode → bounded **6-patch set** (`Scripts/ros2/patches/rmw_zenoh/`), upstreamable (also unblocks Android).

### Build pipeline

- `RMW_VARIANT` switch: separate `build/ros2zenoh` tree, `rmw_zenoh` pinned clone + patches, `zenoh_cpp_vendor` replaced by a per-slice prebuilt zenoh-c prefix (cargo, ROS feature set **minus shared-memory**), fastrtps typesupport pin, `libzenohc.a` merged into `librclros.a`, mini ament prefix for the runtime config lookup. Host tools/venv shared with the cyclonedds tree.
- Static-build patch additions found during integration: `ament_export_dependencies` (PRIVATE deps surface in the static export's link interface) and Security/SystemConfiguration/CoreFoundation/IOKit framework links.
- **Coexistence constraint:** zenoh-pico (wire) and zenoh-c export the same zenoh C API → `SWIFT_ROS2_RCL_RMW=zenoh` carves the zenoh-pico wire family out of the build graph (`#if canImport(SwiftROS2Zenoh)` gates the umbrella's `.zenoh` arm). Default builds unchanged.

## Validation (native macOS, local `rmw_zenohd`)

| Gate | Result |
|---|---|
| `CRos2JazzyZenoh.xcframework` (macos-arm64 + ios-arm64-maccatalyst) | ✅ builds |
| `rmw_zenohd` natively compiled from the patched pipeline sources | ✅ (12.8 MB; routes on :7447) |
| `crcl-smoke` — rcl_init → client session → node → serialized + typed publish | ✅ `crcl_smoke OK` |
| `crcl-golden` — SwiftROS2CDR vs **fastrtps** `rmw_serialize`, 11 types | ✅ all byte-identical — SwiftROS2CDR now proven against BOTH real ROS 2 serializers |
| `crcl-loopback` — typed `rcl_publish` → router → `rcl_take_serialized` → CDRDecoder | ✅ 20/20 round-tripped |
| Default build regression (no env) | ✅ build + 125 tests + lint |
| cyclonedds variant regression | ✅ build + golden gates |

## Not in this PR (follow-ups)

- Remote-host E2E (`ros2 topic echo` via the Ubuntu host's `rmw_zenoh`) — runbook ready; the LAN host became unreachable mid-session (network move). The local-router round-trip exercises the identical client-mode TCP path.
- iphoneos/simulator zenoh slices (Rust targets exist; untested), visionOS (no stable Rust std), release packaging (M6), upstreaming the no-SHM patch set.
- ci-rcl covers the cyclonedds variant; a zenoh-variant CI job is M6 material (adds a Rust toolchain + ~30 min).