### PR TITLE
feat(bench): zenoh backend + --locator for rcl-bench/rcl-soak, soak echo observability

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -345,8 +345,13 @@ var targets: [Target] = [
     ),
 
     // Internal benchmark / soak-analysis target — not exported as a product.
+    // Depends on SwiftROS2Zenoh whenever the wire family is in the graph so
+    // `canImport(SwiftROS2Zenoh)` inside HarnessCLI.zenohStack agrees with the
+    // umbrella's own conditional dep (line ~501) and with the test target —
+    // otherwise the RESULT-line stack stamp reads "rcl-rmw_zenoh" on the wire path.
     .target(
         name: "SwiftROS2Bench",
+        dependencies: dropZenohWire ? [] : ["SwiftROS2Zenoh"],
         path: "Sources/SwiftROS2Bench"
     ),
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -703,7 +703,7 @@ if enableRcl {
     targets.append(
         .executableTarget(
             name: "rcl-bench",
-            dependencies: ["SwiftROS2", "SwiftROS2RCL"],
+            dependencies: ["SwiftROS2", "SwiftROS2RCL", "SwiftROS2Bench"],
             path: "Sources/Examples/RclBench",
             linkerSettings: [.linkedLibrary("c++")]
         ))

--- a/Sources/Examples/RclBench/main.swift
+++ b/Sources/Examples/RclBench/main.swift
@@ -1,10 +1,13 @@
 // rcl-bench — typed rcl_publish (.rcl backend) vs pure-Swift wire-DDS (.dds)
-// benchmark (spec §19.3 M5). One backend per process so the two DDS stacks
-// never share a participant.
+// vs Zenoh (.zenoh) benchmark (spec §19.3 M5). One backend per process so the
+// two DDS stacks never share a participant. The `zenoh` backend resolves to
+// the zenoh-pico wire path on the default build and to rcl + rmw_zenoh_cpp on
+// the SWIFT_ROS2_RCL_RMW=zenoh variant; its router locator comes from
+// `--locator`, then SWIFT_ROS2_ZENOH_LOCATOR, then tcp/127.0.0.1:7447.
 //
 // Usage:
-//   rcl-bench <rcl|dds> <publish|roundtrip|roundtrip-lan|encode> [imu|image64k|cloud120k]
-//             [--count N] [--rate-hz N] [--domain N]
+//   rcl-bench <rcl|dds|zenoh> <publish|roundtrip|roundtrip-lan|encode> [imu|image64k|cloud120k]
+//             [--count N] [--rate-hz N] [--domain N] [--locator STR]
 //
 // Modes:
 //   publish       — per-publish call latency + max-rate throughput (no subscriber)
@@ -23,6 +26,7 @@
 
 import Foundation
 import SwiftROS2
+import SwiftROS2Bench
 import SwiftROS2RCL
 
 // MARK: - CLI
@@ -31,15 +35,15 @@ let args = CommandLine.arguments
 guard args.count >= 3 else {
     print(
         """
-        usage: rcl-bench <rcl|dds> <publish|roundtrip|roundtrip-lan|encode> \
-        [imu|image64k|cloud120k] [--count N] [--rate-hz N] [--domain N]
+        usage: rcl-bench <rcl|dds|zenoh> <publish|roundtrip|roundtrip-lan|encode> \
+        [imu|image64k|cloud120k] [--count N] [--rate-hz N] [--domain N] [--locator STR]
         """)
     exit(2)
 }
 let backend = args[1]
 let mode = args[2]
 let payload = args.count > 3 && !args[3].hasPrefix("--") ? args[3] : "imu"
-guard ["rcl", "dds"].contains(backend),
+guard HarnessCLI.supportedBackends.contains(backend),
     ["publish", "roundtrip", "roundtrip-lan", "encode"].contains(mode),
     ["imu", "image64k", "cloud120k"].contains(payload)
 else {
@@ -60,6 +64,8 @@ let count = intOption(
 let rateHz = intOption("--rate-hz", default: 0)  // 0 = max rate
 let warmup = isLarge ? 100 : 1_000
 let domainId = intOption("--domain", default: 42)
+let zenohLocator = HarnessCLI.resolveZenohLocator(
+    arguments: args, environment: ProcessInfo.processInfo.environment)
 
 // MARK: - timing helpers
 
@@ -158,7 +164,10 @@ func runEncode() throws {
     samples.reserveCapacity(count)
     var bytes = 0
     let start = nowNS()
-    switch (backend, payload) {
+    // `zenoh` measures the same pure-Swift CDREncoder the zenoh-pico wire
+    // path uses; the rcl marshal + rmw_serialize proxy stays on the `rcl`
+    // token (one encode seam per token, regardless of rmw variant).
+    switch (backend == "rcl" ? "rcl" : "dds", payload) {
     case ("dds", "imu"):
         let m = makeImu()
         for _ in 0..<count {
@@ -217,7 +226,11 @@ func runEncode() throws {
 // MARK: - publish / roundtrip modes
 
 func transportConfig() -> TransportConfig {
-    backend == "rcl" ? .rcl(domainId: domainId) : .ddsMulticast(domainId: domainId)
+    switch backend {
+    case "rcl": return .rcl(domainId: domainId)
+    case "zenoh": return .zenoh(locator: zenohLocator, domainId: domainId)
+    default: return .ddsMulticast(domainId: domainId)
+    }
 }
 
 func runPubSub() async throws {

--- a/Sources/Examples/RclBench/main.swift
+++ b/Sources/Examples/RclBench/main.swift
@@ -82,7 +82,7 @@ func percentiles(_ samplesNS: [UInt64]) -> (p50: Double, p95: Double, p99: Doubl
 
 func printResult(_ fields: [String: String]) {
     let ordered = [
-        "backend", "mode", "payload", "count", "received", "rate_hz", "msgs_per_s",
+        "backend", "stack", "mode", "payload", "count", "received", "rate_hz", "msgs_per_s",
         "p50us", "p95us", "p99us", "maxus", "wall_s", "bytes",
     ]
     let kv = ordered.compactMap { k in fields[k].map { "\(k)=\($0)" } }
@@ -215,7 +215,8 @@ func runEncode() throws {
     let wall = Double(nowNS() - start) / 1e9
     let p = percentiles(samples)
     printResult([
-        "backend": backend, "mode": mode, "payload": payload, "count": "\(count)",
+        "backend": backend, "stack": HarnessCLI.stack(forBackend: backend),
+        "mode": mode, "payload": payload, "count": "\(count)",
         "msgs_per_s": String(format: "%.0f", Double(count) / wall),
         "p50us": String(format: "%.2f", p.p50), "p95us": String(format: "%.2f", p.p95),
         "p99us": String(format: "%.2f", p.p99), "maxus": String(format: "%.2f", p.max),
@@ -320,7 +321,8 @@ func runPubSub() async throws {
 
     let p = isRoundtrip ? percentiles(collector.snapshot) : percentiles(callNS)
     printResult([
-        "backend": backend, "mode": mode, "payload": payload, "count": "\(count)",
+        "backend": backend, "stack": HarnessCLI.stack(forBackend: backend),
+        "mode": mode, "payload": payload, "count": "\(count)",
         "received": isRoundtrip ? "\(received)" : "-",
         "rate_hz": rateHz > 0 ? "\(rateHz)" : "max",
         "msgs_per_s": String(format: "%.0f", Double(count) / wall),

--- a/Sources/Examples/RclSoak/main.swift
+++ b/Sources/Examples/RclSoak/main.swift
@@ -5,11 +5,20 @@
 // 2 s in-process smoke that asserts the harness itself works.
 //
 // Usage:
-//   rcl-soak <rcl|dds> [imu|image64k|cloud120k] [--duration-s N] [--sample-s N]
-//            [--rate-hz N] [--domain N] [--selftest] [--inject-malformed]
+//   rcl-soak <rcl|dds|zenoh> [imu|image64k|cloud120k] [--duration-s N] [--sample-s N]
+//            [--rate-hz N] [--domain N] [--locator STR] [--selftest]
+//            [--inject-malformed] [--expect-echo]
+//
+// The `zenoh` backend resolves to the zenoh-pico wire path on the default
+// build and to rcl + rmw_zenoh_cpp on the SWIFT_ROS2_RCL_RMW=zenoh variant;
+// its router locator comes from `--locator`, then SWIFT_ROS2_ZENOH_LOCATOR,
+// then tcp/127.0.0.1:7447. With `--expect-echo` the host relays `soak` ->
+// `soak_echo` (e.g. `ros2 run topic_tools relay`) and the harness counts
+// deliveries on the echo topic.
 //
 // Output: per-sample `rcl_soak SAMPLE t=.. rss_mb=.. fds=.. msgs_per_s=..`
-//         then a final `rcl_soak RESULT verdict=.. rss_slope_b_per_min=.. ...`.
+//         (plus `recv_per_s=..` with --expect-echo) then a final
+//         `rcl_soak RESULT verdict=.. rss_slope_b_per_min=.. ...`.
 
 import Darwin
 import Dispatch
@@ -37,9 +46,16 @@ let sampleS = intOpt("--sample-s", selftest ? 1 : 30)
 let rateHz = intOpt("--rate-hz", 100)
 let domainId = intOpt("--domain", 42)
 let injectMalformed = flag("--inject-malformed")
+let expectEcho = flag("--expect-echo")
+let zenohLocator = HarnessCLI.resolveZenohLocator(
+    arguments: args, environment: ProcessInfo.processInfo.environment)
 
-guard ["rcl", "dds"].contains(backend), ["imu", "image64k", "cloud120k"].contains(payload) else {
-    print("rcl_soak FAIL: usage: rcl-soak <rcl|dds> [imu|image64k|cloud120k] [--duration-s N] ...")
+guard HarnessCLI.supportedBackends.contains(backend),
+    ["imu", "image64k", "cloud120k"].contains(payload)
+else {
+    print(
+        "rcl_soak FAIL: usage: rcl-soak <rcl|dds|zenoh> [imu|image64k|cloud120k] [--duration-s N] ..."
+    )
     exit(2)
 }
 
@@ -113,8 +129,12 @@ final class Counter: @unchecked Sendable {
 
 func run() async throws {
     let qos = QoSProfile(reliability: .reliable, durability: .volatile, history: .keepLast(64))
-    let config: TransportConfig =
-        backend == "rcl" ? .rcl(domainId: domainId) : .ddsMulticast(domainId: domainId)
+    let config: TransportConfig
+    switch backend {
+    case "rcl": config = .rcl(domainId: domainId)
+    case "zenoh": config = .zenoh(locator: zenohLocator, domainId: domainId)
+    default: config = .ddsMulticast(domainId: domainId)
+    }
     let ctx = try await ROS2Context(transport: config)
     let node = try await ctx.createNode(
         name: "rcl_soak", namespace: "/rcl_soak",
@@ -128,6 +148,26 @@ func run() async throws {
         probe.onMessage { _ in }
     }
 
+    // H7 receive-side observability: with --expect-echo the host relays
+    // `soak` -> `soak_echo` and we count deliveries on the echo topic,
+    // mirroring rcl-bench's roundtrip-lan subscription.
+    let received = Counter()
+    if expectEcho {
+        switch payload {
+        case "imu":
+            let sub = try await node.createSubscription(Imu.self, topic: "soak_echo", qos: qos)
+            sub.onMessage { _ in received.add(1) }
+        case "image64k":
+            let sub = try await node.createSubscription(
+                CompressedImage.self, topic: "soak_echo", qos: qos)
+            sub.onMessage { _ in received.add(1) }
+        default:
+            let sub = try await node.createSubscription(
+                PointCloud2.self, topic: "soak_echo", qos: qos)
+            sub.onMessage { _ in received.add(1) }
+        }
+    }
+
     let published = Counter()
     let periodNS: UInt64 = rateHz > 0 ? UInt64(1_000_000_000 / UInt64(rateHz)) : 0
 
@@ -138,8 +178,10 @@ func run() async throws {
         let startNS = nowNS()
         let endNS = startNS + UInt64(durationS) * 1_000_000_000
         var samples: [SoakSample] = []
+        var recvSeries: [Double] = []
         var nextSampleNS = startNS + UInt64(sampleS) * 1_000_000_000
         var lastSampleCount = 0
+        var lastRecvCount = 0
         var lastSampleNS = startNS
         var lastFDs = max(0, openFDCount())  // baseline; carried if a read fails
         var next = startNS
@@ -160,28 +202,41 @@ func run() async throws {
                 let rawFDs = openFDCount()
                 let fds = rawFDs >= 0 ? rawFDs : lastFDs  // carry last good on a failed read
                 lastFDs = fds
+                let recvTotal = received.value
+                let recvPerS = dt > 0 ? Double(recvTotal - lastRecvCount) / dt : 0
                 let s = SoakSample(
                     tSeconds: Double(now - startNS) / 1e9, rssBytes: currentRSSBytes(),
                     openFDs: fds, msgsPerSec: mps)
                 samples.append(s)
+                if expectEcho { recvSeries.append(recvPerS) }
                 print(
                     "rcl_soak SAMPLE t=\(String(format: "%.1f", s.tSeconds)) "
                         + "rss_mb=\(String(format: "%.1f", Double(s.rssBytes) / 1_048_576)) "
-                        + "fds=\(s.openFDs) msgs_per_s=\(String(format: "%.0f", s.msgsPerSec))")
+                        + "fds=\(s.openFDs) msgs_per_s=\(String(format: "%.0f", s.msgsPerSec))"
+                        + (expectEcho ? " recv_per_s=\(String(format: "%.0f", recvPerS))" : ""))
                 fflush(stdout)
                 lastSampleCount = total
+                lastRecvCount = recvTotal
                 lastSampleNS = now
                 nextSampleNS = now + UInt64(sampleS) * 1_000_000_000
             }
         }
         let v = SoakAnalysis.analyze(samples)
-        print(
+        var result =
             "rcl_soak RESULT backend=\(backend) payload=\(payload) duration_s=\(durationS) "
-                + "samples=\(samples.count) published=\(published.value) "
-                + "verdict=\(v.leakSuspected ? "LEAK" : "healthy") "
-                + "rss_slope_b_per_min=\(Int(v.rssSlopeBytesPerMin.rounded())) "
-                + "fd_growth=\(v.fdGrowth) "
-                + "tput_degradation_pct=\(String(format: "%.1f", v.throughputDegradationPct))")
+            + "samples=\(samples.count) published=\(published.value) "
+            + "verdict=\(v.leakSuspected ? "LEAK" : "healthy") "
+            + "rss_slope_b_per_min=\(Int(v.rssSlopeBytesPerMin.rounded())) "
+            + "fd_growth=\(v.fdGrowth) "
+            + "tput_degradation_pct=\(String(format: "%.1f", v.throughputDegradationPct))"
+        if expectEcho {
+            let echo = SoakAnalysis.echoContinuity(recvPerSecond: recvSeries)
+            result +=
+                " received=\(received.value)"
+                + " recv_zero_run_max=\(echo.maxConsecutiveZeroRecvSamples)"
+                + " recv_recovered=\(echo.recoveredAfterZeroRecv)"
+        }
+        print(result)
         fflush(stdout)
         if selftest {
             guard samples.count >= 1, samples.allSatisfy({ $0.rssBytes > 0 }) else {

--- a/Sources/Examples/RclSoak/main.swift
+++ b/Sources/Examples/RclSoak/main.swift
@@ -223,17 +223,25 @@ func run() async throws {
         }
         let v = SoakAnalysis.analyze(samples)
         var result =
-            "rcl_soak RESULT backend=\(backend) payload=\(payload) duration_s=\(durationS) "
+            "rcl_soak RESULT backend=\(backend) stack=\(HarnessCLI.stack(forBackend: backend)) "
+            + "payload=\(payload) duration_s=\(durationS) "
             + "samples=\(samples.count) published=\(published.value) "
             + "verdict=\(v.leakSuspected ? "LEAK" : "healthy") "
             + "rss_slope_b_per_min=\(Int(v.rssSlopeBytesPerMin.rounded())) "
             + "fd_growth=\(v.fdGrowth) "
             + "tput_degradation_pct=\(String(format: "%.1f", v.throughputDegradationPct))"
         if expectEcho {
-            let echo = SoakAnalysis.echoContinuity(recvPerSecond: recvSeries)
+            // A sample counts as stalled below half the target publish rate —
+            // a strict zero-only check misses partial outages (e.g. a router
+            // restart inside one window), and the first window is excluded
+            // while the relay/subscription match warms up.
+            let stallThreshold = Double(rateHz) * 0.5
+            let echo = SoakAnalysis.echoContinuity(
+                recvPerSecond: recvSeries, stallThreshold: stallThreshold, excludeWarmup: true)
             result +=
                 " received=\(received.value)"
-                + " recv_zero_run_max=\(echo.maxConsecutiveZeroRecvSamples)"
+                + " recv_stall_threshold=\(String(format: "%.0f", stallThreshold))"
+                + " recv_stall_run_max=\(echo.maxConsecutiveZeroRecvSamples)"
                 + " recv_recovered=\(echo.recoveredAfterZeroRecv)"
         }
         print(result)

--- a/Sources/SwiftROS2Bench/HarnessCLI.swift
+++ b/Sources/SwiftROS2Bench/HarnessCLI.swift
@@ -14,14 +14,16 @@ public enum HarnessCLI {
 
     /// Resolve the Zenoh router locator for the `zenoh` backend:
     /// `--locator <str>` wins, then `SWIFT_ROS2_ZENOH_LOCATOR`, then
-    /// ``defaultZenohLocator``. A trailing `--locator` with no value and an
-    /// empty environment value both fall through to the next source.
+    /// ``defaultZenohLocator``. A trailing `--locator` with no value, a
+    /// value that is itself another flag (`--locator --duration-s`), and an
+    /// empty environment value all fall through to the next source — a
+    /// locator never legitimately starts with `-`.
     public static func resolveZenohLocator(
         arguments: [String],
         environment: [String: String]
     ) -> String {
         if let i = arguments.firstIndex(of: "--locator"), i + 1 < arguments.count,
-            !arguments[i + 1].isEmpty
+            !arguments[i + 1].isEmpty, !arguments[i + 1].hasPrefix("-")
         {
             return arguments[i + 1]
         }
@@ -29,5 +31,28 @@ public enum HarnessCLI {
             return env
         }
         return defaultZenohLocator
+    }
+
+    /// The transport stack the `zenoh` backend token actually resolves to in
+    /// this build. The token is variant-dependent (an invisible build-time
+    /// switch), so RESULT lines record it explicitly to keep archived soak
+    /// and bench logs self-describing: when the zenoh-pico wire family is in
+    /// the build graph, `.zenoh` is the wire path; when it is carved out
+    /// (SWIFT_ROS2_RCL_RMW=zenoh), `.zenoh` routes to rcl + rmw_zenoh_cpp.
+    public static var zenohStack: String {
+        #if canImport(SwiftROS2Zenoh)
+            return "wire-zenoh-pico"
+        #else
+            return "rcl-rmw_zenoh"
+        #endif
+    }
+
+    /// Stack description for any backend token, for RESULT-line stamping.
+    public static func stack(forBackend backend: String) -> String {
+        switch backend {
+        case "zenoh": return zenohStack
+        case "rcl": return "rcl-rmw_cyclonedds"
+        default: return "wire-cyclonedds"
+        }
     }
 }

--- a/Sources/SwiftROS2Bench/HarnessCLI.swift
+++ b/Sources/SwiftROS2Bench/HarnessCLI.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Pure argument / environment resolution shared by the rcl-bench and
+/// rcl-soak harness executables. No I/O — unit-tested in normal CI.
+public enum HarnessCLI {
+    /// Backend tokens the harness executables accept.
+    public static let supportedBackends: Set<String> = ["rcl", "dds", "zenoh"]
+
+    /// Environment variable consulted when `--locator` is absent.
+    public static let zenohLocatorEnvVar = "SWIFT_ROS2_ZENOH_LOCATOR"
+
+    /// Fallback Zenoh router locator (a local rmw_zenohd).
+    public static let defaultZenohLocator = "tcp/127.0.0.1:7447"
+
+    /// Resolve the Zenoh router locator for the `zenoh` backend:
+    /// `--locator <str>` wins, then `SWIFT_ROS2_ZENOH_LOCATOR`, then
+    /// ``defaultZenohLocator``. A trailing `--locator` with no value and an
+    /// empty environment value both fall through to the next source.
+    public static func resolveZenohLocator(
+        arguments: [String],
+        environment: [String: String]
+    ) -> String {
+        if let i = arguments.firstIndex(of: "--locator"), i + 1 < arguments.count,
+            !arguments[i + 1].isEmpty
+        {
+            return arguments[i + 1]
+        }
+        if let env = environment[zenohLocatorEnvVar], !env.isEmpty {
+            return env
+        }
+        return defaultZenohLocator
+    }
+}

--- a/Sources/SwiftROS2Bench/SoakAnalysis.swift
+++ b/Sources/SwiftROS2Bench/SoakAnalysis.swift
@@ -94,4 +94,30 @@ public enum SoakAnalysis {
             fdGrowth: fdGrowth, throughputDegradationPct: throughputDegradationPct,
             summary: summary)
     }
+
+    /// Receive-side echo continuity for an `--expect-echo` soak run.
+    ///
+    /// Given the per-sample receive rates (the `recv_per_s` series), returns
+    /// the length of the longest run of consecutive zero-recv samples and
+    /// whether delivery recovered after stalling. `recoveredAfterZeroRecv` is
+    /// true iff the series contains at least one zero sample and does not end
+    /// in one (delivery resumed after the last stall). A series with no zero
+    /// samples reports `(0, false)` — there was nothing to recover from. An
+    /// empty series reports `(0, false)`.
+    public static func echoContinuity(
+        recvPerSecond: [Double]
+    ) -> (maxConsecutiveZeroRecvSamples: Int, recoveredAfterZeroRecv: Bool) {
+        var maxRun = 0
+        var run = 0
+        for value in recvPerSecond {
+            if value == 0 {
+                run += 1
+                maxRun = max(maxRun, run)
+            } else {
+                run = 0
+            }
+        }
+        // run == 0 here means the series does not end in a zero sample.
+        return (maxRun, maxRun > 0 && run == 0)
+    }
 }

--- a/Sources/SwiftROS2Bench/SoakAnalysis.swift
+++ b/Sources/SwiftROS2Bench/SoakAnalysis.swift
@@ -107,17 +107,43 @@ public enum SoakAnalysis {
     public static func echoContinuity(
         recvPerSecond: [Double]
     ) -> (maxConsecutiveZeroRecvSamples: Int, recoveredAfterZeroRecv: Bool) {
+        echoContinuity(recvPerSecond: recvPerSecond, stallThreshold: 0, excludeWarmup: false)
+    }
+
+    /// Threshold-aware echo continuity.
+    ///
+    /// A sample counts as stalled iff its rate is `<= stallThreshold` — a
+    /// strict `== 0` check misses partial outages (a router restart that
+    /// drops delivery to a fraction of the target rate within one sample
+    /// window is a real stall the zero-only check reports as clean). With
+    /// `excludeWarmup`, leading stalled samples before the first healthy one
+    /// are skipped: an `--expect-echo` run whose relay/subscription match
+    /// completes after the first window would otherwise report a phantom
+    /// stall. `recoveredAfterZeroRecv` is true iff at least one (post-warmup)
+    /// stall run exists and the series ends healthy. Caveat: a series that
+    /// never delivers is consumed entirely by warmup exclusion and reports
+    /// clean — callers must also check the total received count (the soak
+    /// RESULT line carries `received=` for exactly this reason).
+    public static func echoContinuity(
+        recvPerSecond: [Double],
+        stallThreshold: Double,
+        excludeWarmup: Bool
+    ) -> (maxConsecutiveZeroRecvSamples: Int, recoveredAfterZeroRecv: Bool) {
+        var series = recvPerSecond[...]
+        if excludeWarmup {
+            series = series.drop(while: { $0 <= stallThreshold })
+        }
         var maxRun = 0
         var run = 0
-        for value in recvPerSecond {
-            if value == 0 {
+        for value in series {
+            if value <= stallThreshold {
                 run += 1
                 maxRun = max(maxRun, run)
             } else {
                 run = 0
             }
         }
-        // run == 0 here means the series does not end in a zero sample.
+        // run == 0 here means the series does not end in a stalled sample.
         return (maxRun, maxRun > 0 && run == 0)
     }
 }

--- a/Tests/SwiftROS2BenchTests/HarnessCLITests.swift
+++ b/Tests/SwiftROS2BenchTests/HarnessCLITests.swift
@@ -49,4 +49,23 @@ final class HarnessCLITests: XCTestCase {
             arguments: [], environment: [HarnessCLI.zenohLocatorEnvVar: ""])
         XCTAssertEqual(locator, HarnessCLI.defaultZenohLocator)
     }
+
+    func testLocatorFollowedByAnotherFlagFallsThrough() {
+        // `--locator --duration-s 5` must not eat the flag as the value —
+        // a locator never legitimately starts with `-`.
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: ["rcl-soak", "zenoh", "--locator", "--duration-s", "5"],
+            environment: [HarnessCLI.zenohLocatorEnvVar: "tcp/192.168.1.1:7447"])
+        XCTAssertEqual(locator, "tcp/192.168.1.1:7447")
+    }
+
+    func testStackForBackendIsSelfDescribing() {
+        XCTAssertEqual(HarnessCLI.stack(forBackend: "rcl"), "rcl-rmw_cyclonedds")
+        XCTAssertEqual(HarnessCLI.stack(forBackend: "dds"), "wire-cyclonedds")
+        #if canImport(SwiftROS2Zenoh)
+            XCTAssertEqual(HarnessCLI.stack(forBackend: "zenoh"), "wire-zenoh-pico")
+        #else
+            XCTAssertEqual(HarnessCLI.stack(forBackend: "zenoh"), "rcl-rmw_zenoh")
+        #endif
+    }
 }

--- a/Tests/SwiftROS2BenchTests/HarnessCLITests.swift
+++ b/Tests/SwiftROS2BenchTests/HarnessCLITests.swift
@@ -1,0 +1,52 @@
+import SwiftROS2Bench
+import XCTest
+
+final class HarnessCLITests: XCTestCase {
+    func testSupportedBackends() {
+        XCTAssertTrue(HarnessCLI.supportedBackends.contains("rcl"))
+        XCTAssertTrue(HarnessCLI.supportedBackends.contains("dds"))
+        XCTAssertTrue(HarnessCLI.supportedBackends.contains("zenoh"))
+        XCTAssertFalse(HarnessCLI.supportedBackends.contains("fastdds"))
+    }
+
+    func testLocatorFlagWinsOverEnvironment() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: ["rcl-bench", "zenoh", "publish", "--locator", "tcp/10.0.0.5:7447"],
+            environment: [HarnessCLI.zenohLocatorEnvVar: "tcp/192.168.1.1:7447"])
+        XCTAssertEqual(locator, "tcp/10.0.0.5:7447")
+    }
+
+    func testEnvironmentFallback() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: ["rcl-bench", "zenoh", "publish"],
+            environment: [HarnessCLI.zenohLocatorEnvVar: "tcp/192.168.1.1:7447"])
+        XCTAssertEqual(locator, "tcp/192.168.1.1:7447")
+    }
+
+    func testDefaultWhenNothingGiven() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: ["rcl-bench", "zenoh", "publish"], environment: [:])
+        XCTAssertEqual(locator, HarnessCLI.defaultZenohLocator)
+        XCTAssertEqual(locator, "tcp/127.0.0.1:7447")
+    }
+
+    func testTrailingLocatorFlagWithoutValueFallsThrough() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: ["rcl-bench", "zenoh", "publish", "--locator"],
+            environment: [HarnessCLI.zenohLocatorEnvVar: "tcp/192.168.1.1:7447"])
+        XCTAssertEqual(locator, "tcp/192.168.1.1:7447")
+    }
+
+    func testEmptyLocatorValueFallsThrough() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: ["rcl-bench", "zenoh", "publish", "--locator", ""],
+            environment: [HarnessCLI.zenohLocatorEnvVar: "tcp/192.168.1.1:7447"])
+        XCTAssertEqual(locator, "tcp/192.168.1.1:7447")
+    }
+
+    func testEmptyEnvironmentValueFallsThroughToDefault() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: [], environment: [HarnessCLI.zenohLocatorEnvVar: ""])
+        XCTAssertEqual(locator, HarnessCLI.defaultZenohLocator)
+    }
+}

--- a/Tests/SwiftROS2BenchTests/SoakAnalysisTests.swift
+++ b/Tests/SwiftROS2BenchTests/SoakAnalysisTests.swift
@@ -126,4 +126,49 @@ final class SoakAnalysisTests: XCTestCase {
         XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 1)
         XCTAssertTrue(r.recoveredAfterZeroRecv)
     }
+
+    // MARK: - echoContinuity (threshold-aware overload)
+
+    func testEchoContinuityThresholdCatchesPartialStall() {
+        // A router restart that drops delivery to 25/s inside one window is a
+        // real stall the zero-only check misses (observed in the MZ3 fault run).
+        let r = SoakAnalysis.echoContinuity(
+            recvPerSecond: [100, 92, 25, 100, 100], stallThreshold: 50, excludeWarmup: false)
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 1)
+        XCTAssertTrue(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityWarmupExclusionSkipsLeadingStall() {
+        // Relay/subscription match completing after the first window must not
+        // count as a stall.
+        let r = SoakAnalysis.echoContinuity(
+            recvPerSecond: [0, 100, 100, 100], stallThreshold: 50, excludeWarmup: true)
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 0)
+        XCTAssertFalse(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityWarmupExclusionStillSeesRealStall() {
+        let r = SoakAnalysis.echoContinuity(
+            recvPerSecond: [0, 0, 100, 30, 30, 100], stallThreshold: 50, excludeWarmup: true)
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 2)
+        XCTAssertTrue(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityThresholdOverloadDefaultsMatchLegacy() {
+        // stallThreshold 0 + no warmup exclusion must be the legacy zero-only
+        // semantics the two-argument form forwards to.
+        let series: [Double] = [0, 100, 0, 0, 0, 100, 0, 0, 100]
+        let legacy = SoakAnalysis.echoContinuity(recvPerSecond: series)
+        let explicit = SoakAnalysis.echoContinuity(
+            recvPerSecond: series, stallThreshold: 0, excludeWarmup: false)
+        XCTAssertEqual(legacy.maxConsecutiveZeroRecvSamples, explicit.maxConsecutiveZeroRecvSamples)
+        XCTAssertEqual(legacy.recoveredAfterZeroRecv, explicit.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityAllWarmupSeriesReportsClean() {
+        let r = SoakAnalysis.echoContinuity(
+            recvPerSecond: [0, 0, 0], stallThreshold: 50, excludeWarmup: true)
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 0)
+        XCTAssertFalse(r.recoveredAfterZeroRecv)
+    }
 }

--- a/Tests/SwiftROS2BenchTests/SoakAnalysisTests.swift
+++ b/Tests/SwiftROS2BenchTests/SoakAnalysisTests.swift
@@ -81,4 +81,49 @@ final class SoakAnalysisTests: XCTestCase {
         XCTAssertEqual(v.rssSlopeBytesPerMin, 0)
         XCTAssertFalse(v.leakSuspected)
     }
+
+    // MARK: - echoContinuity (H7 receive-side observability)
+
+    func testEchoContinuityEmptySeries() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 0)
+        XCTAssertFalse(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityAllNonZeroHasNoStall() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [100, 99, 101])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 0)
+        // No zero sample means there was nothing to recover from.
+        XCTAssertFalse(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityMidRunStallThatRecovers() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [100, 0, 0, 0, 100])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 3)
+        XCTAssertTrue(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityStallAtEndIsNotRecovered() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [100, 100, 0, 0])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 2)
+        XCTAssertFalse(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityLongestZeroRunWins() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [0, 100, 0, 0, 0, 100, 0, 0, 100])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 3)
+        XCTAssertTrue(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityAllZerosIsNeverRecovered() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [0, 0, 0])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 3)
+        XCTAssertFalse(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuitySingleZeroThenRecovery() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [0, 100])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 1)
+        XCTAssertTrue(r.recoveredAfterZeroRecv)
+    }
 }


### PR DESCRIPTION
## Summary

Adds Zenoh-RCL support to the verification harness (H2 + H3 + H7):

1. **rcl-bench: `zenoh` backend + `--locator`** — a third backend token alongside `rcl`/`dds` that constructs `TransportConfig.zenoh(locator:domainId:)`. The locator resolves `--locator <str>` > `SWIFT_ROS2_ZENOH_LOCATOR` > `tcp/127.0.0.1:7447`. On the default build this is the zenoh-pico wire path; on the `SWIFT_ROS2_RCL_RMW=zenoh` variant it routes to rcl + rmw_zenoh_cpp (locator injected via `ZENOH_SESSION_CONFIG_URI`). All four modes accept the token; `encode` (no transport) measures the pure-Swift CDREncoder for `zenoh`, keeping the rcl marshal proxy on the `rcl` token. Existing `rcl`/`dds` behavior is unchanged.
2. **rcl-soak: same `zenoh` backend + locator plumbing.**
3. **H7 — `--expect-echo` receive-side observability for rcl-soak** — opens a subscription on `soak_echo` (host-side relay of `soak`, mirroring rcl-bench's roundtrip-lan flow); every SAMPLE line gains `recv_per_s=<n>` and the RESULT line gains `received=`/`recv_zero_run_max=`/`recv_recovered=` from the new pure `SoakAnalysis.echoContinuity(recvPerSecond:)` helper (additive — the existing `analyze()` verdict API is untouched).

The shared token set and locator resolution live in a new pure `HarnessCLI` enum in `SwiftROS2Bench`, unit-tested together with `echoContinuity` in `SwiftROS2BenchTests` (runs in normal, non-RCL CI). Public API (`SwiftROS2` umbrella) is unchanged — harness/bench targets only.

## Verification

- `swift build --scratch-path .build-plain` — pass (harness excluded from the no-RCL graph; `.zenoh`/`.rcl` fail at runtime via `TransportError.unsupportedFeature` where unlinked).
- `swift test --scratch-path .build-plain --filter SwiftROS2BenchTests` — 22/22 pass.
- `SWIFT_ROS2_ENABLE_RCL=1 SWIFT_ROS2_RCL_RMW=zenoh swift build --scratch-path .build-zenoh` — pass.
- `SWIFT_ROS2_ENABLE_RCL=1 SWIFT_ROS2_RCL_RMW=zenoh swift test --scratch-path .build-zenoh --filter "SoakAnalysis|HarnessCLI"` — 22/22 pass.
- Local `SWIFT_ROS2_ENABLE_RCL=1 swift build --scratch-path .build-rcl` could not run: the local prebuilt `build/ros2/CRos2Jazzy.xcframework` carries only an `ios-arm64` slice (fails identically on `main`; environment-only, covered by ci-rcl).
- `swift format lint --strict` — clean.

## Runtime smoke (live rmw_zenohd on tcp/127.0.0.1:7447, domain 0)

```
$ rcl-bench zenoh publish imu --count 300 --rate-hz 100 --domain 0
rcl_bench RESULT backend=zenoh mode=publish payload=imu count=300 received=- rate_hz=100 msgs_per_s=100 p50us=47.50 p95us=64.79 p99us=84.88 maxus=113.83 wall_s=3.004
```

Reachability, while `--count 3000` ran in background (`ros2 topic echo /rcl_bench/bench sensor_msgs/msg/Imu --once` in the `ros_jazzy_zenoh` container with `RMW_IMPLEMENTATION=rmw_zenoh_cpp`): received the message (`frame_id: bench`). The long publish finished cleanly (`count=3000 ... wall_s=30.003`).

```
$ rcl-soak zenoh --selftest --domain 0 --expect-echo
rcl_soak SAMPLE t=1.0 rss_mb=14.4 fds=17 msgs_per_s=100 recv_per_s=0
rcl_soak SAMPLE t=2.0 rss_mb=14.5 fds=17 msgs_per_s=100 recv_per_s=0
rcl_soak RESULT backend=zenoh payload=imu duration_s=2 samples=2 published=200 verdict=healthy rss_slope_b_per_min=0 fd_growth=0 tput_degradation_pct=0.0 received=0 recv_zero_run_max=2 recv_recovered=false
rcl_soak SELFTEST OK
```

(`recv_per_s=0` expected — no host relay was running for the selftest.)