### PR TITLE
ci(rcl): zenoh-rmw variant leg + execute SwiftROS2RCLTests

### DIFF
--- a/.github/workflows/ci-rcl.yml
+++ b/.github/workflows/ci-rcl.yml
@@ -1,10 +1,18 @@
 name: CI (RCL)
-# RCL (native rcl + rmw_cyclonedds_cpp) backend CI. Runs on every PR as a
-# required check: the cost driver is cross-compiling the real ROS 2 stack into
-# CRos2Jazzy.xcframework (~20-25 min for the single maccatalyst slice), which
-# is accepted for main-line protection. The mock-based RCL unit tests need no
-# xcframework and already run in ci.yml; this job covers the parts that
-# require the real xcframework + Mac Catalyst.
+# RCL (native rcl) backend CI, both rmw variants:
+#   rcl-build-smoke — rmw_cyclonedds_cpp (CRos2Jazzy.xcframework): required
+#     check; Mac Catalyst umbrella/smoke builds + native execution of
+#     SwiftROS2RCLTests. The cost driver is cross-compiling the real ROS 2
+#     stack (~20-25 min per slice), so the finished xcframework is cached on
+#     the build inputs (Scripts/build-ros2-xcframework.sh + Scripts/ros2/**);
+#     warm runs skip the cross-build entirely.
+#   rcl-zenoh — rmw_zenoh_cpp (CRos2JazzyZenoh.xcframework): builds the zenoh
+#     rmw variant (SWIFT_ROS2_RCL_RMW=zenoh — the dropZenohWire manifest
+#     carve-out + SWIFT_ROS2_RCL_RMW_ZENOH define + Context routing) and
+#     executes SwiftROS2RCLTests natively. Same cache strategy.
+# SwiftROS2RCLTests only exists in the build graph when SWIFT_ROS2_ENABLE_RCL=1
+# (ci.yml's swift test runs never set it), so this workflow is the only place
+# those tests execute.
 on:
   pull_request:
     branches: [main]
@@ -34,17 +42,6 @@ jobs:
           submodules: recursive
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: brew install cmake
-
-      # ament_cmake's package_xml_2_cmake.py runs under the runner's base python
-      # (CMake's FindPython resolves to it, not the script's venv), so the ROS 2
-      # build deps must be importable there too — install them into the runner
-      # python in addition to the venv the build script creates.
-      - name: Install ROS 2 build deps into runner python
-        run: pip install -r Scripts/ros2/requirements.txt
 
       # Regen-drift guard: re-run the marshalling generator and assert the
       # checked-in C + Swift files are byte-identical. Pure generator (Swift
@@ -65,14 +62,53 @@ jobs:
             Sources/SwiftROS2RCL/Generated \
             || { echo "::error::generated RCL marshalling is stale — run Scripts/regen-rcl-marshalling.sh and commit"; exit 1; }
 
+      # The finished xcframework is a deterministic function of the build
+      # script (which pins the ros2 tag + package set) and Scripts/ros2/**
+      # (metas, patches, toolchain, modulemap) — cache it on those inputs so
+      # warm runs skip the ~40-50 min two-slice cross-build. The Xcode version
+      # is spelled into the key: bumping the toolchain invalidates the cache.
+      # restore/save are split so the cache is persisted right after a
+      # successful cross-build, even if a later smoke step fails.
+      - name: Restore CRos2Jazzy.xcframework cache (cyclonedds)
+        id: cache-ros2
+        uses: actions/cache/restore@v4
+        with:
+          path: build/ros2/CRos2Jazzy.xcframework
+          key: ros2-xcfw-cyclonedds-maccatalyst-macosx-xcode26.4.1-${{ hashFiles('Scripts/build-ros2-xcframework.sh', 'Scripts/ros2/**') }}
+
+      # Python + cmake + the ROS 2 build deps only feed the cross-build; skip
+      # them entirely on a cache hit.
+      - uses: actions/setup-python@v5
+        if: steps.cache-ros2.outputs.cache-hit != 'true'
+        with:
+          python-version: "3.11"
+      - if: steps.cache-ros2.outputs.cache-hit != 'true'
+        run: brew install cmake
+
+      # ament_cmake's package_xml_2_cmake.py runs under the runner's base python
+      # (CMake's FindPython resolves to it, not the script's venv), so the ROS 2
+      # build deps must be importable there too — install them into the runner
+      # python in addition to the venv the build script creates.
+      - name: Install ROS 2 build deps into runner python
+        if: steps.cache-ros2.outputs.cache-hit != 'true'
+        run: pip install -r Scripts/ros2/requirements.txt
+
       # Cross-compile rcl + rmw_cyclonedds_cpp + rosidl introspection into a
-      # single-slice (maccatalyst) CRos2Jazzy.xcframework. One slice is enough:
-      # `xcodebuild -create-xcframework` accepts a single library, and every
-      # step below targets Mac Catalyst. Device-slice verification is done
-      # on-device via Conduit, not here. (The full maccatalyst+iphoneos pair is
-      # built by the separate build-ros2-xcframework.yml workflow when needed.)
-      - name: Build CRos2Jazzy.xcframework (maccatalyst)
-        run: Scripts/build-ros2-xcframework.sh maccatalyst
+      # two-slice CRos2Jazzy.xcframework: maccatalyst for the xcodebuild
+      # umbrella/smoke steps below, macosx so `swift test` can execute
+      # SwiftROS2RCLTests natively at the end. Device-slice verification is
+      # done on-device via Conduit, not here. (The full maccatalyst+iphoneos
+      # pair is built by the separate build-ros2-xcframework.yml workflow when
+      # needed.)
+      - name: Build CRos2Jazzy.xcframework (maccatalyst + macosx)
+        if: steps.cache-ros2.outputs.cache-hit != 'true'
+        run: Scripts/build-ros2-xcframework.sh maccatalyst macosx
+      - name: Save CRos2Jazzy.xcframework cache (cyclonedds)
+        if: steps.cache-ros2.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build/ros2/CRos2Jazzy.xcframework
+          key: ros2-xcfw-cyclonedds-maccatalyst-macosx-xcode26.4.1-${{ hashFiles('Scripts/build-ros2-xcframework.sh', 'Scripts/ros2/**') }}
 
       # Regression guard for the umbrella build path
       # (SwiftROS2 -> SwiftROS2DDS -> CDDSBridge). This is the path the
@@ -244,3 +280,101 @@ jobs:
           printf '%s\n' "$out"
           printf '%s\n' "$out" | grep -q "crcl_action_loopback OK:"
           ! printf '%s\n' "$out" | grep -qi "AddressSanitizer\|runtime error\|detected memory leaks"
+
+      # Execute the RCL unit tests (CrossBackendBytesTests byte parity vs
+      # rmw_serialize, RclDiscoveryEnvTests, RclZenohSessionEnvTests) natively
+      # against the macosx slice. All hermetic: rmw_serialize touches no DDS
+      # participant and the env tests never start rmw. This is the only place
+      # these tests run — the target only exists under SWIFT_ROS2_ENABLE_RCL=1,
+      # which ci.yml's swift test jobs never set.
+      - name: Run SwiftROS2RCLTests (cyclonedds, macOS native)
+        run: swift test --filter SwiftROS2RCLTests
+
+  rcl-zenoh:
+    name: RCL zenoh-rmw build + tests (macOS)
+    # Covers the zenoh rmw variant, which the required check above never
+    # touches: RMW_VARIANT=zenoh cross-build (rmw_zenoh_cpp no-SHM patch set,
+    # fastrtps typesupport pin, zenoh-c Rust staticlib), the dropZenohWire
+    # manifest carve-out (zenoh-pico wire family out of the graph — zenoh-c
+    # and zenoh-pico export the same C API and cannot co-link), the
+    # SWIFT_ROS2_RCL_RMW_ZENOH define, and Context's .zenoh -> rcl routing
+    # (MZ1). One macosx slice is the cheapest meaningful check: `swift build`
+    # compiles the whole carved-out graph natively and `swift test` executes
+    # SwiftROS2RCLTests against the real rmw_zenoh xcframework.
+    runs-on: macos-26
+    timeout-minutes: 180
+    env:
+      SWIFT_ROS2_ENABLE_RCL: "1"
+      SWIFT_ROS2_RCL_RMW: zenoh
+    steps:
+      # No submodules: the regen guard runs only in rcl-build-smoke, the
+      # cross-build does its own clones, and the zenoh-pico vendor tree is
+      # carved out of this variant's build graph anyway.
+      - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app
+
+      # Same input-keyed cache strategy as rcl-build-smoke (the script embeds
+      # the rmw_zenoh / zenoh-c / zenoh-cpp pins, so they are in the hash).
+      - name: Restore CRos2JazzyZenoh.xcframework cache (zenoh)
+        id: cache-ros2zenoh
+        uses: actions/cache/restore@v4
+        with:
+          path: build/ros2zenoh/CRos2JazzyZenoh.xcframework
+          key: ros2-xcfw-zenoh-macosx-xcode26.4.1-${{ hashFiles('Scripts/build-ros2-xcframework.sh', 'Scripts/ros2/**') }}
+
+      - uses: actions/setup-python@v5
+        if: steps.cache-ros2zenoh.outputs.cache-hit != 'true'
+        with:
+          python-version: "3.11"
+      - if: steps.cache-ros2zenoh.outputs.cache-hit != 'true'
+        run: brew install cmake
+
+      # Same runner-python requirement as rcl-build-smoke: CMake's FindPython
+      # resolves the base python, not the script's venv.
+      - name: Install ROS 2 build deps into runner python
+        if: steps.cache-ros2zenoh.outputs.cache-hit != 'true'
+        run: pip install -r Scripts/ros2/requirements.txt
+
+      # build_zenohc drives cargo to build zenoh-c as a Rust staticlib and
+      # runs `rustup target add` for the slice triple (aarch64-apple-darwin
+      # for the macosx slice — the runner's native target, so no
+      # cross-toolchain is needed). GitHub macOS images ship rustup, but
+      # bootstrap it defensively in case a future image drops it.
+      - name: Ensure Rust toolchain
+        if: steps.cache-ros2zenoh.outputs.cache-hit != 'true'
+        run: |
+          if ! command -v rustup >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --profile minimal --default-toolchain stable
+          fi
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.cargo/bin:$PATH"
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+          rustc --version && cargo --version
+
+      # Cross-compile rcl + rmw_zenoh_cpp (+ prebuilt zenoh-c) into a
+      # single-slice (macosx) CRos2JazzyZenoh.xcframework.
+      - name: Build CRos2JazzyZenoh.xcframework (macosx)
+        if: steps.cache-ros2zenoh.outputs.cache-hit != 'true'
+        run: RMW_VARIANT=zenoh Scripts/build-ros2-xcframework.sh macosx
+      - name: Save CRos2JazzyZenoh.xcframework cache (zenoh)
+        if: steps.cache-ros2zenoh.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build/ros2zenoh/CRos2JazzyZenoh.xcframework
+          key: ros2-xcfw-zenoh-macosx-xcode26.4.1-${{ hashFiles('Scripts/build-ros2-xcframework.sh', 'Scripts/ros2/**') }}
+
+      # Whole-graph compile check of the carve-out: SwiftROS2Zenoh/CZenohPico
+      # must be absent, the umbrella's .zenoh arm must route through RCL, and
+      # every example/executable must still build without the wire family.
+      - name: Build (zenoh rmw variant, macOS native)
+        run: swift build
+
+      # CrossBackendBytesTests runs byte parity against rmw_zenoh's fastrtps
+      # typesupport serializer here (padding-normalized — Fast-CDR leaves
+      # alignment padding uninitialized); RclZenohSessionEnvTests covers the
+      # MZ1 router plumbing under the real zenoh-variant build graph.
+      - name: Run SwiftROS2RCLTests (zenoh, macOS native)
+        run: swift test --filter SwiftROS2RCLTests

--- a/Scripts/build-ros2-xcframework.sh
+++ b/Scripts/build-ros2-xcframework.sh
@@ -224,7 +224,10 @@ build_host_tools() {
   ignore_unbuildable
   patch_sources
   # shellcheck disable=SC1091
-  source "$BUILD/venv/bin/activate"
+  # The venv is shared from the cyclonedds tree (VENV, rmw-agnostic) — NOT
+  # $BUILD/venv, which does not exist for the zenoh variant on a clean
+  # checkout (the CI zenoh leg builds host tools before any cyclonedds run).
+  source "$VENV/bin/activate"
   colcon --log-base "$HOST/log" build \
     --base-paths "$SRC" \
     --build-base "$HOST/build" --install-base "$HOST/install" \

--- a/Scripts/build-ros2-xcframework.sh
+++ b/Scripts/build-ros2-xcframework.sh
@@ -276,7 +276,10 @@ build_zenohc() {  # $1 = slice -> $BUILD/$slice/zenohc-install
     git clone https://github.com/eclipse-zenoh/zenoh-cpp.git "$zcpp"
     git -C "$zcpp" checkout "$ZENOHCPP_PIN"
   fi
-  rustup target add "$triple"
+  # zenoh-c pins its Rust toolchain via rust-toolchain.toml (currently
+  # 1.93.0); running `rustup target add` inside the checkout installs the
+  # std for THAT toolchain, not the default one (E0463 otherwise).
+  ( cd "$zc" && rustup target add "$triple" )
   ( cd "$zc" && cargo build --release -j 4 --target "$triple" \
       --features unstable --features transport_serial )
   rm -rf "$out"

--- a/Tests/SwiftROS2RCLTests/CrossBackendBytesTests.swift
+++ b/Tests/SwiftROS2RCLTests/CrossBackendBytesTests.swift
@@ -46,6 +46,16 @@
                 XCTAssertEqual(
                     try wireEncode(decoded), wire,
                     "\(what): normalized rmw bytes diverge from wire bytes")
+                // Bytes beyond wire.count are uninitialized alignment padding
+                // whose VALUES cannot be checked, but their LENGTH can: final
+                // CDR alignment never exceeds 8 bytes. A longer tail means the
+                // serializer emitted real data the decode above never
+                // inspected — fail and show it.
+                let tail = Array(rcl.dropFirst(wire.count))
+                XCTAssertLessThanOrEqual(
+                    tail.count, 8,
+                    "\(what): rmw bytes carry a \(tail.count)-byte tail beyond the wire "
+                        + "encoding — not alignment padding: \(tail.prefix(32))")
             #else
                 XCTAssertEqual(
                     Array(rcl.prefix(wire.count)), wire,

--- a/Tests/SwiftROS2RCLTests/CrossBackendBytesTests.swift
+++ b/Tests/SwiftROS2RCLTests/CrossBackendBytesTests.swift
@@ -1,4 +1,5 @@
 #if SWIFT_ROS2_RCL
+    import Foundation
     import SwiftROS2
     import SwiftROS2RCL
     import XCTest
@@ -17,49 +18,69 @@
 
         /// rmw_serialize may pad the buffer to an alignment boundary beyond the
         /// CDR message length; assert the meaningful prefix matches and any
-        /// trailing bytes are zero padding. In practice every corpus message
-        /// serializes to the same byte count on both paths (the tail is empty);
-        /// the `rcl.count >= wire.count` tolerance is kept for future types
-        /// where rmw might align-pad.
-        private func assertByteParity(_ wire: [UInt8], _ rcl: [UInt8], _ what: String) {
+        /// trailing bytes are ignorable padding. In practice every corpus
+        /// message serializes to the same byte count on both paths (the tail is
+        /// empty); the `rcl.count >= wire.count` tolerance is kept for future
+        /// types where rmw might align-pad.
+        ///
+        /// The cyclonedds variant (introspection typesupport) zeroes alignment
+        /// padding, so the comparison is strict byte equality. The zenoh
+        /// variant serializes through Fast-CDR (fastrtps typesupport), which
+        /// leaves alignment-padding bytes uninitialized — a CDR don't-care —
+        /// so exact byte equality cannot hold at padding positions. There the
+        /// rmw bytes are normalized through the pure-Swift codec first
+        /// (decode → re-encode zeroes the padding) and the normalized form
+        /// must match the wire bytes exactly; any structural divergence
+        /// (field order, alignment, lengths, endianness) still fails because
+        /// the decode misparses and the re-encoded bytes differ.
+        private func assertByteParity<M: CDREncodable & CDRDecodable & Equatable>(
+            _ message: M, _ rcl: [UInt8], _ what: String
+        ) throws {
+            let wire = try wireEncode(message)
             XCTAssertGreaterThanOrEqual(
                 rcl.count, wire.count, "\(what): rmw bytes shorter than wire bytes")
-            XCTAssertEqual(
-                Array(rcl.prefix(wire.count)), wire, "\(what): CDR bytes diverge from rmw_serialize")
-            XCTAssertTrue(
-                rcl.dropFirst(wire.count).allSatisfy { $0 == 0 },
-                "\(what): trailing rmw bytes are not zero padding")
+            #if SWIFT_ROS2_RCL_RMW_ZENOH
+                let decoded = try M(from: CDRDecoder(data: Data(rcl.prefix(wire.count))))
+                XCTAssertEqual(
+                    decoded, message, "\(what): rmw bytes decode to a different message")
+                XCTAssertEqual(
+                    try wireEncode(decoded), wire,
+                    "\(what): normalized rmw bytes diverge from wire bytes")
+            #else
+                XCTAssertEqual(
+                    Array(rcl.prefix(wire.count)), wire,
+                    "\(what): CDR bytes diverge from rmw_serialize")
+                XCTAssertTrue(
+                    rcl.dropFirst(wire.count).allSatisfy { $0 == 0 },
+                    "\(what): trailing rmw bytes are not zero padding")
+            #endif
         }
 
         func testImuByteParity() throws {
             let m = VerificationCorpus.imu()
-            try assertByteParity(wireEncode(m), rclSerializeImu(m), "Imu")
+            try assertByteParity(m, rclSerializeImu(m), "Imu")
         }
 
         func testCompressedImageByteParity() throws {
             let m = VerificationCorpus.compressedImage(byteCount: 65_536)
-            try assertByteParity(
-                wireEncode(m), rclSerializeCompressedImage(m), "CompressedImage 64K")
+            try assertByteParity(m, rclSerializeCompressedImage(m), "CompressedImage 64K")
         }
 
         func testPointCloud2ByteParity() throws {
             let m = VerificationCorpus.pointCloud2(width: 10_000)
-            try assertByteParity(
-                wireEncode(m), rclSerializePointCloud2(m), "PointCloud2 10k pts")
+            try assertByteParity(m, rclSerializePointCloud2(m), "PointCloud2 10k pts")
         }
 
         func testPointCloud2ByteParityLidarScale() throws {
             // ~0.96 MB: 60_000 points × 16 B step — LiDAR-scan scale.
             let m = VerificationCorpus.pointCloud2(width: 60_000)
-            try assertByteParity(
-                wireEncode(m), rclSerializePointCloud2(m), "PointCloud2 60k pts (~0.96 MB)")
+            try assertByteParity(m, rclSerializePointCloud2(m), "PointCloud2 60k pts (~0.96 MB)")
         }
 
         func testCompressedImageByteParityRealSize() throws {
             // ~900 KB: representative of a 640x480 rgb8 frame's compressed payload.
             let m = VerificationCorpus.compressedImage(byteCount: 900_000)
-            try assertByteParity(
-                wireEncode(m), rclSerializeCompressedImage(m), "CompressedImage ~900 KB")
+            try assertByteParity(m, rclSerializeCompressedImage(m), "CompressedImage ~900 KB")
         }
     }
 #endif


### PR DESCRIPTION
## Coverage holes closed

Two adversarially-verified gaps in RCL CI coverage:

1. **The zenoh rmw variant had zero CI.** No workflow set `SWIFT_ROS2_RCL_RMW` or `RMW_VARIANT`, so the `dropZenohWire` manifest carve-out, the `SWIFT_ROS2_RCL_RMW_ZENOH` define, `Context`'s `.zenoh` -> rcl routing (MZ1), and the `RMW_VARIANT=zenoh` cross-build path (rmw_zenoh no-SHM patch set, fastrtps typesupport pin, zenoh-c Rust staticlib) were all unexercised.
2. **`SwiftROS2RCLTests` was compiled but never executed.** ci-rcl's Catalyst `build-for-testing` compiles the target; no workflow ran it (`ci.yml`'s `swift test` jobs never set `SWIFT_ROS2_ENABLE_RCL`, so the target doesn't exist there).

## Changes

### `rcl-build-smoke` (required check — name unchanged)
- Cross-build extended from `maccatalyst` to `maccatalyst macosx`, and a final native `swift test --filter SwiftROS2RCLTests` step executes the 16 tests (CrossBackendBytesTests byte parity vs `rmw_serialize`, RclDiscoveryEnvTests, RclZenohSessionEnvTests) against the macosx slice. All hermetic — no DDS participant, no router.

### New `rcl-zenoh` job
- `RMW_VARIANT=zenoh Scripts/build-ros2-xcframework.sh macosx` (single macosx slice — `swift build`/`swift test` on the runner target macOS natively; the zenoh-c triple is the runner-native `aarch64-apple-darwin`, so no Rust cross-target is needed; rustup is bootstrapped defensively).
- `swift build` under `SWIFT_ROS2_ENABLE_RCL=1 SWIFT_ROS2_RCL_RMW=zenoh` compiles the whole carved-out graph (zenoh-pico wire family absent), then `swift test --filter SwiftROS2RCLTests` runs the same 16 tests against the real rmw_zenoh xcframework.

### Caching (new — ci-rcl previously rebuilt the ROS 2 stack every run)
- Both jobs cache the finished xcframework keyed on `hashFiles('Scripts/build-ros2-xcframework.sh', 'Scripts/ros2/**')` (the script embeds the ros2/rmw_zenoh/zenoh-c pins) plus the Xcode version. Split `cache/restore` + `cache/save` so a successful cross-build persists even if a later smoke step fails. Setup steps (python/cmake/pip/rust) are skipped on a warm cache.

### Test fix required by the zenoh leg
- `CrossBackendBytesTests.assertByteParity` is now padding-tolerant under `SWIFT_ROS2_RCL_RMW_ZENOH`: Fast-CDR (fastrtps typesupport) leaves alignment-padding bytes **uninitialized** (observed: garbage at the string-padding positions in the PointCloud2 corpus), while the introspection serializer zeroes them. The zenoh arm normalizes the rmw bytes through the pure-Swift codec (decode -> re-encode zeroes padding) and requires byte equality of the normalized form + decoded-message equality; structural divergence still fails. The cyclonedds arm keeps the strict byte comparison.

## Verification

- Locally (macosx slices built from the same script): `SWIFT_ROS2_ENABLE_RCL=1 swift test --filter SwiftROS2RCLTests` → 16/16 pass; `SWIFT_ROS2_ENABLE_RCL=1 SWIFT_ROS2_RCL_RMW=zenoh swift build && swift test --filter SwiftROS2RCLTests` → 16/16 pass.
- `swift format lint --strict` clean on the changed test file; workflow YAML parses.

## Expected CI time

- **Cold** (no cache): `rcl-build-smoke` ~70-90 min (two-slice cross-build ~40-50 min + Catalyst builds/smokes + native test build); `rcl-zenoh` ~45-60 min (zenoh-c cargo build + macosx colcon build + native test build).
- **Warm** (cache hit): `rcl-build-smoke` ~30-40 min (cross-build skipped); `rcl-zenoh` ~10-15 min.