### PR TITLE
feat(rcl): M7 parameters — default node options + param round-trip verification

### DIFF
--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -160,9 +160,12 @@ jobs:
       # the per-entity wait threads, the request-id correlation table, and the
       # rmw_serialize / rmw_deserialize marshalling run under AddressSanitizer.
       # Two sequential calls with distinct operands gate against correlation
-      # bugs. Same headless-runner caveats as crcl-loopback: bound the run
-      # (alarm 150 — readiness poll + two calls + ASan slowdown) and decide
-      # success on the OK line + the absence of any ASan/leak report.
+      # bugs, then a parameter phase (default node options, declare/get/set
+      # via ROS2ParameterClient + /parameter_events) verifies the param stack.
+      # Same headless-runner caveats as crcl-loopback: bound the run
+      # (alarm 150 — readiness polls + service calls + param round-trip +
+      # event wait + ASan slowdown) and decide success on the OK line + the
+      # absence of any ASan/leak report.
       - name: Build + run crcl-svc-loopback (Catalyst, ASan)
         run: |
           xcodebuild -scheme crcl-svc-loopback \

--- a/Sources/Examples/CrclLoopback/main.swift
+++ b/Sources/Examples/CrclLoopback/main.swift
@@ -59,12 +59,14 @@ do {
     fail("ROS2Context creation threw: \(error)")
 }
 
+// Default ROS2NodeOptions: the parameter stack (six rcl_interfaces services
+// + the /parameter_events emitter) works on .rcl, so the stock createNode
+// path needs no opt-out.
 let node: ROS2Node
 do {
     node = try await ctx.createNode(
         name: "crcl_loopback",
-        namespace: "/loopback",
-        options: ROS2NodeOptions(startParameterServices: false)
+        namespace: "/loopback"
     )
 } catch {
     fail("createNode threw: \(error)")

--- a/Sources/Examples/CrclSvcLoopback/main.swift
+++ b/Sources/Examples/CrclSvcLoopback/main.swift
@@ -1,13 +1,24 @@
-// crcl-svc-loopback — M7 service round-trip gate.
+// crcl-svc-loopback — M7 service + parameter round-trip gate.
 //
-// One process, one rcl context: a service server and a service client for
-// example_interfaces/AddTwoInts share the name "add_two_ints". Every call
-// travels the full public createService / createClient surface end-to-end:
-// CDREncoder -> rmw_deserialize shim -> typed rcl service server ->
-// user handler -> rmw_serialize shim -> rcl_take_response -> CDRDecoder.
-// Two sequential calls with distinct operands discriminate correlation bugs
-// (a response wired to the wrong request cannot satisfy both sums). On
-// success prints "crcl_svc_loopback OK: …" + flush, then exits 0 (before
+// One process, one rcl context, two phases:
+//
+// 1. Services: a service server and a service client for
+//    example_interfaces/AddTwoInts share the name "add_two_ints". Every call
+//    travels the full public createService / createClient surface end-to-end:
+//    CDREncoder -> rmw_deserialize shim -> typed rcl service server ->
+//    user handler -> rmw_serialize shim -> rcl_take_response -> CDRDecoder.
+//    Two sequential calls with distinct operands discriminate correlation
+//    bugs (a response wired to the wrong request cannot satisfy both sums).
+//
+// 2. Parameters: the node is created with DEFAULT ROS2NodeOptions — the
+//    first time the stock createNode path runs on .rcl — so the six
+//    rcl_interfaces parameter services register at creation and
+//    /parameter_events publishes over the registry-only serialized seam
+//    (zero parameter-specific transport work). A ROS2ParameterClient
+//    pointed at the node's own services declares/gets/sets a parameter and
+//    a /parameter_events subscription asserts the change event arrives.
+//
+// On success prints "crcl_svc_loopback OK: …" + flush, then exits 0 (before
 // context teardown, which can block on headless runners — ci-rcl bounds the
 // run with SIGALRM and decides success on the OK line, consistent with
 // crcl-loopback / crcl-golden / crcl-smoke).
@@ -15,13 +26,14 @@
 import Foundation
 import SwiftROS2
 
-// Last-resort in-process bound (60 s): the per-phase budgets below already
-// sum to 20 s (waitForService 10 + two 5 s calls) and ASan startup adds
-// seconds, so leave real headroom while staying far under ci-rcl's outer
-// 150 s bound. If anything wedges past every per-phase timeout, SIGALRM's
-// default disposition kills the process before the OK line is printed, so
-// the CI grep still fails deterministically.
-alarm(60)
+// Last-resort in-process bound (120 s): the per-phase budgets below sum to
+// ~45 s worst case (service waitForService 10 + two 5 s calls + param
+// waitForService 10 + three 5 s param calls + 10 s event wait — typical runs
+// settle in seconds) and ASan startup adds more, so leave real headroom while
+// staying under ci-rcl's outer 150 s bound. If anything wedges past every
+// per-phase timeout, SIGALRM's default disposition kills the process before
+// the OK line is printed, so the CI grep still fails deterministically.
+alarm(120)
 
 func fail(_ reason: String) -> Never {
     print("crcl_svc_loopback FAIL: \(reason)")
@@ -36,15 +48,15 @@ do {
     fail("ROS2Context creation threw: \(error)")
 }
 
-// Parameter services are deferred on the rcl backend (they land in a
-// follow-up after the services PR) — start the node without them, same as
-// crcl-loopback.
+// Default ROS2NodeOptions on purpose: createNode itself registers the six
+// rcl_interfaces parameter services and installs the /parameter_events
+// emitter, so this single node serves both the AddTwoInts phase and the
+// parameter phase below.
 let node: ROS2Node
 do {
     node = try await ctx.createNode(
         name: "crcl_svc_loopback",
-        namespace: "/loopback",
-        options: ROS2NodeOptions(startParameterServices: false)
+        namespace: "/loopback"
     )
 } catch {
     fail("createNode threw: \(error)")
@@ -98,10 +110,125 @@ guard second.sum == 33 else {
     fail("call #2 sum mismatch: \(second.sum) != 33")
 }
 
-print("crcl_svc_loopback OK: AddTwoInts 2+3=5, -7+40=33")
+// --- Parameter phase ---
+//
+// Subscribe to /parameter_events before any parameter mutation so the
+// change event cannot race the reader-writer match (the publisher QoS is
+// transient-local, but the gate shouldn't have to rely on replay).
+final class EventBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [ParameterEvent] = []
+
+    func record(_ event: ParameterEvent) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    var snapshot: [ParameterEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
+let eventBox = EventBox()
+let eventSub: ROS2Subscription<ParameterEvent>
+do {
+    eventSub = try await node.createSubscription(
+        ParameterEvent.self, topic: "/parameter_events", qos: .parameterEvents)
+} catch {
+    fail("createSubscription(/parameter_events) threw: \(error)")
+}
+let eventConsumer = Task {
+    for await event in eventSub.messages {
+        eventBox.record(event)
+    }
+}
+
+// Declare locally; the lazy /parameter_events publisher spins up on this
+// first mutation (registry-only rcl_interfaces/msg/ParameterEvent entry
+// over the serialized seam).
+do {
+    let declared = try await node.declareParameter("answer", default: Int64(41))
+    guard declared == 41 else {
+        fail("declareParameter returned \(declared), expected 41")
+    }
+} catch {
+    fail("declareParameter threw: \(error)")
+}
+
+// Point a ROS2ParameterClient at this node's own six services — same
+// in-process loopback shape as the AddTwoInts phase.
+let paramClient: ROS2ParameterClient
+do {
+    paramClient = try await node.createParameterClient(remoteNode: node.fullyQualifiedName)
+} catch {
+    fail("createParameterClient threw: \(error)")
+}
+do {
+    try await paramClient.waitForService(timeout: .seconds(10))
+} catch {
+    fail("parameter waitForService threw: \(error)")
+}
+
+// get -> declared value.
+do {
+    let values = try await paramClient.getParameters(["answer"], timeout: .seconds(5))
+    guard values.count == 1, case .integer(let v) = values[0], v == 41 else {
+        fail("param get #1 returned \(values), expected [.integer(41)]")
+    }
+} catch {
+    fail("param get #1 threw: \(error)")
+}
+
+// set -> new value.
+do {
+    let results = try await paramClient.setParameters(
+        [ROS2Parameter(name: "answer", value: .integer(42))], timeout: .seconds(5))
+    guard results.count == 1, results[0].successful else {
+        fail("param set rejected: \(results)")
+    }
+} catch {
+    fail("param set threw: \(error)")
+}
+
+// get -> the value the set committed.
+do {
+    let values = try await paramClient.getParameters(["answer"], timeout: .seconds(5))
+    guard values.count == 1, case .integer(let v) = values[0], v == 42 else {
+        fail("param get #2 returned \(values), expected [.integer(42)]")
+    }
+} catch {
+    fail("param get #2 threw: \(error)")
+}
+
+// The set must surface on /parameter_events as a changed-parameter event.
+let eventDeadline = Date().addingTimeInterval(10)
+var sawChange = false
+while Date() < eventDeadline {
+    if eventBox.snapshot.contains(where: { event in
+        event.changedParameters.contains { $0.name == "answer" }
+    }) {
+        sawChange = true
+        break
+    }
+    try? await Task.sleep(nanoseconds: 50_000_000)
+}
+guard sawChange else {
+    fail(
+        "no /parameter_events change for 'answer' within 10 s "
+            + "(received \(eventBox.snapshot.count) events)")
+}
+
+print(
+    "crcl_svc_loopback OK: AddTwoInts 2+3=5, -7+40=33; "
+        + "param declare/get/set + event round-tripped")
 fflush(stdout)
 
 // Best-effort teardown after the OK line: on a headless runner CycloneDDS
 // teardown can block, and ci-rcl's SIGALRM bound + OK-line grep absorb that.
+eventConsumer.cancel()
+await paramClient.close()
 await ctx.shutdown()
 exit(0)

--- a/Sources/Examples/CrclSvcLoopback/main.swift
+++ b/Sources/Examples/CrclSvcLoopback/main.swift
@@ -27,7 +27,7 @@ import Foundation
 import SwiftROS2
 
 // Last-resort in-process bound (120 s): the per-phase budgets below sum to
-// ~45 s worst case (service waitForService 10 + two 5 s calls + param
+// ~55 s worst case (service waitForService 10 + two 5 s calls + param
 // waitForService 10 + three 5 s param calls + 10 s event wait — typical runs
 // settle in seconds) and ASan startup adds more, so leave real headroom while
 // staying under ci-rcl's outer 150 s bound. If anything wedges past every
@@ -208,7 +208,7 @@ let eventDeadline = Date().addingTimeInterval(10)
 var sawChange = false
 while Date() < eventDeadline {
     if eventBox.snapshot.contains(where: { event in
-        event.changedParameters.contains { $0.name == "answer" }
+        event.changedParameters.contains { $0.name == "answer" && $0.value.integerValue == 42 }
     }) {
         sawChange = true
         break

--- a/Sources/Examples/RclBench/main.swift
+++ b/Sources/Examples/RclBench/main.swift
@@ -221,6 +221,9 @@ func runPubSub() async throws {
     let qos = QoSProfile(
         reliability: .reliable, durability: .volatile, history: .keepLast(2_000))
     let ctx = try await ROS2Context(transport: transportConfig())
+    // Deliberate opt-out (not an rcl limitation): the parameter stack works
+    // on every backend, but six idle services + a /parameter_events
+    // publisher would add discovery traffic to a latency benchmark.
     let node = try await ctx.createNode(
         name: "rcl_bench", namespace: "/rcl_bench",
         options: ROS2NodeOptions(startParameterServices: false))

--- a/Tests/SwiftROS2IntegrationTests/RclParameterIntegrationTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/RclParameterIntegrationTests.swift
@@ -1,0 +1,76 @@
+import SwiftROS2Messages
+import XCTest
+
+@testable import SwiftROS2
+
+/// Serves the six rcl_interfaces parameter services through the real rcl +
+/// rmw_cyclonedds_cpp stack with DEFAULT `ROS2NodeOptions` (M7 parameters
+/// verification: the stock createNode path registers the services and the
+/// /parameter_events publisher; the host lists / gets / sets).
+/// Gated: requires the RCL backend built (SWIFT_ROS2_RCL) and a reachable
+/// Jazzy host (LINUX_IP). This is a runbook test — CI never runs it. Start
+/// the test, then within 60 s run on the host:
+///
+///   ros2 param list /swift_ros2_rcl/swift_ros2_rcl_param_test
+///   ros2 param get /swift_ros2_rcl/swift_ros2_rcl_param_test answer
+///   ros2 param set /swift_ros2_rcl/swift_ros2_rcl_param_test answer 42
+///
+/// `list` must show "answer", `get` must print "Integer value is: 41", and
+/// `set` must print "Set parameter successful" — after which this test
+/// observes the new value in the local store. If no set arrives within 60 s
+/// the test skips (the host side is manual), unless RCL_SVC_EXPECT_CALL=1 is
+/// set — in which case the absence of a set is a failure.
+final class RclParameterIntegrationTests: XCTestCase {
+    func testServeParametersOverRcl() async throws {
+        #if !SWIFT_ROS2_RCL
+            throw XCTSkip("RCL backend not built (set SWIFT_ROS2_ENABLE_RCL=1)")
+        #else
+            guard ProcessInfo.processInfo.environment["LINUX_IP"] != nil else {
+                throw XCTSkip("LINUX_IP not set — skipping LAN integration test")
+            }
+            let expectCall = ProcessInfo.processInfo.environment["RCL_SVC_EXPECT_CALL"] == "1"
+
+            let ctx = try await ROS2Context(transport: .rcl(domainId: 0))
+            // Default options on purpose — this is the verification that the
+            // stock createNode path (six parameter services + the
+            // /parameter_events emitter) works on `.rcl` against a real host.
+            let node = try await ctx.createNode(
+                name: "swift_ros2_rcl_param_test", namespace: "/swift_ros2_rcl")
+            let declared = try await node.declareParameter("answer", default: Int64(41))
+            XCTAssertEqual(declared, 41)
+
+            // Wait up to 60 s for the operator to issue the documented set.
+            // `ros2 param list/get` exercise the services too, but only the
+            // set is observable from this side, so it is the gate.
+            let deadline = ContinuousClock.now.advanced(by: .seconds(60))
+            var observed: Int64 = 41
+            while ContinuousClock.now < deadline {
+                let p = try await node.getParameter("answer")
+                if case .integer(let v) = p.value, v != 41 {
+                    observed = v
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(200))
+            }
+
+            guard observed != 41 else {
+                await ctx.shutdown()
+                if expectCall {
+                    return XCTFail(
+                        "no parameter set within 60 s with RCL_SVC_EXPECT_CALL=1 — "
+                            + "did the host run the runbook? (see the header of this file)")
+                }
+                throw XCTSkip(
+                    "no parameter set within 60 s — run the host-side commands documented "
+                        + "in the header of this file to exercise this test")
+            }
+
+            // The documented host command sets 42; the host-side outputs of
+            // `param list` / `param get` are the live assertions that the
+            // Get/List services answered a real rclpy parameter client.
+            XCTAssertEqual(observed, 42)
+
+            await ctx.shutdown()
+        #endif
+    }
+}

--- a/Tests/SwiftROS2IntegrationTests/RclPublishIntegrationTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/RclPublishIntegrationTests.swift
@@ -17,9 +17,7 @@ final class RclPublishIntegrationTests: XCTestCase {
 
             let ctx = try await ROS2Context(transport: .rcl(domainId: 0))
             let node = try await ctx.createNode(
-                name: "swift_ros2_rcl_test", namespace: "/swift_ros2_rcl",
-                options: ROS2NodeOptions(startParameterServices: false)  // M1 is publish-only
-            )
+                name: "swift_ros2_rcl_test", namespace: "/swift_ros2_rcl")
             let pub = try await node.createPublisher(Imu.self, topic: "imu")
 
             var imu = Imu()

--- a/Tests/SwiftROS2IntegrationTests/RclServiceIntegrationTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/RclServiceIntegrationTests.swift
@@ -28,9 +28,7 @@ final class RclServiceIntegrationTests: XCTestCase {
 
             let ctx = try await ROS2Context(transport: .rcl(domainId: 0))
             let node = try await ctx.createNode(
-                name: "swift_ros2_rcl_svc_test", namespace: "/swift_ros2_rcl",
-                options: ROS2NodeOptions(startParameterServices: false)
-            )
+                name: "swift_ros2_rcl_svc_test", namespace: "/swift_ros2_rcl")
 
             // Capture the requests the handler answered so the test can assert
             // both that a call arrived and what it computed.

--- a/Tests/SwiftROS2IntegrationTests/RclSubscribeIntegrationTests.swift
+++ b/Tests/SwiftROS2IntegrationTests/RclSubscribeIntegrationTests.swift
@@ -23,9 +23,7 @@ final class RclSubscribeIntegrationTests: XCTestCase {
 
             let ctx = try await ROS2Context(transport: .rcl(domainId: 0))
             let node = try await ctx.createNode(
-                name: "swift_ros2_rcl_sub_test", namespace: "/swift_ros2_rcl",
-                options: ROS2NodeOptions(startParameterServices: false)
-            )
+                name: "swift_ros2_rcl_sub_test", namespace: "/swift_ros2_rcl")
             // Reliable to match the `ros2 topic pub` default writer QoS.
             let qos = QoSProfile(
                 reliability: .reliable, durability: .volatile, history: .keepLast(10))

--- a/Tests/SwiftROS2Tests/Parameters/RclParameterStackTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/RclParameterStackTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import SwiftROS2Messages
+import SwiftROS2Transport
+import XCTest
+
+@testable import SwiftROS2
+
+/// M7 parameters verification, mock-seam half: default `ROS2NodeOptions` on
+/// the `.rcl` transport must register the six rcl_interfaces parameter
+/// services and route `/parameter_events` through the serialized publisher
+/// seam — with zero parameter-specific transport work. Backed by a recording
+/// `RclClientProtocol` mock (no xcframework, no SWIFT_ROS2_RCL), so this
+/// guards the wiring in ordinary CI; the live half is the crcl-svc-loopback
+/// gate plus `RclParameterIntegrationTests`.
+final class RclParameterStackTests: XCTestCase {
+    private func makeRclContext() async throws -> (ROS2Context, RecordingRclSeamClient) {
+        let seam = RecordingRclSeamClient()
+        let session = RclTransportSession(client: seam)
+        let ctx = try await ROS2Context(transport: .rcl(domainId: 0), session: session)
+        return (ctx, seam)
+    }
+
+    func testDefaultCreateNodeRegistersSixParameterServicesOnRclSeam() async throws {
+        let (ctx, seam) = try await makeRclContext()
+        defer { Task { await ctx.shutdown() } }
+        _ = try await ctx.createNode(name: "param_node", namespace: "/t")
+
+        let created = seam.servicesCreated
+        XCTAssertEqual(created.count, 6)
+        XCTAssertEqual(
+            Set(created.map(\.serviceName)),
+            [
+                "/t/param_node/get_parameters",
+                "/t/param_node/get_parameter_types",
+                "/t/param_node/set_parameters",
+                "/t/param_node/set_parameters_atomically",
+                "/t/param_node/list_parameters",
+                "/t/param_node/describe_parameters",
+            ])
+        XCTAssertEqual(
+            Set(created.map(\.srvTypeName)),
+            [
+                "rcl_interfaces/srv/GetParameters",
+                "rcl_interfaces/srv/GetParameterTypes",
+                "rcl_interfaces/srv/SetParameters",
+                "rcl_interfaces/srv/SetParametersAtomically",
+                "rcl_interfaces/srv/ListParameters",
+                "rcl_interfaces/srv/DescribeParameters",
+            ])
+    }
+
+    func testDeclareParameterOnRclSeamDoesNotThrowAndPublishesEvent() async throws {
+        let (ctx, seam) = try await makeRclContext()
+        defer { Task { await ctx.shutdown() } }
+        let node = try await ctx.createNode(name: "param_node", namespace: "/t")
+
+        let declared = try await node.declareParameter("rate", default: Int64(30))
+        XCTAssertEqual(declared, 30)
+
+        // The lazy /parameter_events publisher is created (and the declare
+        // event emitted) from a detached Task — poll with a bounded deadline,
+        // same idiom as ParameterEventTests.waitForEvents.
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if !seam.publishedPayloads.isEmpty { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+
+        XCTAssertEqual(seam.publishersCreated.count, 1)
+        XCTAssertEqual(seam.publishersCreated.first?.topic, "/parameter_events")
+        XCTAssertEqual(
+            seam.publishersCreated.first?.typeName, "rcl_interfaces/msg/ParameterEvent")
+        XCTAssertEqual(seam.publishedPayloads.count, 1)
+    }
+}
+
+// MARK: - Recording rcl seam mock
+
+private final class SeamNode: RclNodeHandle, @unchecked Sendable {
+    let name: String
+    init(name: String) { self.name = name }
+}
+
+private final class SeamPublisher: RclPublisherHandle, @unchecked Sendable {
+    var isActive: Bool { true }
+    func close() {}
+}
+
+private final class SeamSubscription: RclSubscriptionHandle, @unchecked Sendable {
+    var isActive: Bool { true }
+}
+
+private final class SeamService: RclServiceHandle, @unchecked Sendable {
+    var isActive: Bool { true }
+}
+
+private final class SeamServiceClient: RclClientHandle, @unchecked Sendable {
+    var isActive: Bool { true }
+}
+
+/// Minimal `RclClientProtocol` recorder: enough to observe what the default
+/// `createNode` path creates on the seam. Distinct from the transport-layer
+/// `MockRclClient` (a different test target), and intentionally thinner — no
+/// fire hooks, no failure injection.
+private final class RecordingRclSeamClient: RclClientProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private func sync<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+
+    var isAvailable: Bool { true }
+
+    private var _publishersCreated: [(topic: String, typeName: String)] = []
+    private var _publishedPayloads: [Data] = []
+    private var _servicesCreated: [(serviceName: String, srvTypeName: String)] = []
+
+    var publishersCreated: [(topic: String, typeName: String)] {
+        sync { _publishersCreated }
+    }
+    var publishedPayloads: [Data] {
+        sync { _publishedPayloads }
+    }
+    var servicesCreated: [(serviceName: String, srvTypeName: String)] {
+        sync { _servicesCreated }
+    }
+
+    func createContext(domainId: Int32) throws {}
+    func destroyContext() {}
+
+    func createNode(name: String, namespace: String) throws -> any RclNodeHandle {
+        SeamNode(name: name)
+    }
+    func destroyNode(_ node: any RclNodeHandle) {}
+
+    func createPublisher(
+        node: any RclNodeHandle, typeName: String, topic: String, qos: TransportQoS
+    ) throws -> any RclPublisherHandle {
+        sync { _publishersCreated.append((topic, typeName)) }
+        return SeamPublisher()
+    }
+
+    func publishSerialized(_ publisher: any RclPublisherHandle, data: Data) throws {
+        sync { _publishedPayloads.append(data) }
+    }
+
+    func createSubscription(
+        node: any RclNodeHandle, typeName: String, topic: String, qos: TransportQoS,
+        handler: @escaping @Sendable (Data, UInt64) -> Void
+    ) throws -> any RclSubscriptionHandle {
+        SeamSubscription()
+    }
+    func destroySubscription(_ subscription: any RclSubscriptionHandle) {}
+
+    func createServiceServer(
+        node: any RclNodeHandle, srvTypeName: String, serviceName: String, qos: TransportQoS,
+        onRequest: @escaping @Sendable (Data, [UInt8]) -> Void
+    ) throws -> any RclServiceHandle {
+        sync { _servicesCreated.append((serviceName, srvTypeName)) }
+        return SeamService()
+    }
+    func sendResponse(_ service: any RclServiceHandle, requestId: [UInt8], data: Data) throws {}
+    func destroyServiceServer(_ service: any RclServiceHandle) {}
+
+    func createServiceClient(
+        node: any RclNodeHandle, srvTypeName: String, serviceName: String, qos: TransportQoS,
+        onResponse: @escaping @Sendable (Int64, Data) -> Void
+    ) throws -> any RclClientHandle {
+        SeamServiceClient()
+    }
+    func sendRequest(_ client: any RclClientHandle, data: Data) throws -> Int64 { 1 }
+    func serverAvailable(_ client: any RclClientHandle) -> Bool { true }
+    func destroyServiceClient(_ client: any RclClientHandle) {}
+}

--- a/Tests/SwiftROS2Tests/Parameters/RclParameterStackTests.swift
+++ b/Tests/SwiftROS2Tests/Parameters/RclParameterStackTests.swift
@@ -27,25 +27,16 @@ final class RclParameterStackTests: XCTestCase {
 
         let created = seam.servicesCreated
         XCTAssertEqual(created.count, 6)
+        // Assert (name, type) as pairs so crossed name-to-type wiring fails too.
         XCTAssertEqual(
-            Set(created.map(\.serviceName)),
+            Set(created.map { "\($0.serviceName)|\($0.srvTypeName)" }),
             [
-                "/t/param_node/get_parameters",
-                "/t/param_node/get_parameter_types",
-                "/t/param_node/set_parameters",
-                "/t/param_node/set_parameters_atomically",
-                "/t/param_node/list_parameters",
-                "/t/param_node/describe_parameters",
-            ])
-        XCTAssertEqual(
-            Set(created.map(\.srvTypeName)),
-            [
-                "rcl_interfaces/srv/GetParameters",
-                "rcl_interfaces/srv/GetParameterTypes",
-                "rcl_interfaces/srv/SetParameters",
-                "rcl_interfaces/srv/SetParametersAtomically",
-                "rcl_interfaces/srv/ListParameters",
-                "rcl_interfaces/srv/DescribeParameters",
+                "/t/param_node/get_parameters|rcl_interfaces/srv/GetParameters",
+                "/t/param_node/get_parameter_types|rcl_interfaces/srv/GetParameterTypes",
+                "/t/param_node/set_parameters|rcl_interfaces/srv/SetParameters",
+                "/t/param_node/set_parameters_atomically|rcl_interfaces/srv/SetParametersAtomically",
+                "/t/param_node/list_parameters|rcl_interfaces/srv/ListParameters",
+                "/t/param_node/describe_parameters|rcl_interfaces/srv/DescribeParameters",
             ])
     }
 


### PR DESCRIPTION
## Summary

Completes M7 on the `.rcl` backend: the parameter stack works with zero parameter-specific transport code (spec §20.4) — `startParameterServices()` registers six plain services over the serialize-shim merged in #129, and `/parameter_events` publishes via the registry-only `rcl_interfaces/msg/ParameterEvent` entry.

- **`crcl-svc-loopback` gains a parameter phase**: the node now uses **default `ROS2NodeOptions`** (first stock `createNode` on `.rcl`), declares a parameter, round-trips get/set through `ROS2ParameterClient` (real service calls over the rcl seam), and asserts the changed-parameter event (name + value) arrives on `/parameter_events`. OK line extended; CI grep unchanged (pure prefix extension). In-process alarm 60 → 120 (budgets now sum to ~55 s worst case, still under the CI step's outer 150 s).
- **`startParameterServices: false` workaround removed** from CrclLoopback, CrclSvcLoopback, and the three RCL LAN integration tests — default options are the norm now. RclBench keeps an explicit opt-out (benchmark purity, re-commented as deliberate); wire-path mock tests untouched.
- **New ordinary-CI mock test** `RclParameterStackTests`: default `createNode` on the rcl seam registers exactly the six parameter services (asserted as name|type pairs) and `declareParameter` publishes one `ParameterEvent` through the seam.
- **New LAN-gated runbook test** `RclParameterIntegrationTests` (same `LINUX_IP` + `RCL_SVC_EXPECT_CALL` idiom as the service test) with the host `ros2 param list/get/set` commands documented in the header.

## Test plan

- [x] Ordinary: 544 XCTest + 135 swift-testing tests green; lint clean
- [x] `SWIFT_ROS2_ENABLE_RCL=1 swift build` green
- [x] Native + Catalyst ASan `crcl-svc-loopback`: `crcl_svc_loopback OK: AddTwoInts 2+3=5, -7+40=33; param declare/get/set + event round-tripped`, no ASan/leak report
- [x] `crcl-loopback` (lost its workaround) still green native + Catalyst ASan
- [x] Live LAN runbook vs youtalk-desktop.local (Jazzy/CycloneDDS): `ros2 param list` shows `answer`, `param get` → 41, `param set` → succeeded, test observed 42 locally and passed
- [ ] CI (RCL) runs automatically on this PR (now a required check)