### PR TITLE
feat(bench): rcl-soak endurance harness + rcl-bench LAN latency mode (Axes 1 & 2)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -684,6 +684,14 @@ if enableRcl {
         ))
     products.append(.executable(name: "rcl-bench", targets: ["rcl-bench"]))
     targets.append(
+        .executableTarget(
+            name: "rcl-soak",
+            dependencies: ["SwiftROS2", "SwiftROS2RCL", "SwiftROS2Bench"],
+            path: "Sources/Examples/RclSoak",
+            linkerSettings: [.linkedLibrary("c++")]
+        ))
+    products.append(.executable(name: "rcl-soak", targets: ["rcl-soak"]))
+    targets.append(
         .target(
             name: "SwiftROS2RCL",
             dependencies: ["CRclBridge", "SwiftROS2Transport", "SwiftROS2Messages"],

--- a/Package.swift
+++ b/Package.swift
@@ -343,6 +343,17 @@ var targets: [Target] = [
         path: "Tests/ParityMatrixTests",
         resources: [.copy("Resources")]
     ),
+
+    // Internal benchmark / soak-analysis target — not exported as a product.
+    .target(
+        name: "SwiftROS2Bench",
+        path: "Sources/SwiftROS2Bench"
+    ),
+    .testTarget(
+        name: "SwiftROS2BenchTests",
+        dependencies: ["SwiftROS2Bench"],
+        path: "Tests/SwiftROS2BenchTests"
+    ),
 ]
 
 // zenoh-pico wire family — every platform EXCEPT the zenoh-rmw RCL variant

--- a/Sources/Examples/RclBench/main.swift
+++ b/Sources/Examples/RclBench/main.swift
@@ -3,18 +3,21 @@
 // never share a participant.
 //
 // Usage:
-//   rcl-bench <rcl|dds> <publish|roundtrip|encode> [imu|image64k|cloud120k]
-//             [--count N] [--rate-hz N]
+//   rcl-bench <rcl|dds> <publish|roundtrip|roundtrip-lan|encode> [imu|image64k|cloud120k]
+//             [--count N] [--rate-hz N] [--domain N]
 //
 // Modes:
-//   publish   — per-publish call latency + max-rate throughput (no subscriber)
-//   roundtrip — in-process pub -> sub end-to-end latency via header.stamp
-//               (send time embedded; receiver computes now - stamp on the
-//               delivery callback thread)
-//   encode    — serialization only: CDREncoder (dds) vs marshal + rmw_serialize
-//               (rcl, via the rclSerialize<Type> golden entry points; the
-//               typed publish path has no marshal-only seam, so this is the
-//               documented encode-side proxy)
+//   publish       — per-publish call latency + max-rate throughput (no subscriber)
+//   roundtrip     — in-process pub -> sub end-to-end latency via header.stamp
+//                   (send time embedded; receiver computes now - stamp on the
+//                   delivery callback thread)
+//   roundtrip-lan — end-to-end latency vs a LAN host that relays `bench` ->
+//                   `bench_echo` (run `ros2 run topic_tools relay <ns>/bench
+//                   <ns>/bench_echo` on the host)
+//   encode        — serialization only: CDREncoder (dds) vs marshal + rmw_serialize
+//                   (rcl, via the rclSerialize<Type> golden entry points; the
+//                   typed publish path has no marshal-only seam, so this is the
+//                   documented encode-side proxy)
 //
 // Results print as single `rcl_bench RESULT ...` key=value lines (µs).
 
@@ -28,15 +31,16 @@ let args = CommandLine.arguments
 guard args.count >= 3 else {
     print(
         """
-        usage: rcl-bench <rcl|dds> <publish|roundtrip|encode> \
-        [imu|image64k|cloud120k] [--count N] [--rate-hz N]
+        usage: rcl-bench <rcl|dds> <publish|roundtrip|roundtrip-lan|encode> \
+        [imu|image64k|cloud120k] [--count N] [--rate-hz N] [--domain N]
         """)
     exit(2)
 }
 let backend = args[1]
 let mode = args[2]
 let payload = args.count > 3 && !args[3].hasPrefix("--") ? args[3] : "imu"
-guard ["rcl", "dds"].contains(backend), ["publish", "roundtrip", "encode"].contains(mode),
+guard ["rcl", "dds"].contains(backend),
+    ["publish", "roundtrip", "roundtrip-lan", "encode"].contains(mode),
     ["imu", "image64k", "cloud120k"].contains(payload)
 else {
     print("rcl_bench FAIL: unknown backend/mode/payload \(backend)/\(mode)/\(payload)")
@@ -55,8 +59,7 @@ let count = intOption(
     "--count", default: mode == "encode" ? (isLarge ? 5_000 : 100_000) : (isLarge ? 1_000 : 10_000))
 let rateHz = intOption("--rate-hz", default: 0)  // 0 = max rate
 let warmup = isLarge ? 100 : 1_000
-// Isolated domain so LAN nodes never interfere with the measurement.
-let domainId = 42
+let domainId = intOption("--domain", default: 42)
 
 // MARK: - timing helpers
 
@@ -235,17 +238,20 @@ func runPubSub() async throws {
         let s = stampedNS(t)
         if s != 0 { collector.record(nowNS() &- s) }
     }
-    if mode == "roundtrip" {
+    let isRoundtrip = mode == "roundtrip" || mode == "roundtrip-lan"
+    let subTopic = mode == "roundtrip-lan" ? "bench_echo" : "bench"
+    if isRoundtrip {
         switch payload {
         case "imu":
-            let sub = try await node.createSubscription(Imu.self, topic: "bench", qos: qos)
+            let sub = try await node.createSubscription(Imu.self, topic: subTopic, qos: qos)
             sub.onMessage { m in recordStamped(m.header.stamp) }
         case "image64k":
             let sub = try await node.createSubscription(
-                CompressedImage.self, topic: "bench", qos: qos)
+                CompressedImage.self, topic: subTopic, qos: qos)
             sub.onMessage { m in recordStamped(m.header.stamp) }
         default:
-            let sub = try await node.createSubscription(PointCloud2.self, topic: "bench", qos: qos)
+            let sub = try await node.createSubscription(
+                PointCloud2.self, topic: subTopic, qos: qos)
             sub.onMessage { m in recordStamped(m.header.stamp) }
         }
     }
@@ -261,7 +267,7 @@ func runPubSub() async throws {
     {
         let pub = try await node.createPublisher(M.self, topic: "bench", qos: qos)
         // Discovery settle (repo precedent: 2 s loopback, 3 s LAN).
-        try await Task.sleep(for: .seconds(2))
+        try await Task.sleep(for: .seconds(mode == "roundtrip-lan" ? 3 : 2))
         var msg = make()
         for _ in 0..<warmup { try await pub.publish(msg) }
         let start = nowNS()
@@ -290,7 +296,7 @@ func runPubSub() async throws {
     }
 
     var received = collector.snapshot.count
-    if mode == "roundtrip" {
+    if isRoundtrip {
         // Drain window for in-flight messages.
         let deadline = nowNS() + 5_000_000_000
         while received < count && nowNS() < deadline {
@@ -299,10 +305,10 @@ func runPubSub() async throws {
         }
     }
 
-    let p = mode == "roundtrip" ? percentiles(collector.snapshot) : percentiles(callNS)
+    let p = isRoundtrip ? percentiles(collector.snapshot) : percentiles(callNS)
     printResult([
         "backend": backend, "mode": mode, "payload": payload, "count": "\(count)",
-        "received": mode == "roundtrip" ? "\(received)" : "-",
+        "received": isRoundtrip ? "\(received)" : "-",
         "rate_hz": rateHz > 0 ? "\(rateHz)" : "max",
         "msgs_per_s": String(format: "%.0f", Double(count) / wall),
         "p50us": String(format: "%.2f", p.p50), "p95us": String(format: "%.2f", p.p95),

--- a/Sources/Examples/RclSoak/main.swift
+++ b/Sources/Examples/RclSoak/main.swift
@@ -1,0 +1,214 @@
+// rcl-soak — endurance / leak harness (design §5 Axis 2). Streams a corpus
+// payload at a fixed rate for a bounded duration, samples RSS + open-FD count
+// + throughput on an interval, prints the time series, and reports the
+// SoakAnalysis verdict. Built for the W4 long run; `--selftest` does a fast
+// 2 s in-process smoke that asserts the harness itself works.
+//
+// Usage:
+//   rcl-soak <rcl|dds> [imu|image64k|cloud120k] [--duration-s N] [--sample-s N]
+//            [--rate-hz N] [--domain N] [--selftest] [--inject-malformed]
+//
+// Output: per-sample `rcl_soak SAMPLE t=.. rss_mb=.. fds=.. msgs_per_s=..`
+//         then a final `rcl_soak RESULT verdict=.. rss_slope_b_per_min=.. ...`.
+
+import Darwin
+import Dispatch
+import Foundation
+import SwiftROS2
+import SwiftROS2Bench
+import SwiftROS2RCL
+
+// MARK: - CLI
+
+let args = CommandLine.arguments
+func flag(_ name: String) -> Bool { args.contains(name) }
+func intOpt(_ name: String, _ def: Int) -> Int {
+    guard let i = args.firstIndex(of: name), i + 1 < args.count, let v = Int(args[i + 1]) else {
+        return def
+    }
+    return v
+}
+
+let selftest = flag("--selftest")
+let backend = args.count > 1 && !args[1].hasPrefix("--") ? args[1] : "rcl"
+let payload = args.count > 2 && !args[2].hasPrefix("--") ? args[2] : "imu"
+let durationS = intOpt("--duration-s", selftest ? 2 : 3600)
+let sampleS = intOpt("--sample-s", selftest ? 1 : 30)
+let rateHz = intOpt("--rate-hz", 100)
+let domainId = intOpt("--domain", 42)
+let injectMalformed = flag("--inject-malformed")
+
+guard ["rcl", "dds"].contains(backend), ["imu", "image64k", "cloud120k"].contains(payload) else {
+    print("rcl_soak FAIL: usage: rcl-soak <rcl|dds> [imu|image64k|cloud120k] [--duration-s N] ...")
+    exit(2)
+}
+
+// MARK: - resource sampling (Darwin)
+
+@inline(__always) func nowNS() -> UInt64 { DispatchTime.now().uptimeNanoseconds }
+
+func currentRSSBytes() -> UInt64 {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(
+        MemoryLayout<mach_task_basic_info_data_t>.size / MemoryLayout<natural_t>.size)
+    let kr = withUnsafeMutablePointer(to: &info) { ptr in
+        ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { intPtr in
+            task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), intPtr, &count)
+        }
+    }
+    return kr == KERN_SUCCESS ? info.resident_size : 0
+}
+
+/// Open file descriptors = entries under /dev/fd on Darwin.
+func openFDCount() -> Int {
+    (try? FileManager.default.contentsOfDirectory(atPath: "/dev/fd").count) ?? -1
+}
+
+// MARK: - payloads (mirror rcl-bench)
+
+func makeImu() -> Imu {
+    Imu(
+        header: Header(stamp: Time(sec: 0, nanosec: 0), frameId: "soak"),
+        orientation: Quaternion(x: 0.1, y: 0.2, z: 0.3, w: 0.4),
+        orientationCovariance: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+        angularVelocity: Vector3(x: 1.5, y: 2.5, z: 3.5),
+        angularVelocityCovariance: [9, 10, 11, 12, 13, 14, 15, 16, 17],
+        linearAcceleration: Vector3(x: 9.8, y: 0.0, z: -9.8),
+        linearAccelerationCovariance: [18, 19, 20, 21, 22, 23, 24, 25, 26])
+}
+func makeImage64k() -> CompressedImage {
+    CompressedImage(
+        header: Header(stamp: Time(sec: 0, nanosec: 0), frameId: "soak"),
+        format: "jpeg", data: (0..<65_536).map { UInt8($0 & 0xFF) })
+}
+func makeCloud120k() -> PointCloud2 {
+    PointCloud2(
+        header: Header(stamp: Time(sec: 0, nanosec: 0), frameId: "soak"),
+        height: 1, width: 10_000,
+        fields: [
+            PointField(name: "x", offset: 0, datatype: 7, count: 1),
+            PointField(name: "y", offset: 4, datatype: 7, count: 1),
+            PointField(name: "z", offset: 8, datatype: 7, count: 1),
+        ],
+        isBigendian: false, pointStep: 12, rowStep: 120_000,
+        data: (0..<120_000).map { UInt8($0 & 0xFF) }, isDense: true)
+}
+
+// MARK: - publish counter (delivery-thread safe)
+
+final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var n = 0
+    func add(_ k: Int) {
+        lock.lock()
+        n += k
+        lock.unlock()
+    }
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return n
+    }
+}
+
+func run() async throws {
+    let qos = QoSProfile(reliability: .reliable, durability: .volatile, history: .keepLast(64))
+    let config: TransportConfig =
+        backend == "rcl" ? .rcl(domainId: domainId) : .ddsMulticast(domainId: domainId)
+    let ctx = try await ROS2Context(transport: config)
+    let node = try await ctx.createNode(
+        name: "rcl_soak", namespace: "/rcl_soak",
+        options: ROS2NodeOptions(startParameterServices: false))
+
+    // Optional resilience probe: open a subscription for a type the publisher
+    // never sends, exercising the receive path's empty-queue handling for the
+    // whole run (a cheap stand-in for malformed-receive robustness).
+    if injectMalformed {
+        let probe = try await node.createSubscription(Imu.self, topic: "soak_absent", qos: qos)
+        probe.onMessage { _ in }
+    }
+
+    let published = Counter()
+    let periodNS: UInt64 = rateHz > 0 ? UInt64(1_000_000_000 / UInt64(rateHz)) : 0
+
+    func stream<M: CDREncodable & ROS2MessageType>(_ make: () -> M) async throws {
+        let pub = try await node.createPublisher(M.self, topic: "soak", qos: qos)
+        try await Task.sleep(for: .seconds(2))  // discovery settle
+        let msg = make()
+        let startNS = nowNS()
+        let endNS = startNS + UInt64(durationS) * 1_000_000_000
+        var samples: [SoakSample] = []
+        var nextSampleNS = startNS + UInt64(sampleS) * 1_000_000_000
+        var lastSampleCount = 0
+        var lastSampleNS = startNS
+        var lastFDs = max(0, openFDCount())  // baseline; carried if a read fails
+        var next = startNS
+        while nowNS() < endNS {
+            if periodNS > 0 {
+                next &+= periodNS
+                let now = nowNS()
+                if next > now { try await Task.sleep(for: .nanoseconds(Int64(next - now))) }
+            }
+            try await pub.publish(msg)
+            published.add(1)
+
+            let now = nowNS()
+            if now >= nextSampleNS {
+                let total = published.value
+                let dt = Double(now - lastSampleNS) / 1e9
+                let mps = dt > 0 ? Double(total - lastSampleCount) / dt : 0
+                let rawFDs = openFDCount()
+                let fds = rawFDs >= 0 ? rawFDs : lastFDs  // carry last good on a failed read
+                lastFDs = fds
+                let s = SoakSample(
+                    tSeconds: Double(now - startNS) / 1e9, rssBytes: currentRSSBytes(),
+                    openFDs: fds, msgsPerSec: mps)
+                samples.append(s)
+                print(
+                    "rcl_soak SAMPLE t=\(String(format: "%.1f", s.tSeconds)) "
+                        + "rss_mb=\(String(format: "%.1f", Double(s.rssBytes) / 1_048_576)) "
+                        + "fds=\(s.openFDs) msgs_per_s=\(String(format: "%.0f", s.msgsPerSec))")
+                fflush(stdout)
+                lastSampleCount = total
+                lastSampleNS = now
+                nextSampleNS = now + UInt64(sampleS) * 1_000_000_000
+            }
+        }
+        let v = SoakAnalysis.analyze(samples)
+        print(
+            "rcl_soak RESULT backend=\(backend) payload=\(payload) duration_s=\(durationS) "
+                + "samples=\(samples.count) published=\(published.value) "
+                + "verdict=\(v.leakSuspected ? "LEAK" : "healthy") "
+                + "rss_slope_b_per_min=\(Int(v.rssSlopeBytesPerMin.rounded())) "
+                + "fd_growth=\(v.fdGrowth) "
+                + "tput_degradation_pct=\(String(format: "%.1f", v.throughputDegradationPct))")
+        fflush(stdout)
+        if selftest {
+            guard samples.count >= 1, samples.allSatisfy({ $0.rssBytes > 0 }) else {
+                print("rcl_soak FAIL: selftest produced no valid samples")
+                await ctx.shutdown()
+                exit(1)
+            }
+            print("rcl_soak SELFTEST OK")
+        }
+    }
+
+    switch payload {
+    case "imu": try await stream(makeImu)
+    case "image64k": try await stream(makeImage64k)
+    default: try await stream(makeCloud120k)
+    }
+    await ctx.shutdown()
+}
+
+let done = DispatchSemaphore(value: 0)
+Task {
+    do { try await run() } catch {
+        print("rcl_soak FAIL: \(error)")
+        fflush(stdout)
+        exit(1)
+    }
+    done.signal()
+}
+done.wait()
+exit(0)

--- a/Sources/SwiftROS2Bench/SoakAnalysis.swift
+++ b/Sources/SwiftROS2Bench/SoakAnalysis.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// One periodic sample taken during a soak run.
+public struct SoakSample: Equatable, Sendable {
+    public let tSeconds: Double
+    public let rssBytes: UInt64
+    public let openFDs: Int
+    public let msgsPerSec: Double
+
+    public init(tSeconds: Double, rssBytes: UInt64, openFDs: Int, msgsPerSec: Double) {
+        self.tSeconds = tSeconds
+        self.rssBytes = rssBytes
+        self.openFDs = openFDs
+        self.msgsPerSec = msgsPerSec
+    }
+}
+
+/// The leak/health verdict for a completed soak run.
+public struct SoakVerdict: Equatable, Sendable {
+    public let leakSuspected: Bool
+    public let rssSlopeBytesPerMin: Double
+    public let fdGrowth: Int
+    public let throughputDegradationPct: Double
+    public let summary: String
+}
+
+/// Pure analysis of a soak time-series. No I/O — unit-tested in normal CI.
+public enum SoakAnalysis {
+    /// `leakSuspected` if any of: RSS least-squares slope exceeds
+    /// `rssSlopeLimitBytesPerMin`; net FD growth (last − first) exceeds
+    /// `fdGrowthLimit`; or throughput degradation (first-fifth vs last-fifth
+    /// mean) exceeds `throughputDegradationLimitPct`. The trend axes (RSS slope,
+    /// throughput) need at least `minSamplesForTrend` samples to be meaningful
+    /// and to outlast process-startup warmup; below that they are reported as 0
+    /// (inconclusive) so a short probe cannot false-flag. FD growth is robust at
+    /// any count. Fewer than 2 samples is fully inconclusive (not a leak).
+    public static func analyze(
+        _ samples: [SoakSample],
+        rssSlopeLimitBytesPerMin: Double = 1_000_000,
+        fdGrowthLimit: Int = 8,
+        throughputDegradationLimitPct: Double = 20,
+        minSamplesForTrend: Int = 10
+    ) -> SoakVerdict {
+        guard samples.count >= 2 else {
+            return SoakVerdict(
+                leakSuspected: false, rssSlopeBytesPerMin: 0, fdGrowth: 0,
+                throughputDegradationPct: 0, summary: "inconclusive: <2 samples")
+        }
+
+        // FD growth (net last − first) is robust even with a couple of samples;
+        // a transient spike that recovers nets to 0.
+        let fdGrowth = samples[samples.count - 1].openFDs - samples[0].openFDs
+
+        // Trend axes need enough points to outlast startup warmup and to give
+        // the first/last fifths ≥2 points each.
+        var rssSlopeBytesPerMin = 0.0
+        var throughputDegradationPct = 0.0
+        if samples.count >= minSamplesForTrend {
+            let n = Double(samples.count)
+            let xs = samples.map { $0.tSeconds }
+            let ys = samples.map { Double($0.rssBytes) }
+            let meanX = xs.reduce(0, +) / n
+            let meanY = ys.reduce(0, +) / n
+            var num = 0.0
+            var den = 0.0
+            for i in 0..<samples.count {
+                num += (xs[i] - meanX) * (ys[i] - meanY)
+                den += (xs[i] - meanX) * (xs[i] - meanX)
+            }
+            rssSlopeBytesPerMin = (den == 0 ? 0 : num / den) * 60
+
+            let fifth = samples.count / 5  // ≥2 here, so the slices are non-empty
+            func mean(_ s: ArraySlice<SoakSample>) -> Double {
+                s.map { $0.msgsPerSec }.reduce(0, +) / Double(s.count)
+            }
+            let firstMean = mean(samples.prefix(fifth))
+            let lastMean = mean(samples.suffix(fifth))
+            throughputDegradationPct =
+                firstMean <= 0 ? 0 : max(0, (firstMean - lastMean) / firstMean * 100)
+        }
+
+        let leakSuspected =
+            rssSlopeBytesPerMin > rssSlopeLimitBytesPerMin
+            || fdGrowth > fdGrowthLimit
+            || throughputDegradationPct > throughputDegradationLimitPct
+
+        let summary =
+            "rss_slope=\(Int(rssSlopeBytesPerMin.rounded())) B/min, fd_growth=\(fdGrowth), "
+            + "tput_degradation=\(String(format: "%.1f", throughputDegradationPct))% -> "
+            + (leakSuspected ? "LEAK SUSPECTED" : "healthy")
+
+        return SoakVerdict(
+            leakSuspected: leakSuspected, rssSlopeBytesPerMin: rssSlopeBytesPerMin,
+            fdGrowth: fdGrowth, throughputDegradationPct: throughputDegradationPct,
+            summary: summary)
+    }
+}

--- a/Tests/SwiftROS2BenchTests/SoakAnalysisTests.swift
+++ b/Tests/SwiftROS2BenchTests/SoakAnalysisTests.swift
@@ -1,0 +1,84 @@
+import SwiftROS2Bench
+import XCTest
+
+final class SoakAnalysisTests: XCTestCase {
+    /// Build a time series: `count` samples at `interval` seconds, RSS starting
+    /// at `rss0` growing `rssPerSample` bytes each step, FDs starting at `fd0`
+    /// growing `fdPerSample`, throughput `tput` scaled linearly to `tputEndScale`
+    /// across the run to model degradation.
+    private func series(
+        count: Int, interval: Double = 1, rss0: UInt64 = 100_000_000,
+        rssPerSample: Int = 0, fd0: Int = 20, fdPerSample: Int = 0,
+        tput: Double = 1000, tputEndScale: Double = 1
+    ) -> [SoakSample] {
+        (0..<count).map { i in
+            let frac = count > 1 ? Double(i) / Double(count - 1) : 0
+            let scale = 1 + (tputEndScale - 1) * frac
+            return SoakSample(
+                tSeconds: Double(i) * interval,
+                rssBytes: UInt64(Int64(rss0) + Int64(rssPerSample) * Int64(i)),
+                openFDs: fd0 + fdPerSample * i,
+                msgsPerSec: tput * scale)
+        }
+    }
+
+    func testFlatSeriesIsHealthy() {
+        let v = SoakAnalysis.analyze(series(count: 600))
+        XCTAssertFalse(v.leakSuspected)
+        XCTAssertLessThan(abs(v.rssSlopeBytesPerMin), 1.0)
+        XCTAssertEqual(v.fdGrowth, 0)
+        XCTAssertLessThan(v.throughputDegradationPct, 1.0)
+    }
+
+    func testRisingRSSFlagsLeak() {
+        let v = SoakAnalysis.analyze(series(count: 600, rssPerSample: 200_000))
+        XCTAssertTrue(v.leakSuspected)
+        XCTAssertGreaterThan(v.rssSlopeBytesPerMin, 1_000_000)
+    }
+
+    func testGrowingFDsFlagsLeak() {
+        let v = SoakAnalysis.analyze(series(count: 60, fdPerSample: 1))
+        XCTAssertTrue(v.leakSuspected)
+        XCTAssertEqual(v.fdGrowth, 59)
+    }
+
+    func testThroughputDegradationFlagged() {
+        let v = SoakAnalysis.analyze(series(count: 600, tputEndScale: 0.5))
+        XCTAssertTrue(v.leakSuspected)
+        XCTAssertGreaterThan(v.throughputDegradationPct, 20)
+    }
+
+    func testEmptyOrSingleSampleIsInconclusiveNotALeak() {
+        XCTAssertFalse(SoakAnalysis.analyze([]).leakSuspected)
+        XCTAssertFalse(SoakAnalysis.analyze(series(count: 1)).leakSuspected)
+    }
+
+    func testAllEqualTimestampsGivesZeroSlopeNotALeak() {
+        // interval 0 → every tSeconds is 0 (den == 0). Even with rising RSS the
+        // slope guard yields 0, so the RSS axis must not false-flag.
+        let v = SoakAnalysis.analyze(series(count: 60, interval: 0, rssPerSample: 200_000))
+        XCTAssertEqual(v.rssSlopeBytesPerMin, 0)
+        XCTAssertFalse(v.leakSuspected)
+    }
+
+    func testTransientFDSpikeThatRecoversIsNotALeak() {
+        // FDs spike mid-run then return to baseline: last − first == 0, so the
+        // net-growth signal (not max − min) correctly reports no leak.
+        let fds = [20, 20, 100, 100, 20, 20]
+        let samples = fds.enumerated().map { i, fd in
+            SoakSample(tSeconds: Double(i), rssBytes: 100_000_000, openFDs: fd, msgsPerSec: 1000)
+        }
+        let v = SoakAnalysis.analyze(samples)
+        XCTAssertEqual(v.fdGrowth, 0)
+        XCTAssertFalse(v.leakSuspected)
+    }
+
+    func testShortRunBelowTrendMinimumDoesNotFlagRSS() {
+        // 8 samples (< the 10-sample trend minimum) with steep RSS growth:
+        // process-startup warmup must not be mistaken for a leak, so the RSS
+        // slope is reported as inconclusive (0).
+        let v = SoakAnalysis.analyze(series(count: 8, rssPerSample: 5_000_000))
+        XCTAssertEqual(v.rssSlopeBytesPerMin, 0)
+        XCTAssertFalse(v.leakSuspected)
+    }
+}

--- a/docs/verification-runbook.md
+++ b/docs/verification-runbook.md
@@ -1,0 +1,94 @@
+# RCL verification runbook (W4)
+
+Runs the W3 harnesses against a LAN ROS 2 Jazzy host and records results into
+`docs/parity-matrix.json`. Apple host with `SWIFT_ROS2_ENABLE_RCL=1`; set
+`LINUX_IP` to the host (e.g. `192.168.1.85`). Build once:
+
+```bash
+SWIFT_ROS2_ENABLE_RCL=1 swift build -c release --product rcl-bench --product rcl-soak
+```
+
+The two backends are selected at runtime by the first argument: `rcl` (native
+rcl + rmw_cyclonedds_cpp) vs `dds` (pure-Swift wire). One binary, two paths.
+
+## Axis 1 — latency / throughput
+
+In-process publish-call cost + throughput (no host needed), per backend × payload:
+
+```bash
+SWIFT_ROS2_ENABLE_RCL=1 swift run -c release rcl-bench rcl publish imu       --count 100000
+SWIFT_ROS2_ENABLE_RCL=1 swift run -c release rcl-bench dds publish imu       --count 100000
+SWIFT_ROS2_ENABLE_RCL=1 swift run -c release rcl-bench rcl publish image64k  --count 1000
+SWIFT_ROS2_ENABLE_RCL=1 swift run -c release rcl-bench rcl publish cloud120k --count 1000
+# ...and the dds variants
+```
+
+LAN end-to-end round-trip. The bench publishes to `/rcl_bench/bench` with a
+send-stamp and subscribes `/rcl_bench/bench_echo`, computing `now − stamp` on
+its own clock (no host/sender clock-sync needed). On the **host**, relay the
+topic back (the host's RMW must match the backend under test):
+
+```bash
+# host (Jazzy)
+ros2 run topic_tools relay /rcl_bench/bench /rcl_bench/bench_echo
+```
+
+On the **Apple host**, measure (domain 0 reaches the LAN; under `.rcl` the link
+is multicast — the `transport.dds` unicast-config gap means `ddsUnicastPeers`
+is ignored on the RCL backend, so the LAN must carry multicast):
+
+```bash
+SWIFT_ROS2_ENABLE_RCL=1 swift run -c release rcl-bench rcl roundtrip-lan imu --domain 0 --count 5000
+```
+
+Record (p50/p99 → value; verdict by your threshold), via the `parity-tool set`
+from W3 Part 1:
+
+```bash
+swift run parity-tool set "publish.typed.sensor_msgs/Imu" --axis latency --verdict pass \
+  --value "rcl publish p50=<X>us p99=<Y>us @max; LAN rt p50=<Z>ms (rcl-bench)"
+```
+
+## Axis 2 — endurance / soak
+
+Long run (background or cron), per backend × payload — start with the large
+payloads (allocation churn is the primary leak detector):
+
+```bash
+SWIFT_ROS2_ENABLE_RCL=1 swift run -c release rcl-soak rcl cloud120k \
+  --duration-s 14400 --sample-s 30 --rate-hz 30 --domain 0 | tee soak-rcl-cloud.log
+```
+
+Each `rcl_soak SAMPLE t=.. rss_mb=.. fds=.. msgs_per_s=..` line is a time-series
+point; the final `rcl_soak RESULT ... verdict=healthy|LEAK rss_slope_b_per_min=..
+fd_growth=.. tput_degradation_pct=..` is the verdict (RSS least-squares slope /
+FD growth / throughput degradation via `SoakAnalysis`; trend axes need ≥10
+samples, so use `--duration-s` ≥ `10 × --sample-s`).
+
+**Resilience (fault injection).** `--inject-malformed` opens a subscription to a
+never-published topic for the whole run (receive-path robustness). Host-restart
+and network-drop cannot be driven from the harness — during a run, manually
+restart the host's subscriber / `rmw_zenohd` or drop the network, and confirm
+the time-series recovers (throughput returns; RSS does not step up).
+
+Record:
+
+```bash
+swift run parity-tool set "publish.typed.sensor_msgs/PointCloud2" --axis soak --verdict pass \
+  --value "4h @30Hz: rss_slope=<X>B/min fd_growth=<Y> healthy (rcl-soak)"
+```
+
+## Committing results
+
+Every `parity-tool set` re-renders `docs/PARITY.md` and re-canonicalizes
+`docs/parity-matrix.json` atomically. Commit both files and open a PR; the CI
+parity-matrix drift guard enforces the canonical form. Latency/soak verdicts are
+recorded here in W4 — they are intentionally left `pending` by the harness PRs.
+
+## Out of scope
+
+- **Axis 4 (resource: binary-size / CPU / battery on a real iPhone)** is
+  Conduit-side (needs the Conduit repo + a physical device + the
+  `conduit-run-on-iphone` / `oslog-stream-to-file` skills), tracked separately.
+- **DDS unicast on the RCL backend** is blocked by the `transport.dds` matrix
+  gap; LAN runs use multicast (RCL) or the pure-Swift `.ddsUnicast` path.


### PR DESCRIPTION
## What & why

W3 verification harness, Part 2 **PR 2 of 2** — stacked on #137 (base `feat/w3p2-soak-analysis`). Builds the runnable harnesses for the design's §5 Axis 1 (latency over a LAN host) and Axis 2 (endurance/soak), driven by the `SoakAnalysis` core from #137.

## Changes

- **`rcl-soak`** (new RCL-gated executable): streams a corpus payload at a fixed rate for `--duration-s`, samples **RSS** (mach `task_info`) + **open-FD count** (`/dev/fd`) + **throughput** every `--sample-s`, prints a `rcl_soak SAMPLE …` time-series, and a final `rcl_soak RESULT … verdict=healthy|LEAK …` from `SoakAnalysis`. Has a `--selftest` (2 s smoke) and a `--inject-malformed` receive-path resilience hook.
- **`rcl-bench roundtrip-lan` mode + `--domain`**: true network end-to-end latency vs a LAN host that relays `bench → bench_echo` (`ros2 run topic_tools relay`), measured on the sender's own clock (no clock-sync). `--domain` lets a LAN run leave the isolated domain 42.
- **`docs/verification-runbook.md`**: the W4 procedure — host relay setup, run commands per backend × payload, and the exact `parity-tool set` calls to fold latency/soak results into the matrix.

## Scope (what this PR does NOT do)

- **Does not record latency/soak verdicts** — those need a LAN host / multi-hour run (W4). The matrix `latency`/`soak` axes stay `pending`; the runbook names the `set` commands W4 uses.
- **Axis 4 (resource, on-device)** is Conduit-side, tracked separately.

## Verification

- `swift test --filter SwiftROS2BenchTests` → 8/8 (the `SoakAnalysis` core, normal CI).
- `SWIFT_ROS2_ENABLE_RCL=1 swift run rcl-soak rcl imu --selftest` → `rcl_soak SELFTEST OK`, exit 0, `verdict=healthy`.
- `SWIFT_ROS2_ENABLE_RCL=1 swift build --product rcl-bench` builds with the `roundtrip-lan` mode.
- `swift format lint --strict` clean.

## Merge order

Merge #137 first; this PR's base retargets to `main` automatically, leaving only the 3 commits unique to this branch (rcl-soak / rcl-bench LAN / runbook).