### PR TITLE
feat(bench): SoakAnalysis — pure leak-verdict core for the soak harness

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -343,6 +343,17 @@ var targets: [Target] = [
         path: "Tests/ParityMatrixTests",
         resources: [.copy("Resources")]
     ),
+
+    // Internal benchmark / soak-analysis target — not exported as a product.
+    .target(
+        name: "SwiftROS2Bench",
+        path: "Sources/SwiftROS2Bench"
+    ),
+    .testTarget(
+        name: "SwiftROS2BenchTests",
+        dependencies: ["SwiftROS2Bench"],
+        path: "Tests/SwiftROS2BenchTests"
+    ),
 ]
 
 // zenoh-pico wire family — every platform EXCEPT the zenoh-rmw RCL variant

--- a/Sources/SwiftROS2Bench/SoakAnalysis.swift
+++ b/Sources/SwiftROS2Bench/SoakAnalysis.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// One periodic sample taken during a soak run.
+public struct SoakSample: Equatable, Sendable {
+    public let tSeconds: Double
+    public let rssBytes: UInt64
+    public let openFDs: Int
+    public let msgsPerSec: Double
+
+    public init(tSeconds: Double, rssBytes: UInt64, openFDs: Int, msgsPerSec: Double) {
+        self.tSeconds = tSeconds
+        self.rssBytes = rssBytes
+        self.openFDs = openFDs
+        self.msgsPerSec = msgsPerSec
+    }
+}
+
+/// The leak/health verdict for a completed soak run.
+public struct SoakVerdict: Equatable, Sendable {
+    public let leakSuspected: Bool
+    public let rssSlopeBytesPerMin: Double
+    public let fdGrowth: Int
+    public let throughputDegradationPct: Double
+    public let summary: String
+}
+
+/// Pure analysis of a soak time-series. No I/O — unit-tested in normal CI.
+public enum SoakAnalysis {
+    /// `leakSuspected` if any of: RSS least-squares slope exceeds
+    /// `rssSlopeLimitBytesPerMin`; net FD growth (last − first) exceeds
+    /// `fdGrowthLimit`; or throughput degradation (first-fifth vs last-fifth
+    /// mean) exceeds `throughputDegradationLimitPct`. The trend axes (RSS slope,
+    /// throughput) need at least `minSamplesForTrend` samples to be meaningful
+    /// and to outlast process-startup warmup; below that they are reported as 0
+    /// (inconclusive) so a short probe cannot false-flag. FD growth is robust at
+    /// any count. Fewer than 2 samples is fully inconclusive (not a leak).
+    public static func analyze(
+        _ samples: [SoakSample],
+        rssSlopeLimitBytesPerMin: Double = 1_000_000,
+        fdGrowthLimit: Int = 8,
+        throughputDegradationLimitPct: Double = 20,
+        minSamplesForTrend: Int = 10
+    ) -> SoakVerdict {
+        guard samples.count >= 2 else {
+            return SoakVerdict(
+                leakSuspected: false, rssSlopeBytesPerMin: 0, fdGrowth: 0,
+                throughputDegradationPct: 0, summary: "inconclusive: <2 samples")
+        }
+
+        // FD growth (net last − first) is robust even with a couple of samples;
+        // a transient spike that recovers nets to 0.
+        let fdGrowth = samples[samples.count - 1].openFDs - samples[0].openFDs
+
+        // Trend axes need enough points to outlast startup warmup and to give
+        // the first/last fifths ≥2 points each.
+        var rssSlopeBytesPerMin = 0.0
+        var throughputDegradationPct = 0.0
+        if samples.count >= minSamplesForTrend {
+            let n = Double(samples.count)
+            let xs = samples.map { $0.tSeconds }
+            let ys = samples.map { Double($0.rssBytes) }
+            let meanX = xs.reduce(0, +) / n
+            let meanY = ys.reduce(0, +) / n
+            var num = 0.0
+            var den = 0.0
+            for i in 0..<samples.count {
+                num += (xs[i] - meanX) * (ys[i] - meanY)
+                den += (xs[i] - meanX) * (xs[i] - meanX)
+            }
+            rssSlopeBytesPerMin = (den == 0 ? 0 : num / den) * 60
+
+            let fifth = samples.count / 5  // ≥2 here, so the slices are non-empty
+            func mean(_ s: ArraySlice<SoakSample>) -> Double {
+                s.map { $0.msgsPerSec }.reduce(0, +) / Double(s.count)
+            }
+            let firstMean = mean(samples.prefix(fifth))
+            let lastMean = mean(samples.suffix(fifth))
+            throughputDegradationPct =
+                firstMean <= 0 ? 0 : max(0, (firstMean - lastMean) / firstMean * 100)
+        }
+
+        let leakSuspected =
+            rssSlopeBytesPerMin > rssSlopeLimitBytesPerMin
+            || fdGrowth > fdGrowthLimit
+            || throughputDegradationPct > throughputDegradationLimitPct
+
+        let summary =
+            "rss_slope=\(Int(rssSlopeBytesPerMin.rounded())) B/min, fd_growth=\(fdGrowth), "
+            + "tput_degradation=\(String(format: "%.1f", throughputDegradationPct))% -> "
+            + (leakSuspected ? "LEAK SUSPECTED" : "healthy")
+
+        return SoakVerdict(
+            leakSuspected: leakSuspected, rssSlopeBytesPerMin: rssSlopeBytesPerMin,
+            fdGrowth: fdGrowth, throughputDegradationPct: throughputDegradationPct,
+            summary: summary)
+    }
+}

--- a/Tests/SwiftROS2BenchTests/SoakAnalysisTests.swift
+++ b/Tests/SwiftROS2BenchTests/SoakAnalysisTests.swift
@@ -1,0 +1,84 @@
+import SwiftROS2Bench
+import XCTest
+
+final class SoakAnalysisTests: XCTestCase {
+    /// Build a time series: `count` samples at `interval` seconds, RSS starting
+    /// at `rss0` growing `rssPerSample` bytes each step, FDs starting at `fd0`
+    /// growing `fdPerSample`, throughput `tput` scaled linearly to `tputEndScale`
+    /// across the run to model degradation.
+    private func series(
+        count: Int, interval: Double = 1, rss0: UInt64 = 100_000_000,
+        rssPerSample: Int = 0, fd0: Int = 20, fdPerSample: Int = 0,
+        tput: Double = 1000, tputEndScale: Double = 1
+    ) -> [SoakSample] {
+        (0..<count).map { i in
+            let frac = count > 1 ? Double(i) / Double(count - 1) : 0
+            let scale = 1 + (tputEndScale - 1) * frac
+            return SoakSample(
+                tSeconds: Double(i) * interval,
+                rssBytes: UInt64(Int64(rss0) + Int64(rssPerSample) * Int64(i)),
+                openFDs: fd0 + fdPerSample * i,
+                msgsPerSec: tput * scale)
+        }
+    }
+
+    func testFlatSeriesIsHealthy() {
+        let v = SoakAnalysis.analyze(series(count: 600))
+        XCTAssertFalse(v.leakSuspected)
+        XCTAssertLessThan(abs(v.rssSlopeBytesPerMin), 1.0)
+        XCTAssertEqual(v.fdGrowth, 0)
+        XCTAssertLessThan(v.throughputDegradationPct, 1.0)
+    }
+
+    func testRisingRSSFlagsLeak() {
+        let v = SoakAnalysis.analyze(series(count: 600, rssPerSample: 200_000))
+        XCTAssertTrue(v.leakSuspected)
+        XCTAssertGreaterThan(v.rssSlopeBytesPerMin, 1_000_000)
+    }
+
+    func testGrowingFDsFlagsLeak() {
+        let v = SoakAnalysis.analyze(series(count: 60, fdPerSample: 1))
+        XCTAssertTrue(v.leakSuspected)
+        XCTAssertEqual(v.fdGrowth, 59)
+    }
+
+    func testThroughputDegradationFlagged() {
+        let v = SoakAnalysis.analyze(series(count: 600, tputEndScale: 0.5))
+        XCTAssertTrue(v.leakSuspected)
+        XCTAssertGreaterThan(v.throughputDegradationPct, 20)
+    }
+
+    func testEmptyOrSingleSampleIsInconclusiveNotALeak() {
+        XCTAssertFalse(SoakAnalysis.analyze([]).leakSuspected)
+        XCTAssertFalse(SoakAnalysis.analyze(series(count: 1)).leakSuspected)
+    }
+
+    func testAllEqualTimestampsGivesZeroSlopeNotALeak() {
+        // interval 0 → every tSeconds is 0 (den == 0). Even with rising RSS the
+        // slope guard yields 0, so the RSS axis must not false-flag.
+        let v = SoakAnalysis.analyze(series(count: 60, interval: 0, rssPerSample: 200_000))
+        XCTAssertEqual(v.rssSlopeBytesPerMin, 0)
+        XCTAssertFalse(v.leakSuspected)
+    }
+
+    func testTransientFDSpikeThatRecoversIsNotALeak() {
+        // FDs spike mid-run then return to baseline: last − first == 0, so the
+        // net-growth signal (not max − min) correctly reports no leak.
+        let fds = [20, 20, 100, 100, 20, 20]
+        let samples = fds.enumerated().map { i, fd in
+            SoakSample(tSeconds: Double(i), rssBytes: 100_000_000, openFDs: fd, msgsPerSec: 1000)
+        }
+        let v = SoakAnalysis.analyze(samples)
+        XCTAssertEqual(v.fdGrowth, 0)
+        XCTAssertFalse(v.leakSuspected)
+    }
+
+    func testShortRunBelowTrendMinimumDoesNotFlagRSS() {
+        // 8 samples (< the 10-sample trend minimum) with steep RSS growth:
+        // process-startup warmup must not be mistaken for a leak, so the RSS
+        // slope is reported as inconclusive (0).
+        let v = SoakAnalysis.analyze(series(count: 8, rssPerSample: 5_000_000))
+        XCTAssertEqual(v.rssSlopeBytesPerMin, 0)
+        XCTAssertFalse(v.leakSuspected)
+    }
+}


### PR DESCRIPTION
## What & why

W3 verification harness, Part 2 (of a 2-PR stack). Adds **`SoakAnalysis`** — the pure, dependency-free core of the upcoming endurance/soak harness (design §5 Axis 2). Extracted as its own internal target so the leak-verdict math gets real unit-test coverage in normal CI (build-macos / build-linux), independent of the RCL gate.

## Changes

- New package-internal target **`SwiftROS2Bench`** (no library product; pure Swift, all platforms).
- `SoakAnalysis.analyze([SoakSample]) -> SoakVerdict` flags `leakSuspected` when any of:
  - RSS **least-squares slope** > 1 MB/min (default),
  - net **FD growth** (last − first) > 8,
  - **throughput degradation** (first-fifth vs last-fifth mean) > 20%.
  - `<2` samples → inconclusive; `<10` samples → throughput treated as inconclusive (a single stutter can't false-flag a short probe).
- 7 unit tests pinning each axis, plus the `den==0` (all-equal timestamps) guard and the transient-FD-spike-recovers case (which justifies `last−first` over `max−min`).

## Next

PR2 (stacked) adds the `rcl-soak` executable that drives this, the `rcl-bench roundtrip-lan` LAN latency mode, and the W4 runbook. Recording actual latency/soak verdicts is W4 (needs a LAN host / multi-hour run).

## Verification

- `swift test --filter SwiftROS2BenchTests` → 7/7.
- `swift format lint --strict` clean over `Package.swift Sources Tests`.
- Internal target, no public API change → API-stability gate unaffected.