### PR TITLE
fix(rcl): drop <EnableTopicDiscoveryEndpoints> from shared discovery XML

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -576,7 +576,7 @@ if canBuildDDS {
         ),
         .testTarget(
             name: "SwiftROS2DDSTests",
-            dependencies: ["SwiftROS2DDS", "SwiftROS2Transport"],
+            dependencies: ["SwiftROS2DDS", "SwiftROS2Transport", "CDDSBridge"],
             path: "Tests/SwiftROS2DDSTests"
         ),
         .testTarget(

--- a/Sources/CDDSBridge/dds_bridge.c
+++ b/Sources/CDDSBridge/dds_bridge.c
@@ -216,13 +216,14 @@ char* dds_bridge_build_domain_config_xml(int32_t domain_id, const bridge_discove
             return NULL;
         }
 
-        // Disable multicast SPDP if in unicast-only mode
-        if (config->mode == BRIDGE_DISCOVERY_UNICAST) {
-            if (!xml_append(&xml, &offset,
-                "      <EnableTopicDiscoveryEndpoints>true</EnableTopicDiscoveryEndpoints>\n")) {
-                return NULL;
-            }
-        }
+        // NOTE: do not emit <EnableTopicDiscoveryEndpoints> here. It does not
+        // disable multicast SPDP (it toggles DCPSTopic discovery, which ROS 2
+        // graph discovery does not use), and CycloneDDS builds compiled without
+        // topic-discovery support — e.g. the one bundled in CRos2Jazzy on iOS,
+        // reached by the RCL path via CYCLONEDDS_URI — reject it as an unknown
+        // element and fail rmw_create_node (issue #149). Leaving multicast SPDP
+        // enabled next to the explicit <Peers> is harmless: it is simply
+        // ignored on networks without multicast (typical Wi-Fi).
 
         // Faster SPDP discovery for mobile devices (default is 30s)
         if (!xml_append(&xml, &offset, "      <SPDPInterval>1s</SPDPInterval>\n")) {

--- a/Tests/SwiftROS2DDSTests/DiscoveryConfigXMLTests.swift
+++ b/Tests/SwiftROS2DDSTests/DiscoveryConfigXMLTests.swift
@@ -1,0 +1,72 @@
+// DiscoveryConfigXMLTests.swift
+// Guards the shared CycloneDDS discovery-XML builder
+// (dds_bridge_build_domain_config_xml) — the SAME function the pure-Swift DDS
+// path (dds_create_domain) and the RCL path (exported as CYCLONEDDS_URI for
+// rmw_cyclonedds) both use, so the XML must be valid on EVERY CycloneDDS slice.
+//
+// Regression for youtalk/swift-ros2#149: the unicast block used to emit
+// <EnableTopicDiscoveryEndpoints>, which CycloneDDS builds compiled without
+// topic-discovery support (e.g. the one bundled in CRos2Jazzy on iOS) reject as
+// an unknown element, failing rmw_create_node on the RCL unicast path.
+
+import CDDSBridge
+import Foundation
+import XCTest
+
+final class DiscoveryConfigXMLTests: XCTestCase {
+    /// Build the discovery XML through the shared C builder, marshalling the
+    /// peers into the NULL-terminated C array it expects (mirrors the
+    /// marshalling in RclClient / DDSClient).
+    private func buildXML(peers: [String], interface: String?, domainId: Int32 = 0) -> String? {
+        var config = bridge_discovery_config_t()
+        config.mode = peers.isEmpty ? BRIDGE_DISCOVERY_MULTICAST : BRIDGE_DISCOVERY_UNICAST
+
+        var peerCStrings: [UnsafeMutablePointer<CChar>?] = peers.map { strdup($0) }
+        peerCStrings.append(nil)  // NULL terminator for the C array
+        let peersPtr = UnsafeMutablePointer<UnsafePointer<CChar>?>.allocate(capacity: peerCStrings.count)
+        defer {
+            for s in peerCStrings where s != nil { free(s) }
+            peersPtr.deallocate()
+        }
+        for (i, s) in peerCStrings.enumerated() { peersPtr[i] = s.map { UnsafePointer($0) } }
+        if !peers.isEmpty {
+            config.unicast_peers = peersPtr
+            config.peer_count = Int32(peers.count)
+        }
+
+        var interfaceCString: UnsafeMutablePointer<CChar>?
+        if let interface {
+            interfaceCString = strdup(interface)
+            config.network_interface = UnsafePointer(interfaceCString)
+        }
+        defer { if let interfaceCString { free(interfaceCString) } }
+
+        guard let xmlPtr = dds_bridge_build_domain_config_xml(domainId, &config) else { return nil }
+        defer { dds_bridge_free_string(xmlPtr) }
+        return String(cString: xmlPtr)
+    }
+
+    /// The unicast block must carry the static <Peer> and the mobile-friendly
+    /// <SPDPInterval>, but must NOT emit <EnableTopicDiscoveryEndpoints> — that
+    /// element is compiled out of some CycloneDDS builds (CRos2Jazzy / iOS) and
+    /// makes rmw_create_node reject the whole config (issue #149).
+    func testUnicastXMLOmitsEnableTopicDiscoveryEndpoints() {
+        let xml = buildXML(peers: ["192.168.1.85"], interface: "en0")
+        XCTAssertNotNil(xml)
+        XCTAssertTrue(xml!.contains("<Peer address=\"192.168.1.85\""))
+        XCTAssertTrue(xml!.contains("<SPDPInterval>"))
+        XCTAssertFalse(
+            xml!.contains("EnableTopicDiscoveryEndpoints"),
+            "discovery XML must not emit <EnableTopicDiscoveryEndpoints>: rejected by "
+                + "CycloneDDS builds without topic-discovery support, failing rmw_create_node (issue #149)")
+    }
+
+    /// Multicast/default discovery emits no <Peers> block and therefore never
+    /// reaches the offending element either.
+    func testMulticastXMLHasNoPeersOrTopicDiscoveryElement() {
+        let xml = buildXML(peers: [], interface: nil)
+        XCTAssertNotNil(xml)
+        XCTAssertFalse(xml!.contains("<Peer "))
+        XCTAssertFalse(xml!.contains("EnableTopicDiscoveryEndpoints"))
+    }
+}

--- a/Tests/SwiftROS2RCLTests/RclDiscoveryEnvTests.swift
+++ b/Tests/SwiftROS2RCLTests/RclDiscoveryEnvTests.swift
@@ -17,6 +17,10 @@
             XCTAssertTrue(xml!.contains("<Peer address=\"192.168.1.85\""))
             XCTAssertTrue(xml!.contains("<NetworkInterface name=\"en0\""))
             XCTAssertTrue(xml!.contains("SPDP"))  // SPDPInterval present in the unicast block
+            // Must NOT emit <EnableTopicDiscoveryEndpoints>: CRos2Jazzy's CycloneDDS
+            // rejects it on iOS (compiled without topic-discovery), failing
+            // rmw_create_node on the RCL unicast path (issue #149).
+            XCTAssertFalse(xml!.contains("EnableTopicDiscoveryEndpoints"))
         }
 
         func testDiscoveryURIXMLMulticastHasNoPeers() {


### PR DESCRIPTION
## Summary

On a physical iPhone, the native RCL backend fails to create a participant when **unicast peers** are configured, while the pure-Swift DDS backend works on the same device/network (found during the M3d / Axis 4 on-device run, #148):

```
config: //CycloneDDS/Domain/Discovery: EnableTopicDiscoveryEndpoints: unknown element (CYCLONEDDS_URI+160 line 8)
[ERROR] [rmw_cyclonedds_cpp]: rmw_create_node: failed to create domain, error Error
```

This is an immediate config-parse failure (~300 ms × 3 retries), not a discovery timeout.

## Root cause

`dds_bridge_build_domain_config_xml` (`Sources/CDDSBridge/dds_bridge.c`) emitted `<EnableTopicDiscoveryEndpoints>true</...>` in the unicast block — which lands at **line 8** of the generated XML, exactly matching the error's `line 8`. That single builder is **shared** by both backends:

| Path | CycloneDDS build | The element |
|------|------------------|-------------|
| DDS (pure-Swift, `dds_create_domain`) | standalone `CCycloneDDS` | **accepted** |
| RCL (`makeDiscoveryURIXML` → `CYCLONEDDS_URI` → `rmw_create_node`) | bundled in `CRos2Jazzy` (iOS slice) | **rejected** (unknown element) |

The iOS `CRos2Jazzy` CycloneDDS is compiled **without topic-discovery support**, so it rejects the element and fails `rmw_create_node`. Two further findings:

- The element does **not** do what its comment claimed (`"Disable multicast SPDP"`). It toggles DCPSTopic discovery, which ROS 2 graph discovery (SPDP/SEDP) does not use.
- It has been wrong since the first integration commit (`1d015b4c8`), and **no test asserted its presence**.

## Fix

Remove the element from the shared builder. This:

- fixes RCL unicast on iOS (Conduit's real scenario — Wi-Fi blocks multicast, so unicast peers are required);
- leaves the DDS path's shipping behavior unchanged (multicast SPDP stays enabled next to the explicit `<Peers>`; harmless — simply ignored on multicast-less networks);
- keeps the RCL/DDS discovery XML **byte-identical** (Axis-3 parity), which is why the element is dropped from the *shared* builder rather than branched per-backend.

Deliberately **not** taken: actually disabling multicast in unicast-only mode (the issue's option 2). That is a never-before-active behavior change with same-host/loopback-discovery risk — out of scope for this blocker.

## Tests

- New **CI-visible** guard `DiscoveryConfigXMLTests` (in `SwiftROS2DDSTests`, runs in the macOS + Linux DDS jobs) calls the shared C builder directly and asserts the unicast XML omits `EnableTopicDiscoveryEndpoints` while keeping `<Peer>` + `<SPDPInterval>`. Verified **red → green**.
- Mirror assertion added to the RCL parity guard `RclDiscoveryEnvTests`.
- `swift test --filter SwiftROS2DDSTests`: 18/18 pass. `swift-format lint --strict`: clean.

## Note on closing

Per the issue, the iOS rejection cannot be reproduced on macOS (its `CRos2Jazzy` slice accepts the element). A **device repro on the unicast path should confirm before closing** — using `Refs #149` (not `Fixes`) so merging does not auto-close ahead of that on-device check.

Refs #149