### PR TITLE
feat(parity): parity-tool write-back (set/canonicalize) + canonical JSON + drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,10 @@ jobs:
           submodules: recursive
       - name: Validate matrix JSON
         run: swift run parity-tool validate
-      - name: Re-render and check for drift
+      - name: Re-render, canonicalize, and check for drift
         run: |
           swift run parity-tool render
+          swift run parity-tool canonicalize
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git diff --exit-code docs/PARITY.md docs/parity-matrix.json
 

--- a/Sources/ParityMatrix/Matrix.swift
+++ b/Sources/ParityMatrix/Matrix.swift
@@ -138,3 +138,38 @@ extension ParityMatrix {
         }
     }
 }
+
+extension ParityMatrix {
+    /// The four verification axes (matches `Verification`'s stored properties).
+    public enum Axis: String, Codable, Sendable, CaseIterable {
+        case latency, soak, correctness, resource
+    }
+
+    /// Record a verification-axis result for one capability id. Throws if the
+    /// id is absent. Other axes and capabilities are untouched.
+    public mutating func setAxis(
+        capabilityId: String, axis: Axis, verdict: AxisVerdict, value: String?
+    ) throws {
+        guard let idx = capabilities.firstIndex(where: { $0.id == capabilityId }) else {
+            throw ParityMatrixError("unknown capability id: \(capabilityId)")
+        }
+        let result = AxisResult(verdict: verdict, value: value)
+        switch axis {
+        case .latency: capabilities[idx].verification.latency = result
+        case .soak: capabilities[idx].verification.soak = result
+        case .correctness: capabilities[idx].verification.correctness = result
+        case .resource: capabilities[idx].verification.resource = result
+        }
+    }
+
+    /// Deterministic JSON for `docs/parity-matrix.json`: sorted keys, pretty
+    /// printed, unescaped slashes, trailing newline. Capability source order is
+    /// preserved (an array); `.sortedKeys` only orders keys *within* each object.
+    public func encodeCanonicalJSON() throws -> Data {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var data = try enc.encode(self)
+        data.append(0x0A)  // trailing newline so the file is POSIX-clean
+        return data
+    }
+}

--- a/Sources/parity-tool/ParityToolCommand.swift
+++ b/Sources/parity-tool/ParityToolCommand.swift
@@ -7,7 +7,7 @@ struct ParityTool: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "parity-tool",
         abstract: "Validate and render the swift-ros2 parity matrix.",
-        subcommands: [Validate.self, Render.self]
+        subcommands: [Validate.self, Render.self, Set.self, Canonicalize.self]
     )
 
     static func loadMatrix(_ path: String) throws -> ParityMatrix {
@@ -49,6 +49,68 @@ struct ParityTool: ParsableCommand {
             let md = matrix.renderMarkdown()
             try md.write(toFile: output, atomically: true, encoding: .utf8)
             FileHandle.standardOutput.write(Data("parity-tool render OK -> \(output)\n".utf8))
+        }
+    }
+
+    struct Set: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "set",
+            abstract: "Record a verification-axis verdict for a capability, then re-render PARITY.md."
+        )
+
+        @Argument(help: "capability id, e.g. publish.typed.sensor_msgs/Imu")
+        var capabilityId: String
+
+        @Option(name: .long, help: "latency | soak | correctness | resource")
+        var axis: String
+
+        @Option(name: .long, help: "pass | fail | pending")
+        var verdict: String
+
+        @Option(name: .long, help: "free-form measured value (optional)")
+        var value: String?
+
+        @Option(name: .long, help: "Path to parity-matrix.json")
+        var input: String = "docs/parity-matrix.json"
+
+        @Option(name: .long, help: "Output Markdown path")
+        var output: String = "docs/PARITY.md"
+
+        func run() throws {
+            guard let axisEnum = ParityMatrix.Axis(rawValue: axis) else {
+                throw ValidationError("axis must be one of: latency, soak, correctness, resource")
+            }
+            guard let verdictEnum = AxisVerdict(rawValue: verdict) else {
+                throw ValidationError("verdict must be one of: pass, fail, pending")
+            }
+            var matrix = try ParityTool.loadMatrix(input)
+            try matrix.setAxis(
+                capabilityId: capabilityId, axis: axisEnum, verdict: verdictEnum, value: value)
+            try matrix.validate()
+            // Atomic writes so an interrupted run never leaves a half-written file.
+            // JSON is written first, then PARITY.md; if the second write fails the two
+            // can drift — re-run `parity-tool render` to resync.
+            try matrix.encodeCanonicalJSON().write(to: URL(fileURLWithPath: input), options: .atomic)
+            try matrix.renderMarkdown().write(toFile: output, atomically: true, encoding: .utf8)
+            FileHandle.standardOutput.write(
+                Data("parity-tool set OK: \(capabilityId) [\(axis)] = \(verdict)\n".utf8))
+        }
+    }
+
+    struct Canonicalize: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Rewrite the matrix JSON in canonical form (idempotent)."
+        )
+
+        @Option(name: .long, help: "Path to parity-matrix.json")
+        var input: String = "docs/parity-matrix.json"
+
+        func run() throws {
+            let matrix = try ParityTool.loadMatrix(input)
+            try matrix.validate()
+            try matrix.encodeCanonicalJSON().write(to: URL(fileURLWithPath: input), options: .atomic)
+            FileHandle.standardOutput.write(
+                Data("parity-tool canonicalize OK -> \(input)\n".utf8))
         }
     }
 }

--- a/Tests/ParityMatrixTests/ParityMatrixTests.swift
+++ b/Tests/ParityMatrixTests/ParityMatrixTests.swift
@@ -10,6 +10,10 @@ final class ParityMatrixTests: XCTestCase {
         return try JSONDecoder().decode(ParityMatrix.self, from: data)
     }
 
+    private func decodeMatrix(_ json: String) throws -> ParityMatrix {
+        try JSONDecoder().decode(ParityMatrix.self, from: Data(json.utf8))
+    }
+
     func testDecodeSample() throws {
         let matrix = try loadSample()
         XCTAssertEqual(matrix.schemaVersion, 1)
@@ -44,5 +48,65 @@ final class ParityMatrixTests: XCTestCase {
     func testValidateAcceptsCleanMatrix() throws {
         let matrix = try loadSample()
         XCTAssertNoThrow(try matrix.validate())
+    }
+
+    func testCanonicalEncodeIsDeterministicAndRoundTrips() throws {
+        // b.cap before a.cap: array order is preserved; .sortedKeys only orders
+        // keys *within* each object. evidence carries a slash to prove no escaping.
+        let matrix = try decodeMatrix(
+            #"""
+            {"schemaVersion":1,"capabilities":[
+              {"id":"b.cap","apiSymbol":"B","pureSwift":"supported","rcl":"supported",
+               "platforms":["macOS"],"typeApplicability":"n-a","severity":"n-a-by-design",
+               "verification":{"latency":{"verdict":"pending"},"soak":{"verdict":"pending"},
+                 "correctness":{"verdict":"pending"},"resource":{"verdict":"pending"}},
+               "evidence":"path/with/slashes.c:10"},
+              {"id":"a.cap","apiSymbol":"A","pureSwift":"supported","rcl":"partial",
+               "platforms":["iOS"],"typeApplicability":"bundled","severity":"major",
+               "verification":{"latency":{"verdict":"pending"},"soak":{"verdict":"pending"},
+                 "correctness":{"verdict":"pending"},"resource":{"verdict":"pending"}}}
+            ]}
+            """#)
+        let first = try matrix.encodeCanonicalJSON()
+        // Idempotent: decode -> encode reproduces identical bytes.
+        let decoded = try JSONDecoder().decode(ParityMatrix.self, from: first)
+        let second = try decoded.encodeCanonicalJSON()
+        XCTAssertEqual(first, second)
+        // Slashes are not escaped, and the file ends in a newline.
+        let text = String(decoding: first, as: UTF8.self)
+        XCTAssertTrue(text.contains("path/with/slashes.c:10"))
+        XCTAssertFalse(text.contains("\\/"))
+        XCTAssertTrue(text.hasSuffix("\n"))
+    }
+
+    func testSetAxisUpdatesNamedCapabilityOnly() throws {
+        var matrix = try decodeMatrix(
+            #"""
+            {"schemaVersion":1,"capabilities":[
+              {"id":"publish.typed.sensor_msgs/Imu","apiSymbol":"p","pureSwift":"supported",
+               "rcl":"supported","platforms":["macOS"],"typeApplicability":"bundled",
+               "severity":"n-a-by-design",
+               "verification":{"latency":{"verdict":"pending"},"soak":{"verdict":"pending"},
+                 "correctness":{"verdict":"pending"},"resource":{"verdict":"pending"}}},
+              {"id":"param.declare","apiSymbol":"q","pureSwift":"supported",
+               "rcl":"supported","platforms":["macOS"],"typeApplicability":"n-a",
+               "severity":"n-a-by-design",
+               "verification":{"latency":{"verdict":"pending"},"soak":{"verdict":"pending"},
+                 "correctness":{"verdict":"pending"},"resource":{"verdict":"pending"}}}
+            ]}
+            """#)
+        try matrix.setAxis(
+            capabilityId: "publish.typed.sensor_msgs/Imu", axis: .correctness,
+            verdict: .pass, value: "CDR==rmw_serialize")
+        // The named capability + axis is updated...
+        XCTAssertEqual(matrix.capabilities[0].verification.correctness.verdict, .pass)
+        XCTAssertEqual(matrix.capabilities[0].verification.correctness.value, "CDR==rmw_serialize")
+        // ...its sibling axis is untouched...
+        XCTAssertEqual(matrix.capabilities[0].verification.latency.verdict, .pending)
+        // ...and so is every other capability.
+        XCTAssertEqual(matrix.capabilities[1].id, "param.declare")
+        XCTAssertEqual(matrix.capabilities[1].verification.correctness.verdict, .pending)
+        XCTAssertThrowsError(
+            try matrix.setAxis(capabilityId: "nope", axis: .latency, verdict: .pass, value: nil))
     }
 }

--- a/docs/parity-matrix.json
+++ b/docs/parity-matrix.json
@@ -1,35 +1,875 @@
 {
-  "schemaVersion": 1,
-  "capabilities": [
-    { "id": "context.create", "apiSymbol": "ROS2Context.init", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "n-a", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "rcl_bridge.c:65 crcl_context_create (rcl_init_options_init + set_domain_id + rcl_init); Context.swift makeDefaultSession .rcl arm under #if SWIFT_ROS2_RCL; RclTransportSessionTests" },
-    { "id": "node.create", "apiSymbol": "ROS2Node", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "n-a", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "rcl_bridge.c:101 crcl_node_create (rcl_node_init); RclClient.createNode:554; node creation works for N nodes \u2014 multi-node entity-binding tracked under node.multi" },
-    { "id": "node.multi", "apiSymbol": "ROS2Context multi-node", "pureSwift": "supported", "rcl": "partial", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "n-a", "severity": "major", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "RclTransportSession.swift:66 registerNode overwrites a single currentNode; preflightPublisher/Subscriber/ServiceEntity bind every entity to the last-registered node, so entities misroute under >1 node (wire path has no such ceiling)" },
-    { "id": "publish.typed.sensor_msgs/Imu", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "crcl_marshal_registry.c:24 Imu typesupport; Imu+RclMarshal.swift rclTypedPublish -> crcl_publish_imu; crcl-golden byte-parity (#121)" },
-    { "id": "publish.typed.sensor_msgs/Image", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "missing", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "byte-seam-only", "severity": "minor", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "raw sensor_msgs/Image is NOT in crcl_marshal_registry.c (only CompressedImage is); publisher creation is registry-gated (rcl_bridge.c:125) so raw Image is unpublishable on RCL. Conduit uses CompressedImage" },
-    { "id": "publish.typed.sensor_msgs/PointCloud2", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "crcl_marshal_registry.c:36 PointCloud2 typesupport; PointCloud2+RclMarshal.swift; crcl-golden byte-parity (populated + empty)" },
-    { "id": "publish.typed.sensor_msgs/BatteryState", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "crcl_marshal_registry.c:13 sensor_msgs/msg/BatteryState typesupport; BatteryState+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)" },
-    { "id": "publish.typed.sensor_msgs/CompressedImage", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "crcl_marshal_registry.c:16 sensor_msgs/msg/CompressedImage typesupport; CompressedImage+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)" },
-    { "id": "publish.typed.sensor_msgs/FluidPressure", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "crcl_marshal_registry.c:19 sensor_msgs/msg/FluidPressure typesupport; FluidPressure+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)" },
-    { "id": "publish.typed.sensor_msgs/Illuminance", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "crcl_marshal_registry.c:22 sensor_msgs/msg/Illuminance typesupport; Illuminance+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)" },
-    { "id": "publish.typed.sensor_msgs/Joy", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "crcl_marshal_registry.c:28 sensor_msgs/msg/Joy typesupport; Joy+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)" },
-    { "id": "publish.typed.sensor_msgs/MagneticField", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "crcl_marshal_registry.c:31 sensor_msgs/msg/MagneticField typesupport; MagneticField+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)" },
-    { "id": "publish.typed.sensor_msgs/NavSatFix", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "crcl_marshal_registry.c:34 sensor_msgs/msg/NavSatFix typesupport; NavSatFix+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)" },
-    { "id": "publish.typed.sensor_msgs/Range", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "crcl_marshal_registry.c:40 sensor_msgs/msg/Range typesupport; Range+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)" },
-    { "id": "publish.typed.sensor_msgs/Temperature", "apiSymbol": "ROS2Publisher.publish(_:)", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "crcl_marshal_registry.c:43 sensor_msgs/msg/Temperature typesupport; Temperature+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)" },
-    { "id": "publish.serialized.non_bundled", "apiSymbol": "ROS2Publisher.publish(_:) byte seam", "pureSwift": "supported", "rcl": "missing", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "byte-seam-only", "severity": "blocker", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "rcl_bridge.c:122-130 crcl_publisher_create rejects any type absent from crcl_marshal_registry.c ('unsupported type'); the byte seam only selects a method on an already-created bundled publisher, so non-bundled types cannot open a publisher at all \u2014 blocks Conduit AudioData + CompressedPointCloud2" },
-    { "id": "subscribe.serialized.sensor_msgs/Imu", "apiSymbol": "ROS2Subscription", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "rcl_subscription.c rcl_take_serialized_message -> (Data,UInt64) seam; Imu bundled in registry; Node.swift:110 CDRDecoder decode is identical across backends" },
-    { "id": "subscribe.serialized.sensor_msgs/Image", "apiSymbol": "ROS2Subscription", "pureSwift": "supported", "rcl": "missing", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "byte-seam-only", "severity": "minor", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "raw Image not bundled; rcl_subscription.c:102-108 crcl_subscription_create is registry-gated -> 'unsupported type' for raw Image" },
-    { "id": "subscribe.serialized.sensor_msgs/PointCloud2", "apiSymbol": "ROS2Subscription", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "PointCloud2 bundled in registry; rcl_subscription.c serialized take + Node.swift CDRDecoder" },
-    { "id": "subscribe.serialized.non_bundled", "apiSymbol": "ROS2Subscription", "pureSwift": "supported", "rcl": "missing", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "byte-seam-only", "severity": "major", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "rcl_subscription.c:102-108 crcl_subscription_create is registry-gated -> 'unsupported type' for any type absent from crcl_marshal_registry.c; pure-Swift ROS2Subscription<M> decodes any CDRDecodable type" },
-    { "id": "service.server", "apiSymbol": "ROS2Node service server", "pureSwift": "supported", "rcl": "partial", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "major", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "rcl_service.c crcl_service_create gated on crcl_srv_registry_lookup (12 bundled srv types, crcl_srv_registry.c); no byte-seam fallback for services. Wire path serves any ROS2ServiceType" },
-    { "id": "service.client", "apiSymbol": "ROS2Node service client", "pureSwift": "supported", "rcl": "partial", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "major", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "rcl_client.c:135-143 crcl_client_create gated on the 12-entry srv registry; ROS2Client is generic over any service on the wire path" },
-    { "id": "param.declare", "apiSymbol": "ROS2Node parameters", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "n-a", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "backend-agnostic ParameterStore actor; declareParameter identical across backends" },
-    { "id": "param.getset", "apiSymbol": "ROS2Node parameters", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "n-a", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "ParameterStore get/set is backend-agnostic; served via bundled rcl_interfaces param services (crcl_srv_registry.c) on RCL" },
-    { "id": "param.event", "apiSymbol": "ParameterEvent", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "n-a", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "/parameter_events via installParameterEventEmitter + lazy ParameterEvent publisher (rcl_interfaces/msg/ParameterEvent bundled in crcl_marshal_registry.c)" },
-    { "id": "action.server", "apiSymbol": "ROS2Node action server", "pureSwift": "supported", "rcl": "partial", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "major", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "rcl_action_server.c:212-220 crcl_action_server_create gated on crcl_action_registry_lookup; registry holds 1 entry (example_interfaces/action/Fibonacci). Wire path serves any action" },
-    { "id": "action.client", "apiSymbol": "ROS2Node action client", "pureSwift": "supported", "rcl": "partial", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "bundled", "severity": "major", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "rcl_action_client.c crcl_action_client_create gated on crcl_action_registry (CRCL_ACTION_REGISTRY_ENTRY_COUNT 1, Fibonacci only)" },
-    { "id": "qos.profiles", "apiSymbol": "QoSProfile", "pureSwift": "supported", "rcl": "supported", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "n-a", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "makeCrclQoS maps reliability/durability/history/depth -> rmw_qos_profile; same knob set as pure-Swift TransportQoS (deadline/lifespan/liveliness absent on both = parity)" },
-    { "id": "transport.dds", "apiSymbol": "TransportConfig.type=.dds", "pureSwift": "supported", "rcl": "partial", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "n-a", "severity": "major", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "RCL rides rmw_cyclonedds (DDS wire works, integration-tested) but RclTransportSession.open reads only domainId; ddsDiscoveryMode/ddsUnicastPeers/ddsNetworkInterface are silently ignored \u2014 unicast/interface only via CYCLONEDDS_URI env var. Conduit exposes dds_discovery_mode/dds_unicast_peers" },
-    { "id": "transport.zenoh", "apiSymbol": "TransportConfig.type=.zenoh", "pureSwift": "supported", "rcl": "partial", "platforms": ["iOS","Catalyst","macOS","visionOS"], "typeApplicability": "n-a", "severity": "n-a-by-design", "verification": { "latency": {"verdict":"pending"}, "soak": {"verdict":"pending"}, "correctness": {"verdict":"pending"}, "resource": {"verdict":"pending"} }, "evidence": "RCL-over-Zenoh only via build-time SWIFT_ROS2_RCL_RMW=zenoh variant (CRos2JazzyZenoh, #128); TransportConfig.rcl takes no zenoh selector and the .zenoh API arm never routes through RCL (dropZenohWire carves out zenoh-pico)" }
-  ]
+  "capabilities" : [
+    {
+      "apiSymbol" : "ROS2Context.init",
+      "evidence" : "rcl_bridge.c:65 crcl_context_create (rcl_init_options_init + set_domain_id + rcl_init); Context.swift makeDefaultSession .rcl arm under #if SWIFT_ROS2_RCL; RclTransportSessionTests",
+      "id" : "context.create",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "n-a",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Node",
+      "evidence" : "rcl_bridge.c:101 crcl_node_create (rcl_node_init); RclClient.createNode:554; node creation works for N nodes — multi-node entity-binding tracked under node.multi",
+      "id" : "node.create",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "n-a",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Context multi-node",
+      "evidence" : "RclTransportSession.swift:66 registerNode overwrites a single currentNode; preflightPublisher/Subscriber/ServiceEntity bind every entity to the last-registered node, so entities misroute under >1 node (wire path has no such ceiling)",
+      "id" : "node.multi",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "partial",
+      "severity" : "major",
+      "typeApplicability" : "n-a",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "crcl_marshal_registry.c:24 Imu typesupport; Imu+RclMarshal.swift rclTypedPublish -> crcl_publish_imu; crcl-golden byte-parity (#121)",
+      "id" : "publish.typed.sensor_msgs/Imu",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "raw sensor_msgs/Image is NOT in crcl_marshal_registry.c (only CompressedImage is); publisher creation is registry-gated (rcl_bridge.c:125) so raw Image is unpublishable on RCL. Conduit uses CompressedImage",
+      "id" : "publish.typed.sensor_msgs/Image",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "missing",
+      "severity" : "minor",
+      "typeApplicability" : "byte-seam-only",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "crcl_marshal_registry.c:36 PointCloud2 typesupport; PointCloud2+RclMarshal.swift; crcl-golden byte-parity (populated + empty)",
+      "id" : "publish.typed.sensor_msgs/PointCloud2",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "crcl_marshal_registry.c:13 sensor_msgs/msg/BatteryState typesupport; BatteryState+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)",
+      "id" : "publish.typed.sensor_msgs/BatteryState",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "crcl_marshal_registry.c:16 sensor_msgs/msg/CompressedImage typesupport; CompressedImage+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)",
+      "id" : "publish.typed.sensor_msgs/CompressedImage",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "crcl_marshal_registry.c:19 sensor_msgs/msg/FluidPressure typesupport; FluidPressure+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)",
+      "id" : "publish.typed.sensor_msgs/FluidPressure",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "crcl_marshal_registry.c:22 sensor_msgs/msg/Illuminance typesupport; Illuminance+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)",
+      "id" : "publish.typed.sensor_msgs/Illuminance",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "crcl_marshal_registry.c:28 sensor_msgs/msg/Joy typesupport; Joy+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)",
+      "id" : "publish.typed.sensor_msgs/Joy",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "crcl_marshal_registry.c:31 sensor_msgs/msg/MagneticField typesupport; MagneticField+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)",
+      "id" : "publish.typed.sensor_msgs/MagneticField",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "crcl_marshal_registry.c:34 sensor_msgs/msg/NavSatFix typesupport; NavSatFix+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)",
+      "id" : "publish.typed.sensor_msgs/NavSatFix",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "crcl_marshal_registry.c:40 sensor_msgs/msg/Range typesupport; Range+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)",
+      "id" : "publish.typed.sensor_msgs/Range",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:)",
+      "evidence" : "crcl_marshal_registry.c:43 sensor_msgs/msg/Temperature typesupport; Temperature+RclMarshal.swift rclTypedPublish (one of 11 bundled sensor_msgs types)",
+      "id" : "publish.typed.sensor_msgs/Temperature",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Publisher.publish(_:) byte seam",
+      "evidence" : "rcl_bridge.c:122-130 crcl_publisher_create rejects any type absent from crcl_marshal_registry.c ('unsupported type'); the byte seam only selects a method on an already-created bundled publisher, so non-bundled types cannot open a publisher at all — blocks Conduit AudioData + CompressedPointCloud2",
+      "id" : "publish.serialized.non_bundled",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "missing",
+      "severity" : "blocker",
+      "typeApplicability" : "byte-seam-only",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Subscription",
+      "evidence" : "rcl_subscription.c rcl_take_serialized_message -> (Data,UInt64) seam; Imu bundled in registry; Node.swift:110 CDRDecoder decode is identical across backends",
+      "id" : "subscribe.serialized.sensor_msgs/Imu",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Subscription",
+      "evidence" : "raw Image not bundled; rcl_subscription.c:102-108 crcl_subscription_create is registry-gated -> 'unsupported type' for raw Image",
+      "id" : "subscribe.serialized.sensor_msgs/Image",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "missing",
+      "severity" : "minor",
+      "typeApplicability" : "byte-seam-only",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Subscription",
+      "evidence" : "PointCloud2 bundled in registry; rcl_subscription.c serialized take + Node.swift CDRDecoder",
+      "id" : "subscribe.serialized.sensor_msgs/PointCloud2",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Subscription",
+      "evidence" : "rcl_subscription.c:102-108 crcl_subscription_create is registry-gated -> 'unsupported type' for any type absent from crcl_marshal_registry.c; pure-Swift ROS2Subscription<M> decodes any CDRDecodable type",
+      "id" : "subscribe.serialized.non_bundled",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "missing",
+      "severity" : "major",
+      "typeApplicability" : "byte-seam-only",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Node service server",
+      "evidence" : "rcl_service.c crcl_service_create gated on crcl_srv_registry_lookup (12 bundled srv types, crcl_srv_registry.c); no byte-seam fallback for services. Wire path serves any ROS2ServiceType",
+      "id" : "service.server",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "partial",
+      "severity" : "major",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Node service client",
+      "evidence" : "rcl_client.c:135-143 crcl_client_create gated on the 12-entry srv registry; ROS2Client is generic over any service on the wire path",
+      "id" : "service.client",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "partial",
+      "severity" : "major",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Node parameters",
+      "evidence" : "backend-agnostic ParameterStore actor; declareParameter identical across backends",
+      "id" : "param.declare",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "n-a",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Node parameters",
+      "evidence" : "ParameterStore get/set is backend-agnostic; served via bundled rcl_interfaces param services (crcl_srv_registry.c) on RCL",
+      "id" : "param.getset",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "n-a",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ParameterEvent",
+      "evidence" : "/parameter_events via installParameterEventEmitter + lazy ParameterEvent publisher (rcl_interfaces/msg/ParameterEvent bundled in crcl_marshal_registry.c)",
+      "id" : "param.event",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "n-a",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Node action server",
+      "evidence" : "rcl_action_server.c:212-220 crcl_action_server_create gated on crcl_action_registry_lookup; registry holds 1 entry (example_interfaces/action/Fibonacci). Wire path serves any action",
+      "id" : "action.server",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "partial",
+      "severity" : "major",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "ROS2Node action client",
+      "evidence" : "rcl_action_client.c crcl_action_client_create gated on crcl_action_registry (CRCL_ACTION_REGISTRY_ENTRY_COUNT 1, Fibonacci only)",
+      "id" : "action.client",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "partial",
+      "severity" : "major",
+      "typeApplicability" : "bundled",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "QoSProfile",
+      "evidence" : "makeCrclQoS maps reliability/durability/history/depth -> rmw_qos_profile; same knob set as pure-Swift TransportQoS (deadline/lifespan/liveliness absent on both = parity)",
+      "id" : "qos.profiles",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "supported",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "n-a",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "TransportConfig.type=.dds",
+      "evidence" : "RCL rides rmw_cyclonedds (DDS wire works, integration-tested) but RclTransportSession.open reads only domainId; ddsDiscoveryMode/ddsUnicastPeers/ddsNetworkInterface are silently ignored — unicast/interface only via CYCLONEDDS_URI env var. Conduit exposes dds_discovery_mode/dds_unicast_peers",
+      "id" : "transport.dds",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "partial",
+      "severity" : "major",
+      "typeApplicability" : "n-a",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    },
+    {
+      "apiSymbol" : "TransportConfig.type=.zenoh",
+      "evidence" : "RCL-over-Zenoh only via build-time SWIFT_ROS2_RCL_RMW=zenoh variant (CRos2JazzyZenoh, #128); TransportConfig.rcl takes no zenoh selector and the .zenoh API arm never routes through RCL (dropZenohWire carves out zenoh-pico)",
+      "id" : "transport.zenoh",
+      "platforms" : [
+        "iOS",
+        "Catalyst",
+        "macOS",
+        "visionOS"
+      ],
+      "pureSwift" : "supported",
+      "rcl" : "partial",
+      "severity" : "n-a-by-design",
+      "typeApplicability" : "n-a",
+      "verification" : {
+        "correctness" : {
+          "verdict" : "pending"
+        },
+        "latency" : {
+          "verdict" : "pending"
+        },
+        "resource" : {
+          "verdict" : "pending"
+        },
+        "soak" : {
+          "verdict" : "pending"
+        }
+      }
+    }
+  ],
+  "schemaVersion" : 1
 }


### PR DESCRIPTION
## What & why

W3 verification harness, Part 1 (of a 2-PR stack). Adds the **matrix write-back path** so benchmark/test runs can fold measured `{verdict, value}` results into the parity matrix deterministically — the connective tissue every verification axis writes through.

## Changes

- **`ParityMatrix`** gains `Axis` (the four verification axes), a `setAxis(capabilityId:axis:verdict:value:)` mutator, and `encodeCanonicalJSON()` (sorted keys, pretty, unescaped slashes, trailing newline).
- **`parity-tool`** gains two subcommands:
  - `set <id> --axis <a> --verdict <v> [--value <s>]` — record a verdict for one capability axis, then re-write canonical JSON + re-render `PARITY.md` (atomic writes).
  - `canonicalize` — rewrite the matrix JSON in canonical form (idempotent).
- **`docs/parity-matrix.json`** normalized to canonical form once (large but purely mechanical reformat; all 30 capability rows' data unchanged, every verification axis still `pending`).
- **CI drift guard** extended: the `parity-matrix` job now runs `render` → `canonicalize` → `git diff --exit-code`, so a non-canonical hand edit fails CI.

## Verification

- `ParityMatrixTests`: 6/6 pass (incl. canonical-encode determinism + per-axis isolation).
- `swift format lint --strict` clean over `Package.swift Sources Tests`.
- Drift guard simulated locally: `render` + `canonicalize` + `git diff --exit-code` is clean on the committed state.
- No verdict values recorded yet — correctness verdicts land in Part 2 (the byte-parity oracle PR), which stacks on this branch.

## Notes

- Public API additions are additive (no removals/signature changes), so the API-stability gate is unaffected.