### PR TITLE
ci(rcl): promote ci-rcl to a per-PR check named CI (RCL)

### DIFF
--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -1,13 +1,20 @@
-name: ci-rcl
-# RCL (native rcl + rmw_cyclonedds_cpp) backend CI. Opt-in / scheduled only:
-# the cost driver is cross-compiling the real ROS 2 stack into
-# CRos2Jazzy.xcframework (~30-60 min), so this is NOT run on every PR. The
-# mock-based RCL unit tests need no xcframework and already run in ci.yml; this
-# job covers the parts that require the real xcframework + Mac Catalyst.
+name: CI (RCL)
+# RCL (native rcl + rmw_cyclonedds_cpp) backend CI. Runs on every PR as a
+# required check: the cost driver is cross-compiling the real ROS 2 stack into
+# CRos2Jazzy.xcframework (~20-25 min for the single maccatalyst slice), which
+# is accepted for main-line protection. The mock-based RCL unit tests need no
+# xcframework and already run in ci.yml; this job covers the parts that
+# require the real xcframework + Mac Catalyst.
 on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch:
-  schedule:
-    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   rcl-build-smoke:


### PR DESCRIPTION
## Summary

- Rename the `ci-rcl` workflow to **CI (RCL)** to match the title-case naming of the other check workflows (`CI`, `Hash Oracle`).
- Trigger on `pull_request` + `push` to `main` (previously dispatch + weekly cron only), so the job can be promoted to a required status check on the `main` ruleset.
- Drop the Monday cron — per-PR + per-push coverage supersedes it. `workflow_dispatch` stays for manual runs on arbitrary branches.
- Add a `concurrency` group mirroring `ci.yml` so superseded in-flight runs are cancelled.

The required-check context is the job name (`RCL build + smoke (Mac Catalyst)`), which is unchanged — dispatch runs already reported on open PR heads (e.g. #129) keep satisfying the rule.

## Follow-up after merge

Add `RCL build + smoke (Mac Catalyst)` to the `main` ruleset's required status checks (repo settings; will be done via `gh api` right after this lands).

## Test plan

- [ ] This PR itself triggers the renamed workflow via `pull_request` — green run is the validation.