### PR TITLE
feat(rcl): fail-loud zenoh variant — route-b gate, AMENT prefix synthesis, .rcl rejection

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -721,13 +721,22 @@ if enableRcl {
             linkerSettings: [.linkedLibrary("c++")]
         ))
     products.append(.executable(name: "rcl-soak", targets: ["rcl-soak"]))
+    // The rmw-variant define must reach SwiftROS2RCL itself, not just the
+    // umbrella: RclClient's zenoh-only behavior (the route-(b) fail-loud gate
+    // and the AMENT_PREFIX_PATH synthesis) lives in this target and would be
+    // dead code behind an undefined `#if SWIFT_ROS2_RCL_RMW_ZENOH` otherwise.
+    var rclSwiftSettings: [SwiftSetting] = []
+    if rclRmwVariant == "zenoh" {
+        rclSwiftSettings.append(.define("SWIFT_ROS2_RCL_RMW_ZENOH"))
+    }
     targets.append(
         .target(
             name: "SwiftROS2RCL",
             dependencies: [
                 "CRclBridge", "CDDSBridge", "SwiftROS2Transport", "SwiftROS2Messages", "SwiftROS2Wire",
             ],
-            path: "Sources/SwiftROS2RCL"
+            path: "Sources/SwiftROS2RCL",
+            swiftSettings: rclSwiftSettings
         ))
     products.append(.library(name: "SwiftROS2RCL", targets: ["SwiftROS2RCL"]))
     var rclTestsSwiftSettings: [SwiftSetting] = [.define("SWIFT_ROS2_RCL")]

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -194,7 +194,16 @@ extension ROS2Context {
         case .dds:
             return DDSTransportSession(client: DDSClient())
         case .rcl:
-            #if SWIFT_ROS2_RCL
+            #if SWIFT_ROS2_RCL_RMW_ZENOH
+                // In the zenoh-rmw build the rcl stack speaks rmw_zenoh: a `.rcl`
+                // (or `.rclUnicast`) config would open rmw_zenoh with default
+                // session settings while exporting a meaningless CYCLONEDDS_URI —
+                // none of its discovery knobs reach the wire. Reject it loudly.
+                throw TransportError.unsupportedFeature(
+                    ".rcl/.rclUnicast target rmw_cyclonedds and are unavailable in the "
+                        + "zenoh-rmw build (SWIFT_ROS2_RCL_RMW=zenoh) — use .zenoh(locator:) "
+                        + "(the RCL transport in this build) or .dds (wire CycloneDDS)")
+            #elseif SWIFT_ROS2_RCL
                 return RclTransportSession(client: RclClient())
             #else
                 throw TransportError.unsupportedFeature(

--- a/Sources/SwiftROS2RCL/RclClient.swift
+++ b/Sources/SwiftROS2RCL/RclClient.swift
@@ -748,10 +748,7 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         // and the live env desynchronize.
         Self.envLock.lock()
         defer { Self.envLock.unlock() }
-        // Wrap in Optional(...) so a previously-UNSET env becomes .some(.none)
-        // ("saved, was unset") rather than collapsing to .none ("never saved") —
-        // restoreDiscoveryEnv relies on that distinction to unset vs. no-op.
-        priorCyclonedDDSURI = Optional(getenv("CYCLONEDDS_URI").map { String(cString: $0) })
+        saveEnvSlotLocked(&priorCyclonedDDSURI, "CYCLONEDDS_URI")
         setenv("CYCLONEDDS_URI", xml, 1)
         return true
     }
@@ -765,6 +762,16 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         guard let prior = saved else { return }
         saved = nil
         if let p = prior { setenv(name, p, 1) } else { unsetenv(name) }
+    }
+
+    /// Save the current value of an env variable into its slot before the
+    /// caller overwrites it — the counterpart of ``restoreEnvSlotLocked``.
+    /// Wraps in `Optional(...)` so a previously-UNSET env becomes
+    /// `.some(.none)` ("saved, was unset") rather than collapsing to `.none`
+    /// ("never saved"); the restore side relies on that distinction to unset
+    /// vs. no-op. Caller holds the relevant env lock.
+    private func saveEnvSlotLocked(_ slot: inout String??, _ name: String) {
+        slot = Optional(getenv(name).map { String(cString: $0) })
     }
 
     /// Restore CYCLONEDDS_URI to its pre-applyDiscoveryEnv value (unset it if it
@@ -795,12 +802,8 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         Self.zenohEnvLock.lock()
         defer { Self.zenohEnvLock.unlock() }
         zenohConfigFileURL = url
-        // Wrap in Optional(...) so a previously-UNSET env becomes .some(.none)
-        // ("saved, was unset") rather than collapsing to .none ("never saved").
-        priorZenohSessionConfigURI = Optional(
-            getenv("ZENOH_SESSION_CONFIG_URI").map { String(cString: $0) })
-        priorZenohRouterCheckAttempts = Optional(
-            getenv("ZENOH_ROUTER_CHECK_ATTEMPTS").map { String(cString: $0) })
+        saveEnvSlotLocked(&priorZenohSessionConfigURI, "ZENOH_SESSION_CONFIG_URI")
+        saveEnvSlotLocked(&priorZenohRouterCheckAttempts, "ZENOH_ROUTER_CHECK_ATTEMPTS")
         setenv("ZENOH_SESSION_CONFIG_URI", url.path, 1)
         // Check for the router once, then continue: a mobile publisher must not
         // block context creation when the remote router is briefly unreachable.
@@ -886,9 +889,7 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
                     "failed to synthesize the rmw_zenoh_cpp ament prefix at \(root.path): \(error)")
             }
             amentPrefixDirURL = root
-            // Wrap in Optional(...) so a previously-UNSET env becomes .some(.none)
-            // ("saved, was unset") rather than collapsing to .none ("never saved").
-            priorAmentPrefixPath = Optional(existing)
+            saveEnvSlotLocked(&priorAmentPrefixPath, "AMENT_PREFIX_PATH")
             if let existing, !existing.isEmpty {
                 setenv("AMENT_PREFIX_PATH", "\(root.path):\(existing)", 1)
             } else {

--- a/Sources/SwiftROS2RCL/RclClient.swift
+++ b/Sources/SwiftROS2RCL/RclClient.swift
@@ -644,6 +644,14 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
     /// Temp file backing ZENOH_SESSION_CONFIG_URI; removed on restore.
     /// Guarded by `zenohEnvLock`.
     private var zenohConfigFileURL: URL?
+    #if SWIFT_ROS2_RCL_RMW_ZENOH
+        /// Saved AMENT_PREFIX_PATH to restore on destroyContext. Outer optional =
+        /// "we saved"; inner = "was previously set". Guarded by `zenohEnvLock`.
+        private var priorAmentPrefixPath: String??
+        /// Synthesized minimal ament prefix directory backing AMENT_PREFIX_PATH;
+        /// removed on restore. Guarded by `zenohEnvLock`.
+        private var amentPrefixDirURL: URL?
+    #endif
     /// Route-(b) sibling-participant session (`bridge_dds_session_t*`), created
     /// lazily on the first non-bundled publisher and matched to the rcl
     /// context's discovery. nil until then.
@@ -801,7 +809,9 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
     }
 
     /// Restore the Zenoh env to its pre-apply values (unset what was unset) and
-    /// remove the temp config file. Idempotent: a no-op when nothing was saved.
+    /// remove the temp config file. In the zenoh-rmw variant this also restores
+    /// AMENT_PREFIX_PATH and deletes the synthesized ament prefix. Idempotent:
+    /// a no-op when nothing was saved.
     package func restoreZenohSessionEnv() {
         Self.zenohEnvLock.lock()
         defer { Self.zenohEnvLock.unlock() }
@@ -811,7 +821,81 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
             try? FileManager.default.removeItem(at: url)
             zenohConfigFileURL = nil
         }
+        #if SWIFT_ROS2_RCL_RMW_ZENOH
+            restoreEnvSlotLocked(&priorAmentPrefixPath, "AMENT_PREFIX_PATH")
+            if let dir = amentPrefixDirURL {
+                try? FileManager.default.removeItem(at: dir)
+                amentPrefixDirURL = nil
+            }
+        #endif
     }
+
+    #if SWIFT_ROS2_RCL_RMW_ZENOH
+        /// True when the colon-separated ament prefix path registers
+        /// rmw_zenoh_cpp in its resource index — i.e. ament_index (and therefore
+        /// rmw_init) can resolve DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5 through
+        /// one of its prefixes. `package` so tests can assert the rule.
+        package static func amentPrefixPathContainsRmwZenoh(_ path: String) -> Bool {
+            path.split(separator: ":").contains { prefix in
+                FileManager.default.fileExists(
+                    atPath: "\(prefix)/share/ament_index/resource_index/packages/rmw_zenoh_cpp")
+            }
+        }
+
+        /// rmw_zenoh_cpp hard-requires AMENT_PREFIX_PATH at rmw_init
+        /// (rmw_init.cpp:114 at the pinned fe3553c7) to resolve its default
+        /// session config via ament_index — and a consumer app cannot be
+        /// expected to export it. When the process env is unset/empty or lacks
+        /// the rmw_zenoh_cpp resource, synthesize a minimal ament prefix in a
+        /// temp directory (resource-index marker + the two default config
+        /// json5 files) and export it, prepending any existing value so
+        /// user-registered resources stay resolvable. A user-provided prefix
+        /// that already carries the resource is left untouched. Same
+        /// single-apply-per-context contract as `applyZenohSessionEnv`; pair
+        /// with `restoreZenohSessionEnv()` on teardown or a failed
+        /// createContext. `package` so SwiftROS2RCLTests can exercise the
+        /// synthesis without starting rmw.
+        package func applyAmentPrefixEnv() throws {
+            Self.zenohEnvLock.lock()
+            defer { Self.zenohEnvLock.unlock() }
+            let existing = getenv("AMENT_PREFIX_PATH").map { String(cString: $0) }
+            if let existing, !existing.isEmpty, Self.amentPrefixPathContainsRmwZenoh(existing) {
+                return  // valid user-provided prefix — leave it untouched
+            }
+            let fm = FileManager.default
+            let root = fm.temporaryDirectory
+                .appendingPathComponent("swift-ros2-ament-\(UUID().uuidString)", isDirectory: true)
+            let markerDir = root.appendingPathComponent(
+                "share/ament_index/resource_index/packages", isDirectory: true)
+            let configDir = root.appendingPathComponent(
+                "share/rmw_zenoh_cpp/config", isDirectory: true)
+            do {
+                try fm.createDirectory(at: markerDir, withIntermediateDirectories: true)
+                try fm.createDirectory(at: configDir, withIntermediateDirectories: true)
+                // Empty marker file — its presence is what ament_index resolves.
+                try Data().write(to: markerDir.appendingPathComponent("rmw_zenoh_cpp"))
+                try RmwZenohDefaultConfig.sessionConfigJSON5.write(
+                    to: configDir.appendingPathComponent("DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5"),
+                    atomically: true, encoding: .utf8)
+                try RmwZenohDefaultConfig.routerConfigJSON5.write(
+                    to: configDir.appendingPathComponent("DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5"),
+                    atomically: true, encoding: .utf8)
+            } catch {
+                try? fm.removeItem(at: root)
+                throw TransportError.connectionFailed(
+                    "failed to synthesize the rmw_zenoh_cpp ament prefix at \(root.path): \(error)")
+            }
+            amentPrefixDirURL = root
+            // Wrap in Optional(...) so a previously-UNSET env becomes .some(.none)
+            // ("saved, was unset") rather than collapsing to .none ("never saved").
+            priorAmentPrefixPath = Optional(existing)
+            if let existing, !existing.isEmpty {
+                setenv("AMENT_PREFIX_PATH", "\(root.path):\(existing)", 1)
+            } else {
+                setenv("AMENT_PREFIX_PATH", root.path, 1)
+            }
+        }
+    #endif
 
     package func createContext(
         domainId: Int32, unicastPeerAddresses: [String], networkInterface: String?,
@@ -840,7 +924,6 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         // session config silently drops the publisher onto default (router-less,
         // multicast) settings. So a present-but-unappliable locator fails loudly
         // here instead of producing a connection that never reaches the router.
-        var appliedZenohEnv = false
         if let locator = zenohRouterLocator {
             guard Self.isEmbeddableZenohLocator(locator) else {
                 if appliedDiscoveryEnv { restoreDiscoveryEnv() }
@@ -853,11 +936,25 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
                 throw TransportError.connectionFailed(
                     "failed to write the Zenoh session config for locator \(locator)")
             }
-            appliedZenohEnv = true
         }
+        #if SWIFT_ROS2_RCL_RMW_ZENOH
+            // Unconditional for the zenoh variant (locator or not): rmw_init
+            // fails outright without a resolvable rmw_zenoh_cpp ament resource,
+            // so context creation must be self-sufficient.
+            do {
+                try applyAmentPrefixEnv()
+            } catch {
+                if appliedDiscoveryEnv { restoreDiscoveryEnv() }
+                restoreZenohSessionEnv()
+                throw error
+            }
+        #endif
         guard let c = crcl_context_create(Int(domainId)) else {
             if appliedDiscoveryEnv { restoreDiscoveryEnv() }
-            if appliedZenohEnv { restoreZenohSessionEnv() }
+            // Idempotent — restores only the slots this context applied (the
+            // session-config env when a locator was given; the AMENT prefix in
+            // the zenoh variant) and no-ops on the rest.
+            restoreZenohSessionEnv()
             throw TransportError.connectionFailed(lastError())
         }
         lock.lock()

--- a/Sources/SwiftROS2RCL/RclClient.swift
+++ b/Sources/SwiftROS2RCL/RclClient.swift
@@ -894,10 +894,32 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         crcl_node_destroy(b.ptr)
     }
 
+    #if SWIFT_ROS2_RCL_RMW_ZENOH
+        /// Fail-loud gate for the zenoh-rmw variant: on a marshal-registry miss
+        /// the cyclonedds variant falls back to route (b) — a raw-CDR writer /
+        /// reader on a sibling **CycloneDDS** participant. Under rmw_zenoh the
+        /// rcl graph speaks Zenoh through a router, so that sibling participant's
+        /// DDS multicast domain has no counterpart: route-(b) traffic would go
+        /// out (or be listened for) where nobody communicates — silent data
+        /// loss, not degraded service. Throw instead. Runs before the node
+        /// handle is inspected, so SwiftROS2RCLTests can assert the gate
+        /// without a live rmw context (`package` for exactly that).
+        package static func requireBundledTypesupport(_ typeName: String) throws {
+            guard crcl_marshal_resolve_typesupport(typeName) == nil else { return }
+            throw TransportError.unsupportedFeature(
+                "type \(typeName) has no bundled typesupport; the raw-CDR fallback is "
+                    + "CycloneDDS-only and unreachable via rmw_zenoh — bundle the type or "
+                    + "use the .dds transport")
+        }
+    #endif
+
     package func createPublisher(
         node: any RclNodeHandle, typeName: String, typeHash: String?, topic: String,
         qos: TransportQoS
     ) throws -> any RclPublisherHandle {
+        #if SWIFT_ROS2_RCL_RMW_ZENOH
+            try Self.requireBundledTypesupport(typeName)
+        #endif
         guard let b = node as? RclNodeBox else {
             throw TransportError.publisherCreationFailed("invalid node handle")
         }
@@ -1057,6 +1079,9 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         qos: TransportQoS,
         handler: @escaping @Sendable (Data, UInt64) -> Void
     ) throws -> any RclSubscriptionHandle {
+        #if SWIFT_ROS2_RCL_RMW_ZENOH
+            try Self.requireBundledTypesupport(typeName)
+        #endif
         guard let b = node as? RclNodeBox else {
             throw TransportError.subscriberCreationFailed("invalid node handle")
         }

--- a/Sources/SwiftROS2RCL/RmwZenohDefaultConfig.swift
+++ b/Sources/SwiftROS2RCL/RmwZenohDefaultConfig.swift
@@ -1,0 +1,1661 @@
+// RmwZenohDefaultConfig.swift
+// Default rmw_zenoh_cpp config payloads for the synthesized ament prefix.
+
+#if SWIFT_ROS2_RCL_RMW_ZENOH
+
+    /// The two DEFAULT_RMW_ZENOH_*_CONFIG.json5 payloads that rmw_zenoh_cpp
+    /// resolves through ament_index at rmw_init. Embedded verbatim so the
+    /// zenoh-rmw variant can synthesize a minimal ament prefix when the host
+    /// process has no usable AMENT_PREFIX_PATH (an app bundle cannot be
+    /// expected to export one) — see `RclClient.applyAmentPrefixEnv()`.
+    ///
+    /// Copied byte-for-byte (including the trailing newline) from the
+    /// rmw_zenoh_cpp/config/ directory of the pinned rmw_zenoh checkout the
+    /// variant xcframework is built from: https://github.com/ros2/rmw_zenoh
+    /// at RMW_ZENOH_PIN fe3553c7c127273280617d3d778859f22c4c3eb7
+    /// (Scripts/build-ros2-xcframework.sh:196). Re-copy when the pin moves.
+    package enum RmwZenohDefaultConfig {
+        /// Verbatim rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5.
+        package static let sessionConfigJSON5 = """
+            /// This file attempts to list and document available configuration elements.
+            /// For a more complete view of the configuration's structure, check out `zenoh/src/config.rs`'s `Config` structure.
+            /// Note that the values here are correctly typed, but may not be sensible, so copying this file to change only the parts that matter to you is not good practice.
+            {
+              /// The identifier (as unsigned 128bit integer in hexadecimal lowercase - leading zeros are not accepted)
+              /// that zenoh runtime will use.
+              /// If not set, a random unsigned 128bit integer will be used.
+              /// WARNING: this id must be unique in your zenoh network.
+              // id: "1234567890abcdef",
+
+              /// The node's mode (router, peer or client)
+              mode: "peer",
+
+              /// Which endpoints to connect to. E.g. tcp/localhost:7447.
+              /// By configuring the endpoints, it is possible to tell zenoh which router/peer to connect to at startup.
+              ///
+              /// For TCP/UDP on Linux, it is possible additionally specify the interface to be connected to:
+              /// E.g. tcp/192.168.0.1:7447#iface=eth0, for connect only if the IP address is reachable via the interface eth0
+              ///
+              /// It is also possible to specify a priority range and/or a reliability setting to be used on the link.
+              /// For example `tcp/localhost?prio=6-7;rel=0` assigns priorities "data_low" and "background" to the established link.
+              ///
+              /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
+              /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+              /// For TCP, UDP, Quic and TLS links, it is possible to specify a `bind` address for the local socket:
+              /// E.g. tcp/192.168.0.1:7447#bind=192.168.0.1:0
+              ///  Note!: Currently it is unsupported to specify both `bind` and `iface`.
+              ///
+              /// For TCP/UDP links, it's possible to specify the DSCP field of the IP header:
+              /// E.g. tcp/192.168.0.1:7447#dscp=0x08
+              connect: {
+                /// timeout waiting for all endpoints connected (0: no retry, -1: infinite timeout)
+                /// Accepts a single value (e.g. timeout_ms: 0)
+                /// or different values for router, peer and client (e.g. timeout_ms: { router: -1, peer: -1, client: 0 }).
+                timeout_ms: { router: -1, peer: -1, client: 0 },
+
+                /// The list of endpoints to connect to.
+                /// Accepts a single list (e.g. endpoints: ["tcp/10.10.10.10:7447", "tcp/11.11.11.11:7447"])
+                /// or different lists for router, peer and client (e.g. endpoints: { router: ["tcp/10.10.10.10:7447"], peer: ["tcp/11.11.11.11:7447"] }).
+                ///
+                /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
+                ///
+                /// ROS setting: By default connect to the Zenoh router on localhost on port 7447.
+                endpoints: [
+                  "tcp/localhost:7447"
+                ],
+
+                /// Global connect configuration,
+                /// Accepts a single value or different values for router, peer and client.
+                /// The configuration can also be specified for the separate endpoint
+                /// it will override the global one
+                /// E.g. tcp/192.168.0.1:7447#retry_period_init_ms=20000;retry_period_max_ms=10000"
+
+                /// exit from application, if timeout exceed
+                exit_on_failure: { router: false, peer: false, client: true },
+                /// connect establishing retry configuration
+                retry: {
+                  /// initial wait timeout until next connect try
+                  period_init_ms: 1000,
+                  /// maximum wait timeout until next connect try
+                  period_max_ms: 4000,
+                  /// increase factor for the next timeout until nexti connect try
+                  period_increase_factor: 2,
+                },
+              },
+
+              /// Which endpoints to listen on. E.g. tcp/0.0.0.0:7447.
+              /// By configuring the endpoints, it is possible to tell zenoh which are the endpoints that other routers,
+              /// peers, or client can use to establish a zenoh session.
+              ///
+              /// For TCP/UDP on Linux, it is possible additionally specify the interface to be listened to:
+              /// E.g. tcp/0.0.0.0:7447#iface=eth0, for listen connection only on eth0
+              ///
+              /// It is also possible to specify a priority range and/or a reliability setting to be used on the link.
+              /// For example `tcp/localhost?prio=6-7;rel=0` assigns priorities "data_low" and "background" to the established link.
+              ///
+              /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
+              /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+              ///
+              /// For TCP/UDP links, it's possible to specify the DSCP field of the IP header:
+              /// E.g. tcp/192.168.0.1:7447#dscp=0x08
+              listen: {
+                /// timeout waiting for all listen endpoints (0: no retry, -1: infinite timeout)
+                /// Accepts a single value (e.g. timeout_ms: 0)
+                /// or different values for router, peer and client (e.g. timeout_ms: { router: -1, peer: -1, client: 0 }).
+                timeout_ms: 0,
+
+                /// The list of endpoints to listen on.
+                /// Accepts a single list (e.g. endpoints: ["tcp/[::]:7447", "udp/[::]:7447"])
+                /// or different lists for router, peer and client (e.g. endpoints: { router: ["tcp/[::]:7447"], peer: ["tcp/[::]:0"] }).
+                ///
+                /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
+                ///
+                /// ROS setting: By default accept incoming connections only from localhost (i.e. from colocalized Nodes).
+                ///              All communications with other hosts are routed by the Zenoh router.
+                endpoints: [
+                  "tcp/localhost:0"
+                ],
+
+                /// Global listen configuration,
+                /// Accepts a single value or different values for router, peer and client.
+                /// The configuration can also be specified for the separate endpoint
+                /// it will override the global one
+                /// E.g. tcp/192.168.0.1:7447#exit_on_failure=false;retry_period_max_ms=1000"
+
+                /// exit from application, if timeout exceed
+                exit_on_failure: true,
+                /// listen retry configuration
+                retry: {
+                  /// initial wait timeout until next try
+                  period_init_ms: 1000,
+                  /// maximum wait timeout until next try
+                  period_max_ms: 4000,
+                  /// increase factor for the next timeout until next try
+                  period_increase_factor: 2,
+                },
+              },
+
+              /// Configure the session open behavior.
+              open: {
+                /// Configure the conditions to be met before session open returns.
+                return_conditions: {
+                  /// Session open waits to connect to scouted peers and routers before returning.
+                  /// When set to false, first publications and queries after session open from peers may be lost.
+                  connect_scouted: true,
+                  /// Session open waits to receive initial declares from connected peers before returning.
+                  /// Setting to false may cause extra traffic at startup from peers.
+                  declares: true,
+                },
+              },
+
+              /// Configure the scouting mechanisms and their behaviours
+              scouting: {
+                /// In client mode, the period in milliseconds dedicated to scouting for a router before failing.
+                timeout: 3000,
+                /// In peer mode, the maximum period in milliseconds dedicated to scouting remote peers before attempting other operations.
+                delay: 500,
+                /// The multicast scouting configuration.
+                multicast: {
+                  /// Whether multicast scouting is enabled or not
+                  ///
+                  /// ROS setting: disable multicast discovery by default
+                  enabled: false,
+                  /// The socket which should be used for multicast scouting
+                  address: "224.0.0.224:7446",
+                  /// The network interface which should be used for multicast scouting
+                  interface: "auto", // If not set or set to "auto" the interface if picked automatically
+                  /// The time-to-live on multicast scouting packets
+                  ttl: 1,
+                  /// Which type of Zenoh instances to automatically establish sessions with upon discovery on UDP multicast.
+                  /// Accepts a single value (e.g. autoconnect: ["router", "peer"]) which applies whatever the configured "mode" is,
+                  /// or different values for router, peer or client mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
+                  /// Each value is a list of: "peer", "router" and/or "client".
+                  autoconnect: { router: [], peer: ["router", "peer"], client: ["router"] },
+                  /// Strategy for autoconnection, mainly to avoid nodes connecting to each other redundantly.
+                  /// Possible options are:
+                  /// - "always": always attempt to autoconnect, may result in redundant connections.
+                  /// - "greater-zid": attempt to connect to another node only if its own zid is greater than the other's.
+                  ///   If both nodes use this strategy, only one will attempt the connection.
+                  ///   This strategy may not be suited if one of the nodes is not reachable by the other one, for example
+                  ///   because of a private IP.
+                  /// Accepts a single value (e.g. autoconnect: "always") which applies whatever node would be auto-connected to,
+                  /// or different values for router and/or peer depending on the type of node detected
+                  /// (e.g. autoconnect_strategy : { to_router:  "always", to_peer: "greater-zid" }),
+                  /// or different values for router or peer mode
+                  /// (e.g. autoconnect_strategy : { peer: { to_router:  "always", to_peer: "greater-zid" } }).
+                  /// ROS setting: by default all peers rely on the router to discover each other. Thus configuring the peer to send gossip
+                  ///              messages only to the router is sufficient and avoids unecessary traffic between Nodes at launch time.
+                  autoconnect_strategy: { peer: { to_router: "always", to_peer: "greater-zid" } },
+                  /// Whether or not to listen for scout messages on UDP multicast and reply to them.
+                  listen: true,
+                },
+                /// The gossip scouting configuration. Note that instances in "client" mode do not participate in gossip.
+                gossip: {
+                  /// Whether gossip scouting is enabled or not
+                  enabled: true,
+                  /// When true, gossip scouting information are propagated multiple hops to all nodes in the local network.
+                  /// When false, gossip scouting information are only propagated to the next hop.
+                  /// Activating multihop gossip implies more scouting traffic and a lower scalability.
+                  /// It mostly makes sense when using "linkstate" routing mode where all nodes in the subsystem don't have
+                  /// direct connectivity with each other.
+                  multihop: false,
+                  /// Which type of Zenoh instances to send gossip messages to.
+                  /// Accepts a single value (e.g. target: ["router", "peer"]) which applies whatever the configured "mode" is,
+                  /// or different values for router or peer mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
+                  /// Each value is a list of "peer" and/or "router".
+                  /// ROS setting: by default all peers rely on the router to discover each other. Thus configuring the peer to send gossip
+                  ///              messages only to the router is sufficient and avoids unecessary traffic between Nodes at launch time.
+                  target: { router: ["router", "peer"], peer: ["router"]},
+                  /// Which type of Zenoh instances to automatically establish sessions with upon discovery on gossip.
+                  /// Accepts a single value (e.g. autoconnect: ["router", "peer"]) which applies whatever the configured "mode" is,
+                  /// or different values for router or peer mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
+                  /// Each value is a list of: "peer" and/or "router".
+                  autoconnect: { router: [], peer: ["router", "peer"] },
+                  /// Strategy for autoconnection, mainly to avoid nodes connecting to each other redundantly.
+                  /// Possible options are:
+                  /// - "always": always attempt to autoconnect, may result in redundant connection which will then be closed.
+                  /// - "greater-zid": attempt to connect to another node only if its own zid is greater than the other's.
+                  ///   If both nodes use this strategy, only one will attempt the connection.
+                  ///   This strategy may not be suited if one of the nodes is not reachable by the other one, for example
+                  ///   because of a private IP.
+                  /// Accepts a single value (e.g. autoconnect: "always") which applies whatever node would be auto-connected to,
+                  /// or different values for router and/or peer depending on the type of node detected
+                  /// (e.g. autoconnect_strategy : { to_router:  "always", to_peer: "greater-zid" }),
+                  /// or different values for router or peer mode
+                  /// (e.g. autoconnect_strategy : { peer: { to_router:  "always", to_peer: "greater-zid" } }).
+                  /// ROS setting: as by default all peers will interconnect to each other over the loopback interface,
+                  ///              they are all reachable to each other. Hence using "greater-zid" for peers connecting to
+                  ///              other peers is sufficient and avoids unecessary double connections between peers at startup.
+                  autoconnect_strategy: { peer: { to_router: "always", to_peer: "greater-zid" } },
+                },
+              },
+
+              /// Configuration of data messages timestamps management.
+              timestamping: {
+                /// Whether data messages should be timestamped if not already.
+                /// Accepts a single boolean value or different values for router, peer and client.
+                ///
+                /// ROS setting: PublicationCache which is required for transient_local durability
+                ///              only works when time-stamping is enabled.
+                enabled: { router: true, peer: true, client: true },
+                /// Whether data messages with timestamps in the future should be dropped or not.
+                /// If set to false (default), messages with timestamps in the future are retimestamped.
+                /// Timestamps are ignored if timestamping is disabled.
+                drop_future_timestamp: false,
+              },
+
+              /// The default timeout to apply to queries in milliseconds.
+              /// ROS setting: The default value of 600000 ms (10 minutes) is already quite high, but it can be increased if needed.
+              ///              For instance to avoid timeout with Service Server that that is unresponsive or lagging,
+              ///              which could occur at launch time with a large number of Nodes starting all together.
+              ///              It’s recommended to configure a value that exceeds the longest timeout specified in any
+              ///              `spin_until_complete(service_call_future_result, timeout)` call.
+              ///              Note that the action-related service "get_result" is hard-coded with an infinite timeout,
+              ///              as in some use case an action could spend several hours (e.g. mission plans).
+              queries_default_timeout: 600000,
+
+              /// The routing strategy to use and it's configuration.
+              routing: {
+                /// The routing strategy to use in routers and it's configuration.
+                router: {
+                  /// When set to true a router will forward data between two peers
+                  /// directly connected to it if it detects that those peers are not
+                  /// connected to each other.
+                  /// The failover brokering only works if gossip discovery is enabled
+                  /// and peers are configured with gossip target "router".
+                  peers_failover_brokering: true,
+                  /// Linkstate mode configuration.
+                  linkstate: {
+                    /// Weights of the outgoing transports in linkstate mode.
+                    /// If none of the two endpoint nodes of a transport specifies its weight, a weight of 100 is applied.
+                    /// If only one of the two endpoint nodes of a transport specifies its weight, the specified weight is applied.
+                    /// If both endpoint nodes of a transport specify its weight, the greater weight is applied.
+                    // transport_weights: [
+                    //   { dst_zid: "1", weight: "10" },
+                    //   { dst_zid: "2", weight: "200" },
+                    // ]
+                  },
+                },
+                /// The routing strategy to use in peers and it's configuration.
+                peer: {
+                  /// The routing strategy to use in peers. ("peer_to_peer" or "linkstate").
+                  /// This option needs to be set to the same value in all peers and routers of the subsystem.
+                  mode: "peer_to_peer",
+                  /// Linkstate mode configuration (only taken into account if mode == "linkstate").
+                  linkstate: {
+                    /// Weights of the outgoing transports in linkstate mode.
+                    /// If none of the two endpoint nodes of a transport specifies its weight, a weight of 100 is applied.
+                    /// If only one of the two endpoint nodes of a transport specifies its weight, the specified weight is applied.
+                    /// If both endpoint nodes of a transport specify its weight, the greater weight is applied.
+                    // transport_weights: [
+                    //   { dst_zid: "1", weight: "10" },
+                    //   { dst_zid: "2", weight: "200" },
+                    // ]
+                  },
+                },
+                /// The interests-based routing configuration.
+                /// This configuration applies regardless of the mode (router, peer or client).
+                interests: {
+                  /// The timeout to wait for incoming interests declarations in milliseconds.
+                  /// The expiration of this timeout implies that the discovery protocol might be incomplete,
+                  /// leading to potential loss of messages, queries or liveliness tokens.
+                  timeout: 10000,
+                },
+              },
+
+              // /// Overwrite QoS options for Zenoh messages by key expression (ignores Zenoh API QoS config for overwritten values)
+              // qos: {
+              //   /// Overwrite QoS options for PUT and DELETE messages
+              //   publication: [
+              //     {
+              //       /// PUT and DELETE messages on key expressions that are included by these key expressions
+              //       /// will have their QoS options overwritten by the given config.
+              //       key_exprs: ["demo/**", "example/key"],
+              //       /// Configurations that will be applied on the publisher.
+              //       /// Options that are supplied here will overwrite the configuration given in Zenoh API
+              //       config: {
+              //         congestion_control: "block",
+              //         priority: "data_high",
+              //         express: true,
+              //         reliability: "best_effort",
+              //         allowed_destination: "remote",
+              //       },
+              //     },
+              //   ],
+              //   /// Overwrite QoS options for messages sent and received from/to the network
+              //   /// This allows more fine grained rules (per network card, etc...) but is
+              //   /// less performant than the publication option above.
+              //   network: [
+              //     {
+              //       /// Optional Id, has to be unique.
+              //       id: "lo0_en0_qos_overwrite",
+              //       /// Optional list of ZIDs on which qos will be overwritten when communicating with.
+              //       // zids: ["38a4829bce9166ee"],
+              //       /// Optional list of interfaces, if not specified, will be applied to all interfaces.
+              //       interfaces: [
+              //         "lo0",
+              //         "en0",
+              //       ],
+              //       /// Optional list of link protocols. Transports with at least one of these links will have their qos overwritten.
+              //       /// If absent, the overwrite will be applied to all transports. An empty list is invalid.
+              //       link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+              //       /// List of message types to apply to.
+              //       messages: [
+              //         "put", // put publications
+              //         "delete", // delete publications
+              //         "query", // get queries
+              //         "reply", // replies to queries
+              //       ],
+              //       /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
+              //       /// If absent, the rules will be applied to both flows.
+              //       flows: ["egress", "ingress"],
+              //       /// QoS filter to apply to the messages matching this item.
+              //       qos: {
+              //         congestion_control: "drop",
+              //         priority: "data",
+              //         express: true,
+              //         reliability: "reliable",
+              //       },
+              //       /// payload_size range for the messages matching this item.
+              //       payload_size: "1000000..",
+              //       key_exprs: ["test/demo"],
+              //       overwrite: {
+              //         /// Optional new priority value, if not specified priority of the messages will stay unchanged.
+              //         priority: "real_time",
+              //         /// Optional new congestion control value, if not specified congestion control of the messages will stay unchanged.
+              //         congestion_control: "block",
+              //         /// Optional new express value, if not specified express flag of the messages will stay unchanged.
+              //         express: true,
+              //       },
+              //     },
+              //   ],
+              // },
+
+              // /// The declarations aggregation strategy.
+              // aggregation: {
+              //   /// A list of key-expressions for which all included subscribers will be aggregated into.
+              //   subscribers: [
+              //     // key_expression
+              //   ],
+              //   /// A list of key-expressions for which all included publishers will be aggregated into.
+              //   publishers: [
+              //     // key_expression
+              //   ],
+              // },
+
+              // /// Namespace prefix.
+              // /// If specified, all outgoing key expressions will be automatically prefixed with specified string,
+              // /// and all incoming key expressions will be stripped of specified prefix.
+              // /// The namespace prefix should satisfy all key expression constraints
+              // /// and additionally it can not contain wild characters ('*').
+              // /// Namespace is applied to the session.
+              // /// E. g. if session has a namespace of "1" then session.put("my/keyexpr", my_message),
+              // /// will put a message into 1/my/keyexpr. Same applies to all other operations within this session.
+              // namespace: "my/namespace",
+
+              // /// The downsampling declaration.
+              // downsampling: [
+              //   {
+              //     /// Optional Id, has to be unique
+              //     id: "wlan0egress",
+              //     /// Optional list of network interfaces messages will be processed on, the rest will be passed as is.
+              //     /// If absent, the rules will be applied to all interfaces. An empty list is invalid.
+              //     interfaces: [ "wlan0" ],
+              //     /// Optional list of link protocols. Transports with at least one of these links will have their messages filtered.
+              //     /// If absent, the rules will be applied to all transports. An empty list is invalid.
+              //     link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+              //     /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
+              //     /// If absent, the rules will be applied to both flows.
+              //     flows: ["ingress", "egress"],
+              //     /// List of message type on which downsampling will be applied. Must not be empty.
+              //     messages: [
+              //       /// Delete
+              //       "delete",
+              //       /// Put
+              //       "put",
+              //       /// Get
+              //       "query",
+              //       /// Queryable Reply to a Query
+              //       "reply",
+              //     ],
+              //     /// A list of downsampling rules: key_expression and the maximum frequency in Hertz
+              //     rules: [
+              //       { key_expr: "demo/example/zenoh-rs-pub", freq: 0.1 },
+              //     ],
+              //   },
+              // ],
+
+              // /// Configure access control (ACL) rules
+              // access_control: {
+              //   /// [true/false] acl will be activated only if this is set to true
+              //   "enabled": false,
+              //   /// [deny/allow] default permission is deny (even if this is left empty or not specified)
+              //   "default_permission": "deny",
+              //   /// Rule set for permissions allowing or denying access to key-expressions
+              //   "rules":
+              //   [
+              //     {
+              //       /// Id has to be unique within the rule set
+              //       "id": "rule1",
+              //       "messages": [
+              //         "put", "delete", "declare_subscriber",
+              //         "query", "reply", "declare_queryable",
+              //         "liveliness_token", "liveliness_query", "declare_liveliness_subscriber",
+              //       ],
+              //       "flows":["egress","ingress"],
+              //       "permission": "allow",
+              //       "key_exprs": [
+              //         "test/demo"
+              //       ],
+              //     },
+              //     {
+              //       "id": "rule2",
+              //       "messages": [
+              //         "put", "delete", "declare_subscriber",
+              //         "query", "reply", "declare_queryable",
+              //       ],
+              //       "flows":["ingress"],
+              //       "permission": "allow",
+              //       "key_exprs": [
+              //         "**"
+              //       ],
+              //     },
+              //   ],
+              //   /// List of combinations of subjects.
+              //   ///
+              //   /// If a subject property (i.e. username, certificate common name or interface) is empty
+              //   /// it is interpreted as a wildcard. Moreover, a subject property cannot be an empty list.
+              //   "subjects":
+              //   [
+              //     {
+              //       /// Id has to be unique within the subjects list
+              //       "id": "subject1",
+              //       /// Subjects can be interfaces
+              //       "interfaces": [
+              //         "lo0",
+              //         "en0",
+              //       ],
+              //       /// Subjects can be cert_common_names when using TLS or Quic
+              //       "cert_common_names": [
+              //         "example.zenoh.io"
+              //       ],
+              //       /// Subjects can be usernames when using user/password authentication
+              //       "usernames": [
+              //         "zenoh-example"
+              //       ],
+              //       /// This instance translates internally to this filter:
+              //       /// (interface="lo0" && cert_common_name="example.zenoh.io" && username="zenoh-example") ||
+              //       /// (interface="en0" && cert_common_name="example.zenoh.io" && username="zenoh-example")
+              //     },
+              //     {
+              //       "id": "subject2",
+              //       "interfaces": [
+              //         "lo0",
+              //         "en0",
+              //       ],
+              //       "cert_common_names": [
+              //         "example2.zenoh.io"
+              //       ],
+              //       /// This instance translates internally to this filter:
+              //       /// (interface="lo0" && cert_common_name="example2.zenoh.io") ||
+              //       /// (interface="en0" && cert_common_name="example2.zenoh.io")
+              //     },
+              //     {
+              //       "id": "subject3",
+              //       /// An empty subject combination is a wildcard
+              //     },
+              //     {
+              //       "id": "subject4",
+              //       /// link protocols can also be used to identify transports to filter messages on.
+              //       /// If absent, the rules will be applied to all transports. An empty list is invalid.
+              //       link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+              //       /// ZIDs can also be used to identify transports to filter messages on.
+              //       /// NOTE: ZID is not backed by an authentication mechanism, it can only be trusted for ACL if it is
+              //       ///       dynamically added/removed by eventual dedicated Zenoh mechanisms when transports are opened/closed.
+              //       ///       If managed manually in ACL config, can be useful for prototyping but should not be used in production!
+              //       zids: ["38a4829bce9166ee"],
+              //     },
+              //   ],
+              //   /// The policies list associates rules to subjects
+              //   "policies":
+              //   [
+              //     /// Each policy associates one or multiple rules to one or multiple subject combinations
+              //     {
+              //       /// Id is optional. If provided, it has to be unique within the policies list
+              //       "id": "policy1",
+              //       /// Rules and Subjects are identified with their unique IDs declared above
+              //       "rules": ["rule1"],
+              //       "subjects": ["subject1", "subject2"],
+              //     },
+              //     {
+              //       "rules": ["rule2"],
+              //       "subjects": ["subject3", "subject4"],
+              //     },
+              //   ]
+              // },
+
+              // low_pass_filter: [
+              //   {
+              //     /// Optional Id, has to be unique
+              //     "id": "filter1",
+              //     /// Optional list of network interfaces messages will be processed on, the rest will not be filtered.
+              //     /// If absent, the filter will be applied to all interfaces.
+              //     interfaces: [ "wlan0" ],
+              //     /// Optional list of link protocols. Transports with at least one of these links will have their messages filtered.
+              //     /// If absent, the rule will be applied to all transports. An empty list is invalid.
+              //     link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+              //     /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
+              //     /// If absent, the filter will be applied to both flows.
+              //     flows: ["ingress", "egress"],
+              //     /// List of message type on which the filter will be applied. Must not be empty.
+              //     messages: [
+              //       "put",
+              //       "delete",
+              //       "query",
+              //       "reply"
+              //     ],
+              //     /// List of key_expressions which matching messages will be filtered
+              //     key_exprs: [
+              //       "demo/**",
+              //     ],
+              //     /// Inclusive max size of serialized payload + serialized attachment
+              //     size_limit: 8192,
+              //   },
+              // ],
+
+              /// Enable stats per key expression.
+              // stats: {
+              //   filters: [
+              //     {
+              //       key: "some/key/expression/**",
+              //     }
+              //   ],
+              // },
+
+              /// Configure internal transport parameters
+              transport: {
+                unicast: {
+                  /// Timeout in milliseconds when opening a link
+                  /// ROS setting: increase the value to avoid timeout at launch time with a large number of Nodes starting all together
+                  open_timeout: 60000,
+                  /// Timeout in milliseconds when accepting a link
+                  /// ROS setting: increase the value to avoid timeout at launch time with a large number of Nodes starting all together
+                  accept_timeout: 60000,
+                  /// Maximum number of links in pending state while performing the handshake for accepting it
+                  /// ROS setting: increase the value to support a large number of Nodes starting all together
+                  accept_pending: 10000,
+                  /// Maximum number of transports that can be simultaneously alive for a single zenoh sessions
+                  /// ROS setting: increase the value to support a large number of Nodes starting all together
+                  max_sessions: 10000,
+                  /// Maximum number of incoming links that are admitted per transport
+                  max_links: 1,
+                  /// Enables the LowLatency transport
+                  /// This option does not make LowLatency transport mandatory, the actual implementation of transport
+                  /// used will depend on Establish procedure and other party's settings
+                  ///
+                  /// NOTE: Currently, the LowLatency transport doesn't preserve QoS prioritization.
+                  /// NOTE: Due to the note above, 'lowlatency' is incompatible with 'qos' option, so in order to
+                  ///       enable 'lowlatency' you need to explicitly disable 'qos'.
+                  /// NOTE: LowLatency transport does not support the fragmentation, so the message size should be
+                  ///       smaller than the tx batch_size.
+                  lowlatency: false,
+                  /// Enables QoS on unicast communications.
+                  qos: {
+                    enabled: true,
+                  },
+                  /// Enables compression on unicast communications.
+                  /// Compression capabilities are negotiated during session establishment.
+                  /// If both Zenoh nodes support compression, then compression is activated.
+                  compression: {
+                    enabled: false,
+                  },
+                },
+                /// WARNING: multicast communication does not perform any negotiation upon group joining.
+                ///   Because of that, it is important that all transport parameters are the same to make
+                ///   sure all your nodes in the system can communicate. One common parameter to configure
+                ///   is "transport/link/tx/batch_size" since its default value depends on the actual platform
+                ///   when operating on multicast.
+                ///   E.g., the batch size on Linux and Windows is 65535 bytes, on Mac OS X is 9216, and anything else is 8192.
+                multicast: {
+                  /// JOIN message transmission interval in milliseconds.
+                  join_interval: 2500,
+                  /// Maximum number of multicast sessions.
+                  max_sessions: 1000,
+                  /// Enables QoS on multicast communication.
+                  /// Default to false for Zenoh-to-Zenoh-Pico out-of-the-box compatibility.
+                  qos: {
+                    enabled: false,
+                  },
+                  /// Enables compression on multicast communication.
+                  /// Default to false for Zenoh-to-Zenoh-Pico out-of-the-box compatibility.
+                  compression: {
+                    enabled: false,
+                  },
+                },
+                link: {
+                  /// An optional whitelist of protocols to be used for accepting and opening sessions. If not
+                  /// configured, all the supported protocols are automatically whitelisted. The supported
+                  /// protocols are: ["tcp" , "udp", "tls", "quic", "ws", "unixsock-stream", "vsock"] For
+                  /// example, to only enable "tls" and "quic": protocols: ["tls", "quic"],
+                  ///
+                  /// Configure the zenoh TX parameters of a link
+                  tx: {
+                    /// The resolution in bits to be used for the message sequence numbers.
+                    /// When establishing a session with another Zenoh instance, the lowest value of the two instances will be used.
+                    /// Accepted values: 8bit, 16bit, 32bit, 64bit.
+                    sequence_number_resolution: "32bit",
+                    /// Link lease duration in milliseconds to announce to other zenoh nodes
+                    /// ROS setting: increase the value to avoid lease expiration at launch time with a large number of Nodes starting all together
+                    lease: 60000,
+                    /// Number of keep-alive messages in a link lease duration. If no data is sent, keep alive
+                    /// messages will be sent at the configured time interval.
+                    /// NOTE: In order to consider eventual packet loss and transmission latency and jitter,
+                    ///       set the actual keep_alive interval to one fourth of the lease time: i.e. send
+                    ///       4 keep_alive messages in a lease period. Changing the lease time will have the
+                    ///       keep_alive messages sent more or less often.
+                    ///       This is in-line with the ITU-T G.8013/Y.1731 specification on continuous connectivity
+                    ///       check which considers a link as failed when no messages are received in 3.5 times the
+                    ///       target interval.
+                    /// ROS setting: decrease the value since Nodes are communicating over the loopback
+                    ///              where keep-alive messages have less chances to be lost.
+                    keep_alive: 2,
+                    /// Batch size in bytes is expressed as a 16bit unsigned integer.
+                    /// Therefore, the maximum batch size is 2^16-1 (i.e. 65535).
+                    /// The default batch size value is the maximum batch size: 65535.
+                    batch_size: 65535,
+                    /// Each zenoh link has a transmission queue that can be configured
+                    queue: {
+                      /// The size of each priority queue indicates the number of batches a given queue can contain.
+                      /// NOTE: the number of batches in each priority must be included between 1 and 16. Different values will result in an error.
+                      /// The amount of memory being allocated for each queue is then SIZE_XXX * BATCH_SIZE.
+                      /// In the case of the transport link MTU being smaller than the ZN_BATCH_SIZE,
+                      /// then amount of memory being allocated for each queue is SIZE_XXX * LINK_MTU.
+                      /// If qos is false, then only the DATA priority will be allocated.
+                      size: {
+                        control: 2,
+                        real_time: 2,
+                        interactive_high: 2,
+                        interactive_low: 2,
+                        data_high: 2,
+                        data: 2,
+                        data_low: 2,
+                        background: 2,
+                      },
+                      /// Congestion occurs when the queue is empty (no available batch).
+                      congestion_control: {
+                        /// Behavior pushing CongestionControl::Drop messages to the queue.
+                        drop: {
+                          /// The maximum time in microseconds to wait for an available batch before dropping a droppable message if still no batch is available.
+                          wait_before_drop: 1000,
+                          /// The maximum deadline limit for multi-fragment messages.
+                          max_wait_before_drop_fragments: 50000,
+                        },
+                        /// Behavior pushing CongestionControl::Block messages to the queue.
+                        block: {
+                          /// The maximum time in microseconds to wait for an available batch before closing the transport session when sending a blocking message
+                          /// if still no batch is available.
+                          /// ROS setting: increase the value to avoid unecessary link closure at launch time where congestion is likely
+                          ///              to occur even over the loopback since all the Nodes are starting at the same time.
+                          wait_before_close: 60000000,
+                        },
+                      },
+                      /// Perform batching of messages if they are smaller of the batch_size
+                      batching: {
+                        /// Perform adaptive batching of messages if they are smaller of the batch_size.
+                        /// When the network is detected to not be fast enough to transmit every message individually, many small messages may be
+                        /// batched together and sent all at once on the wire reducing the overall network overhead. This is typically of a high-throughput
+                        /// scenario mainly composed of small messages. In other words, batching is activated by the network back-pressure.
+                        enabled: true,
+                        /// The maximum time limit (in ms) a message should be retained for batching when back-pressure happens.
+                        time_limit: 1,
+                      },
+                      allocation: {
+                        /// Mode for memory allocation of batches in the priority queues.
+                        /// - "init": batches are allocated at queue initialization time.
+                        /// - "lazy": batches are allocated when needed up to the maximum number of batches configured in the size configuration parameter.
+                        mode: "lazy",
+                      },
+                    },
+                  },
+                  /// Configure the zenoh RX parameters of a link
+                  rx: {
+                    /// Receiving buffer size in bytes for each link
+                    /// The default the rx_buffer_size value is the same as the default batch size: 65535.
+                    /// For very high throughput scenarios, the rx_buffer_size can be increased to accommodate
+                    /// more in-flight data. This is particularly relevant when dealing with large messages.
+                    /// E.g. for 16MiB rx_buffer_size set the value to: 16777216.
+                    buffer_size: 65535,
+                    /// Maximum size of the defragmentation buffer at receiver end.
+                    /// Fragmented messages that are larger than the configured size will be dropped.
+                    /// The default value is 1GiB. This would work in most scenarios.
+                    /// NOTE: reduce the value if you are operating on a memory constrained device.
+                    max_message_size: 1073741824,
+                  },
+                  /// Configure TLS specific parameters
+                  tls: {
+                    /// Path to the certificate of the certificate authority used to validate either the server
+                    /// or the client's keys and certificates, depending on the node's mode. If not specified
+                    /// on router mode then the default WebPKI certificates are used instead.
+                    root_ca_certificate: null,
+                    /// Path to the TLS listening side private key
+                    listen_private_key: null,
+                    /// Path to the TLS listening side public certificate
+                    listen_certificate: null,
+                    ///  Enables mTLS (mutual authentication), client authentication
+                    enable_mtls: false,
+                    /// Path to the TLS connecting side private key
+                    connect_private_key: null,
+                    /// Path to the TLS connecting side certificate
+                    connect_certificate: null,
+                    /// Whether or not to verify the matching between hostname/dns and certificate when connecting,
+                    /// if set to false zenoh will disregard the common names of the certificates when verifying servers.
+                    /// This could be dangerous because your CA can have signed a server cert for foo.com, that's later being used to host a server at baz.com. If you wan't your
+                    /// ca to verify that the server at baz.com is actually baz.com, let this be true (default).
+                    verify_name_on_connect: true,
+                    /// Whether or not to close links when remote certificates expires.
+                    /// If set to true, links that require certificates (tls/quic) will automatically disconnect when the time of expiration of the remote certificate chain is reached
+                    /// note that mTLS (client authentication) is required for a listener to disconnect a client on expiration
+                    close_link_on_expiration: false,
+                    /// Optional configuration for TCP system buffers sizes for TLS links
+                    ///
+                    /// Configure TCP read buffer size (bytes)
+                    // so_rcvbuf: 123456,
+                    /// Configure TCP write buffer size (bytes)
+                    // so_sndbuf: 123456,
+                  },
+                  // // Configure optional TCP link specific parameters
+                  // tcp: {
+                  //   /// Optional configuration for TCP system buffers sizes for TCP links
+                  //   ///
+                  //   /// Configure TCP read buffer size (bytes)
+                  //   // so_rcvbuf: 123456,
+                  //   /// Configure TCP write buffer size (bytes)
+                  //   // so_sndbuf: 123456,
+                  // },
+                },
+                /// Shared memory configuration.
+                /// NOTE: shared memory can be used only if zenoh is compiled with "shared-memory" feature, otherwise
+                /// settings in this section have no effect.
+                shared_memory: {
+                  /// Whether shared memory is enabled or not.
+                  /// If set to `true`, the SHM buffer optimization support will be announced to other parties. (default `true`).
+                  /// This option doesn't make SHM buffer optimization mandatory, the real support depends on other party setting.
+                  /// A probing procedure for shared memory is performed upon session opening. To enable zenoh to operate
+                  /// over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
+                  /// subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
+                  ///
+                  /// ROS setting: disabled by default until fully tested
+                  enabled: false,
+                  /// SHM resources initialization mode (default "lazy").
+                  /// - "lazy": SHM subsystem internals will be initialized lazily upon the first SHM buffer
+                  /// allocation or reception. This setting provides better startup time and optimizes resource usage,
+                  /// but produces extra latency at the first SHM buffer interaction.
+                  /// - "init": SHM subsystem internals will be initialized upon Session opening. This setting sacrifices
+                  /// startup time, but guarantees no latency impact when first SHM buffer is processed.
+                  mode: "lazy",
+                  /// ROS setting: the section below controls SHM parameters used for large message passing on ROS
+                  transport_optimization: {
+                      /// Enables transport optimization for large messages (default `true`).
+                      /// Implicitly puts large messages into shared memory for transports with SHM-compatible connection.
+                      enabled: true,
+                      /// SHM memory size in bytes used for transport optimization (default `48 * 1024 * 1024`).
+                      pool_size: 50331648,
+                      /// Allow optimization for messages equal or larger than this threshold in bytes (default `3072`).
+                      message_size_threshold: 512,
+                  },
+                },
+                auth: {
+                  /// The configuration of authentication.
+                  /// A password implies a username is required.
+                  usrpwd: {
+                    user: null,
+                    password: null,
+                    /// The path to a file containing the user password dictionary
+                    dictionary_file: null,
+                  },
+                  pubkey: {
+                    public_key_pem: null,
+                    private_key_pem: null,
+                    public_key_file: null,
+                    private_key_file: null,
+                    key_size: null,
+                    known_keys_file: null,
+                  },
+                },
+              },
+
+              /// Configure the Admin Space
+              /// Unstable: this configuration part works as advertised, but may change in a future release
+              adminspace: {
+                /// Enables the admin space
+                enabled: true,
+                /// read and/or write permissions on the admin space
+                permissions: {
+                  read: true,
+                  write: false,
+                },
+              },
+
+            }
+
+            """
+
+        /// Verbatim rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5.
+        package static let routerConfigJSON5 = """
+            /// This file attempts to list and document available configuration elements.
+            /// For a more complete view of the configuration's structure, check out `zenoh/src/config.rs`'s `Config` structure.
+            /// Note that the values here are correctly typed, but may not be sensible, so copying this file to change only the parts that matter to you is not good practice.
+            {
+              /// The identifier (as unsigned 128bit integer in hexadecimal lowercase - leading zeros are not accepted)
+              /// that zenoh runtime will use.
+              /// If not set, a random unsigned 128bit integer will be used.
+              /// WARNING: this id must be unique in your zenoh network.
+              // id: "1234567890abcdef",
+
+              /// The node's mode (router, peer or client)
+              mode: "router",
+
+              /// Which endpoints to connect to. E.g. tcp/localhost:7447.
+              /// By configuring the endpoints, it is possible to tell zenoh which router/peer to connect to at startup.
+              ///
+              /// For TCP/UDP on Linux, it is possible additionally specify the interface to be connected to:
+              /// E.g. tcp/192.168.0.1:7447#iface=eth0, for connect only if the IP address is reachable via the interface eth0
+              ///
+              /// It is also possible to specify a priority range and/or a reliability setting to be used on the link.
+              /// For example `tcp/localhost?prio=6-7;rel=0` assigns priorities "data_low" and "background" to the established link.
+              ///
+              /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
+              /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+              /// For TCP, UDP, Quic and TLS links, it is possible to specify a `bind` address for the local socket:
+              /// E.g. tcp/192.168.0.1:7447#bind=192.168.0.1:0
+              ///  Note!: Currently it is unsupported to specify both `bind` and `iface`.
+              ///
+              /// For TCP/UDP links, it's possible to specify the DSCP field of the IP header:
+              /// E.g. tcp/192.168.0.1:7447#dscp=0x08
+              connect: {
+                /// timeout waiting for all endpoints connected (0: no retry, -1: infinite timeout)
+                /// Accepts a single value (e.g. timeout_ms: 0)
+                /// or different values for router, peer and client (e.g. timeout_ms: { router: -1, peer: -1, client: 0 }).
+                timeout_ms: { router: -1, peer: -1, client: 0 },
+
+                /// The list of endpoints to connect to.
+                /// Accepts a single list (e.g. endpoints: ["tcp/10.10.10.10:7447", "tcp/11.11.11.11:7447"])
+                /// or different lists for router, peer and client (e.g. endpoints: { router: ["tcp/10.10.10.10:7447"], peer: ["tcp/11.11.11.11:7447"] }).
+                ///
+                /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
+                endpoints: [
+                  // "<proto>/<address>"
+                ],
+
+                /// Global connect configuration,
+                /// Accepts a single value or different values for router, peer and client.
+                /// The configuration can also be specified for the separate endpoint
+                /// it will override the global one
+                /// E.g. tcp/192.168.0.1:7447#retry_period_init_ms=20000;retry_period_max_ms=10000"
+
+                /// exit from application, if timeout exceed
+                exit_on_failure: { router: false, peer: false, client: true },
+                /// connect establishing retry configuration
+                retry: {
+                  /// initial wait timeout until next connect try
+                  period_init_ms: 1000,
+                  /// maximum wait timeout until next connect try
+                  period_max_ms: 4000,
+                  /// increase factor for the next timeout until nexti connect try
+                  period_increase_factor: 2,
+                },
+              },
+
+              /// Which endpoints to listen on. E.g. tcp/0.0.0.0:7447.
+              /// By configuring the endpoints, it is possible to tell zenoh which are the endpoints that other routers,
+              /// peers, or client can use to establish a zenoh session.
+              ///
+              /// For TCP/UDP on Linux, it is possible additionally specify the interface to be listened to:
+              /// E.g. tcp/0.0.0.0:7447#iface=eth0, for listen connection only on eth0
+              ///
+              /// It is also possible to specify a priority range and/or a reliability setting to be used on the link.
+              /// For example `tcp/localhost?prio=6-7;rel=0` assigns priorities "data_low" and "background" to the established link.
+              ///
+              /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
+              /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+              ///
+              /// For TCP/UDP links, it's possible to specify the DSCP field of the IP header:
+              /// E.g. tcp/192.168.0.1:7447#dscp=0x08
+              listen: {
+                /// timeout waiting for all listen endpoints (0: no retry, -1: infinite timeout)
+                /// Accepts a single value (e.g. timeout_ms: 0)
+                /// or different values for router, peer and client (e.g. timeout_ms: { router: -1, peer: -1, client: 0 }).
+                timeout_ms: 0,
+
+                /// The list of endpoints to listen on.
+                /// Accepts a single list (e.g. endpoints: ["tcp/[::]:7447", "udp/[::]:7447"])
+                /// or different lists for router, peer and client (e.g. endpoints: { router: ["tcp/[::]:7447"], peer: ["tcp/[::]:0"] }).
+                ///
+                /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
+                endpoints: [
+                  "tcp/[::]:7447"
+                ],
+
+                /// Global listen configuration,
+                /// Accepts a single value or different values for router, peer and client.
+                /// The configuration can also be specified for the separate endpoint
+                /// it will override the global one
+                /// E.g. tcp/192.168.0.1:7447#exit_on_failure=false;retry_period_max_ms=1000"
+
+                /// exit from application, if timeout exceed
+                exit_on_failure: true,
+                /// listen retry configuration
+                retry: {
+                  /// initial wait timeout until next try
+                  period_init_ms: 1000,
+                  /// maximum wait timeout until next try
+                  period_max_ms: 4000,
+                  /// increase factor for the next timeout until next try
+                  period_increase_factor: 2,
+                },
+              },
+
+              /// Configure the session open behavior.
+              open: {
+                /// Configure the conditions to be met before session open returns.
+                return_conditions: {
+                  /// Session open waits to connect to scouted peers and routers before returning.
+                  /// When set to false, first publications and queries after session open from peers may be lost.
+                  connect_scouted: true,
+                  /// Session open waits to receive initial declares from connected peers before returning.
+                  /// Setting to false may cause extra traffic at startup from peers.
+                  declares: true,
+                },
+              },
+
+              /// Configure the scouting mechanisms and their behaviours
+              scouting: {
+                /// In client mode, the period in milliseconds dedicated to scouting for a router before failing.
+                timeout: 3000,
+                /// In peer mode, the maximum period in milliseconds dedicated to scouting remote peers before attempting other operations.
+                delay: 500,
+                /// The multicast scouting configuration.
+                multicast: {
+                  /// Whether multicast scouting is enabled or not
+                  ///
+                  /// ROS setting: disable multicast discovery by default
+                  enabled: false,
+                  /// The socket which should be used for multicast scouting
+                  address: "224.0.0.224:7446",
+                  /// The network interface which should be used for multicast scouting
+                  interface: "auto", // If not set or set to "auto" the interface if picked automatically
+                  /// The time-to-live on multicast scouting packets
+                  ttl: 1,
+                  /// Which type of Zenoh instances to automatically establish sessions with upon discovery on UDP multicast.
+                  /// Accepts a single value (e.g. autoconnect: ["router", "peer"]) which applies whatever the configured "mode" is,
+                  /// or different values for router, peer or client mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
+                  /// Each value is a list of: "peer", "router" and/or "client".
+                  autoconnect: { router: [], peer: ["router", "peer"], client: ["router"] },
+                  /// Strategy for autoconnection, mainly to avoid nodes connecting to each other redundantly.
+                  /// Possible options are:
+                  /// - "always": always attempt to autoconnect, may result in redundant connections.
+                  /// - "greater-zid": attempt to connect to another node only if its own zid is greater than the other's.
+                  ///   If both nodes use this strategy, only one will attempt the connection.
+                  ///   This strategy may not be suited if one of the nodes is not reachable by the other one, for example
+                  ///   because of a private IP.
+                  /// Accepts a single value (e.g. autoconnect: "always") which applies whatever node would be auto-connected to,
+                  /// or different values for router and/or peer depending on the type of node detected
+                  /// (e.g. autoconnect_strategy : { to_router:  "always", to_peer: "greater-zid" }),
+                  /// or different values for router or peer mode
+                  /// (e.g. autoconnect_strategy : { peer: { to_router:  "always", to_peer: "greater-zid" } }).
+                  autoconnect_strategy: { router: { to_router: "always", to_peer: "always" } },
+                  /// Whether or not to listen for scout messages on UDP multicast and reply to them.
+                  listen: true,
+                },
+                /// The gossip scouting configuration. Note that instances in "client" mode do not participate in gossip.
+                gossip: {
+                  /// Whether gossip scouting is enabled or not
+                  enabled: true,
+                  /// When true, gossip scouting information are propagated multiple hops to all nodes in the local network.
+                  /// When false, gossip scouting information are only propagated to the next hop.
+                  /// Activating multihop gossip implies more scouting traffic and a lower scalability.
+                  /// It mostly makes sense when using "linkstate" routing mode where all nodes in the subsystem don't have
+                  /// direct connectivity with each other.
+                  multihop: false,
+                  /// Which type of Zenoh instances to send gossip messages to.
+                  /// Accepts a single value (e.g. target: ["router", "peer"]) which applies whatever the configured "mode" is,
+                  /// or different values for router or peer mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
+                  /// Each value is a list of "peer" and/or "router".
+                  /// ROS setting: by default all peers rely on the router to discover each other. Thus configuring the peer to send gossip
+                  ///               messages only to the router is sufficient and avoids unecessary traffic between Nodes at launch time.
+                  target: { router: ["router", "peer"], peer: ["router"]},
+                  /// Which type of Zenoh instances to automatically establish sessions with upon discovery on gossip.
+                  /// Accepts a single value (e.g. autoconnect: ["router", "peer"]) which applies whatever the configured "mode" is,
+                  /// or different values for router or peer mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
+                  /// Each value is a list of: "peer" and/or "router".
+                  autoconnect: { router: [], peer: ["router", "peer"] },
+                  /// Strategy for autoconnection, mainly to avoid nodes connecting to each other redundantly.
+                  /// Possible options are:
+                  /// - "always": always attempt to autoconnect, may result in redundant connections.
+                  /// - "greater-zid": attempt to connect to another node only if its own zid is greater than the other's.
+                  ///   If both nodes use this strategy, only one will attempt the connection.
+                  ///   This strategy may not be suited if one of the nodes is not reachable by the other one, for example
+                  ///   because of a private IP.
+                  /// Accepts a single value (e.g. autoconnect: "always") which applies whatever node would be auto-connected to,
+                  /// or different values for router and/or peer depending on the type of node detected
+                  /// (e.g. autoconnect_strategy : { to_router:  "always", to_peer: "greater-zid" }),
+                  /// or different values for router or peer mode
+                  /// (e.g. autoconnect_strategy : { peer: { to_router:  "always", to_peer: "greater-zid" } }).
+                  autoconnect_strategy: { router: { to_router: "always", to_peer: "always" } },
+                },
+              },
+
+              /// Configuration of data messages timestamps management.
+              timestamping: {
+                /// Whether data messages should be timestamped if not already.
+                /// Accepts a single boolean value or different values for router, peer and client.
+                ///
+                /// ROS setting: PublicationCache which is required for transient_local durability
+                ///              only works when time-stamping is enabled.
+                enabled: { router: true, peer: true, client: true },
+                /// Whether data messages with timestamps in the future should be dropped or not.
+                /// If set to false (default), messages with timestamps in the future are retimestamped.
+                /// Timestamps are ignored if timestamping is disabled.
+                drop_future_timestamp: false,
+              },
+
+              /// The default timeout to apply to queries in milliseconds.
+              /// ROS setting: The default value of 600000 ms (10 minutes) is already quite high, but it can be increased if needed.
+              ///              For instance to avoid timeout with Service Server that that is unresponsive or lagging,
+              ///              which could occur at launch time with a large number of Nodes starting all together.
+              ///              It’s recommended to configure a value that exceeds the longest timeout specified in any
+              ///              `spin_until_complete(service_call_future_result, timeout)` call.
+              ///              Note that the action-related service "get_result" is hard-coded with an infinite timeout,
+              ///              as in some use case an action could spend several hours (e.g. mission plans).
+              queries_default_timeout: 600000,
+
+              /// The routing strategy to use and it's configuration.
+              routing: {
+                /// The routing strategy to use in routers and it's configuration.
+                router: {
+                  /// When set to true a router will forward data between two peers
+                  /// directly connected to it if it detects that those peers are not
+                  /// connected to each other.
+                  /// The failover brokering only works if gossip discovery is enabled
+                  /// and peers are configured with gossip target "router".
+                  /// ROS setting: disabled by default because it serves no purpose when each peer connects directly to all others,
+                  ///              and it introduces additional management overhead and extra messages during system startup.
+                  peers_failover_brokering: false,
+                  /// Linkstate mode configuration.
+                  linkstate: {
+                    /// Weights of the outgoing transports in linkstate mode.
+                    /// If none of the two endpoint nodes of a transport specifies its weight, a weight of 100 is applied.
+                    /// If only one of the two endpoint nodes of a transport specifies its weight, the specified weight is applied.
+                    /// If both endpoint nodes of a transport specify its weight, the greater weight is applied.
+                    // transport_weights: [
+                    //   { dst_zid: "1", weight: "10" },
+                    //   { dst_zid: "2", weight: "200" },
+                    // ]
+                  },
+                },
+                /// The routing strategy to use in peers and it's configuration.
+                peer: {
+                  /// The routing strategy to use in peers. ("peer_to_peer" or "linkstate").
+                  /// This option needs to be set to the same value in all peers and routers of the subsystem.
+                  mode: "peer_to_peer",
+                  /// Linkstate mode configuration (only taken into account if mode == "linkstate").
+                  linkstate: {
+                    /// Weights of the outgoing transports in linkstate mode.
+                    /// If none of the two endpoint nodes of a transport specifies its weight, a weight of 100 is applied.
+                    /// If only one of the two endpoint nodes of a transport specifies its weight, the specified weight is applied.
+                    /// If both endpoint nodes of a transport specify its weight, the greater weight is applied.
+                    // transport_weights: [
+                    //   { dst_zid: "1", weight: "10" },
+                    //   { dst_zid: "2", weight: "200" },
+                    // ]
+                  },
+                },
+                /// The interests-based routing configuration.
+                /// This configuration applies regardless of the mode (router, peer or client).
+                interests: {
+                  /// The timeout to wait for incoming interests declarations in milliseconds.
+                  /// The expiration of this timeout implies that the discovery protocol might be incomplete,
+                  /// leading to potential loss of messages, queries or liveliness tokens.
+                  timeout: 10000,
+                },
+              },
+
+              // /// Overwrite QoS options for Zenoh messages by key expression (ignores Zenoh API QoS config for overwritten values)
+              // qos: {
+              //   /// Overwrite QoS options for PUT and DELETE messages
+              //   publication: [
+              //     {
+              //       /// PUT and DELETE messages on key expressions that are included by these key expressions
+              //       /// will have their QoS options overwritten by the given config.
+              //       key_exprs: ["demo/**", "example/key"],
+              //       /// Configurations that will be applied on the publisher.
+              //       /// Options that are supplied here will overwrite the configuration given in Zenoh API
+              //       config: {
+              //         congestion_control: "block",
+              //         priority: "data_high",
+              //         express: true,
+              //         reliability: "best_effort",
+              //         allowed_destination: "remote",
+              //       },
+              //     },
+              //   ],
+              //   /// Overwrite QoS options for messages sent and received from/to the network
+              //   /// This allows more fine grained rules (per network card, etc...) but is
+              //   /// less performant than the publication option above.
+              //   network: [
+              //     {
+              //       /// Optional Id, has to be unique.
+              //       id: "lo0_en0_qos_overwrite",
+              //       /// Optional list of ZIDs on which qos will be overwritten when communicating with.
+              //       // zids: ["38a4829bce9166ee"],
+              //       /// Optional list of interfaces, if not specified, will be applied to all interfaces.
+              //       interfaces: [
+              //         "lo0",
+              //         "en0",
+              //       ],
+              //       /// Optional list of link protocols. Transports with at least one of these links will have their qos overwritten.
+              //       /// If absent, the overwrite will be applied to all transports. An empty list is invalid.
+              //       link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+              //       /// List of message types to apply to.
+              //       messages: [
+              //         "put", // put publications
+              //         "delete", // delete publications
+              //         "query", // get queries
+              //         "reply", // replies to queries
+              //       ],
+              //       /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
+              //       /// If absent, the rules will be applied to both flows.
+              //       flows: ["egress", "ingress"],
+              //       /// QoS filter to apply to the messages matching this item.
+              //       qos: {
+              //         congestion_control: "drop",
+              //         priority: "data",
+              //         express: true,
+              //         reliability: "reliable",
+              //       },
+              //       /// payload_size range for the messages matching this item.
+              //       payload_size: "1000000..",
+              //       key_exprs: ["test/demo"],
+              //       overwrite: {
+              //         /// Optional new priority value, if not specified priority of the messages will stay unchanged.
+              //         priority: "real_time",
+              //         /// Optional new congestion control value, if not specified congestion control of the messages will stay unchanged.
+              //         congestion_control: "block",
+              //         /// Optional new express value, if not specified express flag of the messages will stay unchanged.
+              //         express: true,
+              //       },
+              //     },
+              //   ],
+              // },
+
+              // /// The declarations aggregation strategy.
+              // aggregation: {
+              //   /// A list of key-expressions for which all included subscribers will be aggregated into.
+              //   subscribers: [
+              //     // key_expression
+              //   ],
+              //   /// A list of key-expressions for which all included publishers will be aggregated into.
+              //   publishers: [
+              //     // key_expression
+              //   ],
+              // },
+
+              // /// Namespace prefix.
+              // /// If specified, all outgoing key expressions will be automatically prefixed with specified string,
+              // /// and all incoming key expressions will be stripped of specified prefix.
+              // /// The namespace prefix should satisfy all key expression constraints
+              // /// and additionally it can not contain wild characters ('*').
+              // /// Namespace is applied to the session.
+              // /// E. g. if session has a namespace of "1" then session.put("my/keyexpr", my_message),
+              // /// will put a message into 1/my/keyexpr. Same applies to all other operations within this session.
+              // namespace: "my/namespace",
+
+              // /// The downsampling declaration.
+              // downsampling: [
+              //   {
+              //     /// Optional Id, has to be unique
+              //     id: "wlan0egress",
+              //     /// Optional list of network interfaces messages will be processed on, the rest will be passed as is.
+              //     /// If absent, the rules will be applied to all interfaces. An empty list is invalid.
+              //     interfaces: [ "wlan0" ],
+              //     /// Optional list of link protocols. Transports with at least one of these links will have their messages filtered.
+              //     /// If absent, the rules will be applied to all transports. An empty list is invalid.
+              //     link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+              //     /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
+              //     /// If absent, the rules will be applied to both flows.
+              //     flows: ["ingress", "egress"],
+              //     /// List of message type on which downsampling will be applied. Must not be empty.
+              //     messages: [
+              //       /// Delete
+              //       "delete",
+              //       /// Put
+              //       "put",
+              //       /// Get
+              //       "query",
+              //       /// Queryable Reply to a Query
+              //       "reply",
+              //     ],
+              //     /// A list of downsampling rules: key_expression and the maximum frequency in Hertz
+              //     rules: [
+              //       { key_expr: "demo/example/zenoh-rs-pub", freq: 0.1 },
+              //     ],
+              //   },
+              // ],
+
+              // /// Configure access control (ACL) rules
+              // access_control: {
+              //   /// [true/false] acl will be activated only if this is set to true
+              //   "enabled": false,
+              //   /// [deny/allow] default permission is deny (even if this is left empty or not specified)
+              //   "default_permission": "deny",
+              //   /// Rule set for permissions allowing or denying access to key-expressions
+              //   "rules":
+              //   [
+              //     {
+              //       /// Id has to be unique within the rule set
+              //       "id": "rule1",
+              //       "messages": [
+              //         "put", "delete", "declare_subscriber",
+              //         "query", "reply", "declare_queryable",
+              //         "liveliness_token", "liveliness_query", "declare_liveliness_subscriber",
+              //       ],
+              //       "flows":["egress","ingress"],
+              //       "permission": "allow",
+              //       "key_exprs": [
+              //         "test/demo"
+              //       ],
+              //     },
+              //     {
+              //       "id": "rule2",
+              //       "messages": [
+              //         "put", "delete", "declare_subscriber",
+              //         "query", "reply", "declare_queryable",
+              //       ],
+              //       "flows":["ingress"],
+              //       "permission": "allow",
+              //       "key_exprs": [
+              //         "**"
+              //       ],
+              //     },
+              //   ],
+              //   /// List of combinations of subjects.
+              //   ///
+              //   /// If a subject property (i.e. username, certificate common name or interface) is empty
+              //   /// it is interpreted as a wildcard. Moreover, a subject property cannot be an empty list.
+              //   "subjects":
+              //   [
+              //     {
+              //       /// Id has to be unique within the subjects list
+              //       "id": "subject1",
+              //       /// Subjects can be interfaces
+              //       "interfaces": [
+              //         "lo0",
+              //         "en0",
+              //       ],
+              //       /// Subjects can be cert_common_names when using TLS or Quic
+              //       "cert_common_names": [
+              //         "example.zenoh.io"
+              //       ],
+              //       /// Subjects can be usernames when using user/password authentication
+              //       "usernames": [
+              //         "zenoh-example"
+              //       ],
+              //       /// This instance translates internally to this filter:
+              //       /// (interface="lo0" && cert_common_name="example.zenoh.io" && username="zenoh-example") ||
+              //       /// (interface="en0" && cert_common_name="example.zenoh.io" && username="zenoh-example")
+              //     },
+              //     {
+              //       "id": "subject2",
+              //       "interfaces": [
+              //         "lo0",
+              //         "en0",
+              //       ],
+              //       "cert_common_names": [
+              //         "example2.zenoh.io"
+              //       ],
+              //       /// This instance translates internally to this filter:
+              //       /// (interface="lo0" && cert_common_name="example2.zenoh.io") ||
+              //       /// (interface="en0" && cert_common_name="example2.zenoh.io")
+              //     },
+              //     {
+              //       "id": "subject3",
+              //       /// An empty subject combination is a wildcard
+              //     },
+              //     {
+              //       "id": "subject4",
+              //       /// link protocols can also be used to identify transports to filter messages on.
+              //       /// If absent, the rules will be applied to all transports. An empty list is invalid.
+              //       link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+              //       /// ZIDs can also be used to identify transports to filter messages on.
+              //       /// NOTE: ZID is not backed by an authentication mechanism, it can only be trusted for ACL if it is
+              //       ///       dynamically added/removed by eventual dedicated Zenoh mechanisms when transports are opened/closed.
+              //       ///       If managed manually in ACL config, can be useful for prototyping but should not be used in production!
+              //       zids: ["38a4829bce9166ee"],
+              //     },
+              //   ],
+              //   /// The policies list associates rules to subjects
+              //   "policies":
+              //   [
+              //     /// Each policy associates one or multiple rules to one or multiple subject combinations
+              //     {
+              //       /// Id is optional. If provided, it has to be unique within the policies list
+              //       "id": "policy1",
+              //       /// Rules and Subjects are identified with their unique IDs declared above
+              //       "rules": ["rule1"],
+              //       "subjects": ["subject1", "subject2"],
+              //     },
+              //     {
+              //       "rules": ["rule2"],
+              //       "subjects": ["subject3", "subject4"],
+              //     },
+              //   ]
+              // },
+
+              // low_pass_filter: [
+              //   {
+              //     /// Optional Id, has to be unique
+              //     "id": "filter1",
+              //     /// Optional list of network interfaces messages will be processed on, the rest will not be filtered.
+              //     /// If absent, the filter will be applied to all interfaces.
+              //     interfaces: [ "wlan0" ],
+              //     /// Optional list of link protocols. Transports with at least one of these links will have their messages filtered.
+              //     /// If absent, the rule will be applied to all transports. An empty list is invalid.
+              //     link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+              //     /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
+              //     /// If absent, the filter will be applied to both flows.
+              //     flows: ["ingress", "egress"],
+              //     /// List of message type on which the filter will be applied. Must not be empty.
+              //     messages: [
+              //       "put",
+              //       "delete",
+              //       "query",
+              //       "reply"
+              //     ],
+              //     /// List of key_expressions which matching messages will be filtered
+              //     key_exprs: [
+              //       "demo/**",
+              //     ],
+              //     /// Inclusive max size of serialized payload + serialized attachment
+              //     size_limit: 8192,
+              //   },
+              // ],
+
+              /// Enable stats per key expression.
+              // stats: {
+              //   filters: [
+              //     {
+              //       key: "some/key/expression/**",
+              //     }
+              //   ],
+              // },
+
+              /// Configure internal transport parameters
+              transport: {
+                unicast: {
+                  /// Timeout in milliseconds when opening a link
+                  /// ROS setting: increase the value to avoid timeout at launch time with a large number of Nodes starting all together
+                  open_timeout: 60000,
+                  /// Timeout in milliseconds when accepting a link
+                  /// ROS setting: increase the value to avoid timeout at launch time with a large number of Nodes starting all together
+                  accept_timeout: 60000,
+                  /// Maximum number of links in pending state while performing the handshake for accepting it
+                  /// ROS setting: increase the value to support a large number of Nodes starting all together
+                  accept_pending: 10000,
+                  /// Maximum number of transports that can be simultaneously alive for a single zenoh sessions
+                  /// ROS setting: increase the value to support a large number of Nodes starting all together
+                  max_sessions: 10000,
+                  /// Maximum number of incoming links that are admitted per transport
+                  max_links: 1,
+                  /// Enables the LowLatency transport
+                  /// This option does not make LowLatency transport mandatory, the actual implementation of transport
+                  /// used will depend on Establish procedure and other party's settings
+                  ///
+                  /// NOTE: Currently, the LowLatency transport doesn't preserve QoS prioritization.
+                  /// NOTE: Due to the note above, 'lowlatency' is incompatible with 'qos' option, so in order to
+                  ///       enable 'lowlatency' you need to explicitly disable 'qos'.
+                  /// NOTE: LowLatency transport does not support the fragmentation, so the message size should be
+                  ///       smaller than the tx batch_size.
+                  lowlatency: false,
+                  /// Enables QoS on unicast communications.
+                  qos: {
+                    enabled: true,
+                  },
+                  /// Enables compression on unicast communications.
+                  /// Compression capabilities are negotiated during session establishment.
+                  /// If both Zenoh nodes support compression, then compression is activated.
+                  compression: {
+                    enabled: false,
+                  },
+                },
+                /// WARNING: multicast communication does not perform any negotiation upon group joining.
+                ///   Because of that, it is important that all transport parameters are the same to make
+                ///   sure all your nodes in the system can communicate. One common parameter to configure
+                ///   is "transport/link/tx/batch_size" since its default value depends on the actual platform
+                ///   when operating on multicast.
+                ///   E.g., the batch size on Linux and Windows is 65535 bytes, on Mac OS X is 9216, and anything else is 8192.
+                multicast: {
+                  /// JOIN message transmission interval in milliseconds.
+                  join_interval: 2500,
+                  /// Maximum number of multicast sessions.
+                  max_sessions: 1000,
+                  /// Enables QoS on multicast communication.
+                  /// Default to false for Zenoh-to-Zenoh-Pico out-of-the-box compatibility.
+                  qos: {
+                    enabled: false,
+                  },
+                  /// Enables compression on multicast communication.
+                  /// Default to false for Zenoh-to-Zenoh-Pico out-of-the-box compatibility.
+                  compression: {
+                    enabled: false,
+                  },
+                },
+                link: {
+                  /// An optional whitelist of protocols to be used for accepting and opening sessions. If not
+                  /// configured, all the supported protocols are automatically whitelisted. The supported
+                  /// protocols are: ["tcp" , "udp", "tls", "quic", "ws", "unixsock-stream", "vsock"] For
+                  /// example, to only enable "tls" and "quic": protocols: ["tls", "quic"],
+                  ///
+                  /// Configure the zenoh TX parameters of a link
+                  tx: {
+                    /// The resolution in bits to be used for the message sequence numbers.
+                    /// When establishing a session with another Zenoh instance, the lowest value of the two instances will be used.
+                    /// Accepted values: 8bit, 16bit, 32bit, 64bit.
+                    sequence_number_resolution: "32bit",
+                    /// Link lease duration in milliseconds to announce to other zenoh nodes
+                    /// ROS setting: increase the value to avoid lease expiration at launch time with a large number of Nodes starting all together
+                    lease: 60000,
+                    /// Number of keep-alive messages in a link lease duration. If no data is sent, keep alive
+                    /// messages will be sent at the configured time interval.
+                    /// NOTE: In order to consider eventual packet loss and transmission latency and jitter,
+                    ///       set the actual keep_alive interval to one fourth of the lease time: i.e. send
+                    ///       4 keep_alive messages in a lease period. Changing the lease time will have the
+                    ///       keep_alive messages sent more or less often.
+                    ///       This is in-line with the ITU-T G.8013/Y.1731 specification on continuous connectivity
+                    ///       check which considers a link as failed when no messages are received in 3.5 times the
+                    ///       target interval.
+                    /// ROS setting: decrease the value since Nodes are communicating over the loopback
+                    ///              where keep-alive messages have less chances to be lost.
+                    keep_alive: 2,
+                    /// Batch size in bytes is expressed as a 16bit unsigned integer.
+                    /// Therefore, the maximum batch size is 2^16-1 (i.e. 65535).
+                    /// The default batch size value is the maximum batch size: 65535.
+                    batch_size: 65535,
+                    /// Each zenoh link has a transmission queue that can be configured
+                    queue: {
+                      /// The size of each priority queue indicates the number of batches a given queue can contain.
+                      /// NOTE: the number of batches in each priority must be included between 1 and 16. Different values will result in an error.
+                      /// The amount of memory being allocated for each queue is then SIZE_XXX * BATCH_SIZE.
+                      /// In the case of the transport link MTU being smaller than the ZN_BATCH_SIZE,
+                      /// then amount of memory being allocated for each queue is SIZE_XXX * LINK_MTU.
+                      /// If qos is false, then only the DATA priority will be allocated.
+                      size: {
+                        control: 2,
+                        real_time: 2,
+                        interactive_high: 2,
+                        interactive_low: 2,
+                        data_high: 2,
+                        data: 2,
+                        data_low: 2,
+                        background: 2,
+                      },
+                      /// Congestion occurs when the queue is empty (no available batch).
+                      congestion_control: {
+                        /// Behavior pushing CongestionControl::Drop messages to the queue.
+                        drop: {
+                          /// The maximum time in microseconds to wait for an available batch before dropping a droppable message if still no batch is available.
+                          wait_before_drop: 1000,
+                          /// The maximum deadline limit for multi-fragment messages.
+                          max_wait_before_drop_fragments: 50000,
+                        },
+                        /// Behavior pushing CongestionControl::Block messages to the queue.
+                        block: {
+                          /// The maximum time in microseconds to wait for an available batch before closing the transport session when sending a blocking message
+                          /// if still no batch is available.
+                          /// ROS setting: unlike DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5, no change here:
+                          ///              as the router is routing messages to outside the robot, possibly over WiFi,
+                          ///              keeping a lower value ensure the router is not blocked for too long in case of congestioned WiFi.
+                          wait_before_close: 5000000,
+                        },
+                      },
+                      /// Perform batching of messages if they are smaller of the batch_size
+                      batching: {
+                        /// Perform adaptive batching of messages if they are smaller of the batch_size.
+                        /// When the network is detected to not be fast enough to transmit every message individually, many small messages may be
+                        /// batched together and sent all at once on the wire reducing the overall network overhead. This is typically of a high-throughput
+                        /// scenario mainly composed of small messages. In other words, batching is activated by the network back-pressure.
+                        enabled: true,
+                        /// The maximum time limit (in ms) a message should be retained for batching when back-pressure happens.
+                        time_limit: 1,
+                      },
+                      allocation: {
+                        /// Mode for memory allocation of batches in the priority queues.
+                        /// - "init": batches are allocated at queue initialization time.
+                        /// - "lazy": batches are allocated when needed up to the maximum number of batches configured in the size configuration parameter.
+                        mode: "lazy",
+                      },
+                    },
+                  },
+                  /// Configure the zenoh RX parameters of a link
+                  rx: {
+                    /// Receiving buffer size in bytes for each link
+                    /// The default the rx_buffer_size value is the same as the default batch size: 65535.
+                    /// For very high throughput scenarios, the rx_buffer_size can be increased to accommodate
+                    /// more in-flight data. This is particularly relevant when dealing with large messages.
+                    /// E.g. for 16MiB rx_buffer_size set the value to: 16777216.
+                    buffer_size: 65535,
+                    /// Maximum size of the defragmentation buffer at receiver end.
+                    /// Fragmented messages that are larger than the configured size will be dropped.
+                    /// The default value is 1GiB. This would work in most scenarios.
+                    /// NOTE: reduce the value if you are operating on a memory constrained device.
+                    max_message_size: 1073741824,
+                  },
+                  /// Configure TLS specific parameters
+                  tls: {
+                    /// Path to the certificate of the certificate authority used to validate either the server
+                    /// or the client's keys and certificates, depending on the node's mode. If not specified
+                    /// on router mode then the default WebPKI certificates are used instead.
+                    root_ca_certificate: null,
+                    /// Path to the TLS listening side private key
+                    listen_private_key: null,
+                    /// Path to the TLS listening side public certificate
+                    listen_certificate: null,
+                    ///  Enables mTLS (mutual authentication), client authentication
+                    enable_mtls: false,
+                    /// Path to the TLS connecting side private key
+                    connect_private_key: null,
+                    /// Path to the TLS connecting side certificate
+                    connect_certificate: null,
+                    /// Whether or not to verify the matching between hostname/dns and certificate when connecting,
+                    /// if set to false zenoh will disregard the common names of the certificates when verifying servers.
+                    /// This could be dangerous because your CA can have signed a server cert for foo.com, that's later being used to host a server at baz.com. If you wan't your
+                    /// ca to verify that the server at baz.com is actually baz.com, let this be true (default).
+                    verify_name_on_connect: true,
+                    /// Whether or not to close links when remote certificates expires.
+                    /// If set to true, links that require certificates (tls/quic) will automatically disconnect when the time of expiration of the remote certificate chain is reached
+                    /// note that mTLS (client authentication) is required for a listener to disconnect a client on expiration
+                    close_link_on_expiration: false,
+                    /// Optional configuration for TCP system buffers sizes for TLS links
+                    ///
+                    /// Configure TCP read buffer size (bytes)
+                    // so_rcvbuf: 123456,
+                    /// Configure TCP write buffer size (bytes)
+                    // so_sndbuf: 123456,
+                  },
+                  // // Configure optional TCP link specific parameters
+                  // tcp: {
+                  //   /// Optional configuration for TCP system buffers sizes for TCP links
+                  //   ///
+                  //   /// Configure TCP read buffer size (bytes)
+                  //   // so_rcvbuf: 123456,
+                  //   /// Configure TCP write buffer size (bytes)
+                  //   // so_sndbuf: 123456,
+                  // },
+                },
+                /// Shared memory configuration.
+                /// NOTE: shared memory can be used only if zenoh is compiled with "shared-memory" feature, otherwise
+                /// settings in this section have no effect.
+                shared_memory: {
+                  /// Whether shared memory is enabled or not.
+                  /// If set to `true`, the SHM buffer optimization support will be announced to other parties. (default `true`).
+                  /// This option doesn't make SHM buffer optimization mandatory, the real support depends on other party setting.
+                  /// A probing procedure for shared memory is performed upon session opening. To enable zenoh to operate
+                  /// over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
+                  /// subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
+                  ///
+                  /// ROS setting: disabled by default until fully tested
+                  enabled: false,
+                  /// SHM resources initialization mode (default "lazy").
+                  /// - "lazy": SHM subsystem internals will be initialized lazily upon the first SHM buffer
+                  /// allocation or reception. This setting provides better startup time and optimizes resource usage,
+                  /// but produces extra latency at the first SHM buffer interaction.
+                  /// - "init": SHM subsystem internals will be initialized upon Session opening. This setting sacrifices
+                  /// startup time, but guarantees no latency impact when first SHM buffer is processed.
+                  mode: "lazy",
+                  /// ROS setting: the section below controls SHM parameters used for large message passing on ROS
+                  transport_optimization: {
+                      /// Enables transport optimization for large messages (default `true`).
+                      /// Implicitly puts large messages into shared memory for transports with SHM-compatible connection.
+                      enabled: true,
+                      /// SHM memory size in bytes used for transport optimization (default `48 * 1024 * 1024`).
+                      pool_size: 50331648,
+                      /// Allow optimization for messages equal or larger than this threshold in bytes (default `3072`).
+                      message_size_threshold: 512,
+                  },
+                },
+                auth: {
+                  /// The configuration of authentication.
+                  /// A password implies a username is required.
+                  usrpwd: {
+                    user: null,
+                    password: null,
+                    /// The path to a file containing the user password dictionary
+                    dictionary_file: null,
+                  },
+                  pubkey: {
+                    public_key_pem: null,
+                    private_key_pem: null,
+                    public_key_file: null,
+                    private_key_file: null,
+                    key_size: null,
+                    known_keys_file: null,
+                  },
+                },
+              },
+
+              /// Configure the Admin Space
+              /// Unstable: this configuration part works as advertised, but may change in a future release
+              adminspace: {
+                /// Enables the admin space
+                enabled: true,
+                /// read and/or write permissions on the admin space
+                permissions: {
+                  read: true,
+                  write: false,
+                },
+              },
+
+            }
+
+            """
+    }
+#endif

--- a/Tests/SwiftROS2RCLTests/RclZenohFailLoudTests.swift
+++ b/Tests/SwiftROS2RCLTests/RclZenohFailLoudTests.swift
@@ -73,4 +73,145 @@
             XCTAssertNoThrow(try RclClient.requireBundledTypesupport("sensor_msgs/msg/Imu"))
         }
     }
+
+    // MARK: - RclAmentPrefixEnvTests (S2)
+
+    /// rmw_zenoh_cpp hard-requires AMENT_PREFIX_PATH at rmw_init (live-proven:
+    /// context creation threw "Environment variable AMENT_PREFIX_PATH is not
+    /// set or empty"). `applyAmentPrefixEnv` synthesizes a minimal ament prefix
+    /// so consumers need not export one; `restoreZenohSessionEnv` undoes it.
+    final class RclAmentPrefixEnvTests: XCTestCase {
+        /// Hermetic: snapshot + restore whatever the environment already had.
+        private var outerAmentPrefixPath: String?
+
+        override func setUp() {
+            super.setUp()
+            outerAmentPrefixPath = getenv("AMENT_PREFIX_PATH").map { String(cString: $0) }
+        }
+
+        override func tearDown() {
+            if let p = outerAmentPrefixPath {
+                setenv("AMENT_PREFIX_PATH", p, 1)
+            } else {
+                unsetenv("AMENT_PREFIX_PATH")
+            }
+            super.tearDown()
+        }
+
+        private var currentAmentPrefixPath: String? {
+            getenv("AMENT_PREFIX_PATH").map { String(cString: $0) }
+        }
+
+        /// Create a directory carrying the rmw_zenoh_cpp resource-index marker
+        /// (a "valid user prefix" as far as ament_index resolution goes).
+        private func makeValidUserPrefix() throws -> URL {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("swift-ros2-test-prefix-\(UUID().uuidString)")
+            let markerDir = root.appendingPathComponent(
+                "share/ament_index/resource_index/packages", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: markerDir, withIntermediateDirectories: true)
+            try Data().write(to: markerDir.appendingPathComponent("rmw_zenoh_cpp"))
+            return root
+        }
+
+        func testApplySynthesizesPrefixWhenUnset() throws {
+            unsetenv("AMENT_PREFIX_PATH")
+            let client = RclClient()
+            try client.applyAmentPrefixEnv()
+
+            let prefix = try XCTUnwrap(currentAmentPrefixPath, "env not exported")
+            let marker = "\(prefix)/share/ament_index/resource_index/packages/rmw_zenoh_cpp"
+            let sessionCfg = "\(prefix)/share/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5"
+            let routerCfg = "\(prefix)/share/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5"
+            XCTAssertTrue(FileManager.default.fileExists(atPath: marker), "resource marker missing")
+            XCTAssertTrue(FileManager.default.fileExists(atPath: sessionCfg), "session config missing")
+            XCTAssertTrue(FileManager.default.fileExists(atPath: routerCfg), "router config missing")
+            let session = try String(contentsOfFile: sessionCfg, encoding: .utf8)
+            XCTAssertTrue(session.contains("mode: \"peer\""), "session config is not the peer default")
+            let router = try String(contentsOfFile: routerCfg, encoding: .utf8)
+            XCTAssertTrue(router.contains("mode: \"router\""), "router config is not the router default")
+            XCTAssertTrue(
+                RclClient.amentPrefixPathContainsRmwZenoh(prefix),
+                "synthesized prefix must satisfy the resolution rule it was created for")
+
+            client.restoreZenohSessionEnv()
+            XCTAssertNil(currentAmentPrefixPath, "env not restored to unset")
+            XCTAssertFalse(
+                FileManager.default.fileExists(atPath: prefix), "temp prefix not cleaned up")
+        }
+
+        func testApplyPrependsWhenResourceMissing() throws {
+            // A set-but-unusable AMENT_PREFIX_PATH (no rmw_zenoh_cpp resource)
+            // gets the synthesized prefix PREPENDED, keeping the user's other
+            // ament resources resolvable; restore brings back the exact value.
+            let bogus = FileManager.default.temporaryDirectory
+                .appendingPathComponent("swift-ros2-test-bogus-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: bogus, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: bogus) }
+            setenv("AMENT_PREFIX_PATH", bogus.path, 1)
+
+            let client = RclClient()
+            try client.applyAmentPrefixEnv()
+            let value = try XCTUnwrap(currentAmentPrefixPath)
+            XCTAssertTrue(value.hasSuffix(":\(bogus.path)"), "existing value not preserved: \(value)")
+            XCTAssertTrue(
+                RclClient.amentPrefixPathContainsRmwZenoh(value),
+                "prepended prefix must make the resource resolvable")
+
+            client.restoreZenohSessionEnv()
+            XCTAssertEqual(currentAmentPrefixPath, bogus.path, "prior value not restored")
+        }
+
+        func testApplyLeavesValidUserPrefixUntouched() throws {
+            let userPrefix = try makeValidUserPrefix()
+            defer { try? FileManager.default.removeItem(at: userPrefix) }
+            setenv("AMENT_PREFIX_PATH", userPrefix.path, 1)
+
+            let client = RclClient()
+            try client.applyAmentPrefixEnv()
+            XCTAssertEqual(currentAmentPrefixPath, userPrefix.path, "valid user prefix was touched")
+
+            // Nothing was applied, so restore must be a no-op for this slot.
+            client.restoreZenohSessionEnv()
+            XCTAssertEqual(currentAmentPrefixPath, userPrefix.path, "no-op restore mutated the env")
+        }
+
+        func testAmentPrefixPathContainsRmwZenohRule() throws {
+            let valid = try makeValidUserPrefix()
+            defer { try? FileManager.default.removeItem(at: valid) }
+            XCTAssertTrue(RclClient.amentPrefixPathContainsRmwZenoh(valid.path))
+            XCTAssertTrue(
+                RclClient.amentPrefixPathContainsRmwZenoh("/nonexistent:\(valid.path)"),
+                "any prefix in the colon-separated list must satisfy the rule")
+            XCTAssertFalse(RclClient.amentPrefixPathContainsRmwZenoh("/nonexistent"))
+            XCTAssertFalse(RclClient.amentPrefixPathContainsRmwZenoh(""))
+        }
+
+        func testCreateContextWithoutAmentEnvDoesNotThrowAmentError() {
+            // The live-proven failure mode: with no AMENT_PREFIX_PATH, rmw_init
+            // used to fail with "Environment variable AMENT_PREFIX_PATH is not
+            // set or empty" (rmw_init.cpp:114). With the synthesis in place,
+            // context creation must get past that error — it either succeeds
+            // (router reachable at the locator) or fails for a non-AMENT reason
+            // (e.g. no router). Either way the env slots are restored.
+            unsetenv("AMENT_PREFIX_PATH")
+            let client = RclClient()
+            do {
+                try client.createContext(
+                    domainId: 0, unicastPeerAddresses: [], networkInterface: nil,
+                    zenohRouterLocator: "tcp/127.0.0.1:7447")
+                client.destroyContext()
+            } catch {
+                let description = String(describing: error)
+                XCTAssertFalse(
+                    description.contains("AMENT_PREFIX_PATH"),
+                    "the AMENT error resurfaced: \(description)")
+            }
+            XCTAssertNil(currentAmentPrefixPath, "AMENT_PREFIX_PATH not restored to unset")
+            XCTAssertNil(
+                getenv("ZENOH_SESSION_CONFIG_URI").map { String(cString: $0) },
+                "ZENOH_SESSION_CONFIG_URI not restored to unset")
+        }
+    }
 #endif

--- a/Tests/SwiftROS2RCLTests/RclZenohFailLoudTests.swift
+++ b/Tests/SwiftROS2RCLTests/RclZenohFailLoudTests.swift
@@ -214,4 +214,31 @@
                 "ZENOH_SESSION_CONFIG_URI not restored to unset")
         }
     }
+
+    // MARK: - RclZenohTransportConfigTests (S6)
+
+    /// `.rcl` / `.rclUnicast` target rmw_cyclonedds: in the zenoh-rmw build they
+    /// would open rmw_zenoh with default session settings while exporting a
+    /// meaningless CYCLONEDDS_URI. The supported transports here are `.zenoh`
+    /// (RCL via rmw_zenoh) and `.dds` (wire CycloneDDS) — reject the rest.
+    final class RclZenohTransportConfigTests: XCTestCase {
+        private func assertRejected(_ config: TransportConfig) async {
+            do {
+                _ = try await ROS2Context(transport: config)
+                XCTFail("expected unsupportedFeature for \(config.type)")
+            } catch TransportError.unsupportedFeature(let message) {
+                XCTAssertTrue(message.contains(".zenoh"), "remedy missing from: \(message)")
+            } catch {
+                XCTFail("expected unsupportedFeature, got \(error)")
+            }
+        }
+
+        func testRclConfigIsRejected() async {
+            await assertRejected(.rcl())
+        }
+
+        func testRclUnicastConfigIsRejected() async {
+            await assertRejected(.rclUnicast(peers: [DDSPeer(address: "192.168.1.10")]))
+        }
+    }
 #endif

--- a/Tests/SwiftROS2RCLTests/RclZenohFailLoudTests.swift
+++ b/Tests/SwiftROS2RCLTests/RclZenohFailLoudTests.swift
@@ -1,0 +1,76 @@
+// RclZenohFailLoudTests.swift
+// Zenoh-rmw-variant fail-loud behavior: the route-(b) registry-miss gate (S1),
+// the AMENT_PREFIX_PATH self-sufficiency synthesis (S2), and the `.rcl` /
+// `.rclUnicast` config rejection (S6). All compiled only in the zenoh variant
+// (SWIFT_ROS2_RCL_RMW=zenoh); the cyclonedds variant keeps its route-(b)
+// fallback and `.rcl` support unchanged.
+
+#if SWIFT_ROS2_RCL && SWIFT_ROS2_RCL_RMW_ZENOH
+    import Foundation
+    import SwiftROS2
+    import SwiftROS2RCL
+    import SwiftROS2Transport
+    import XCTest
+
+    // MARK: - FakeNodeHandle
+
+    /// Stand-in node handle: the registry-miss gate fires before the node
+    /// handle is even inspected, so these tests need no rcl context or node.
+    private final class FakeNodeHandle: RclNodeHandle {}
+
+    // MARK: - RclZenohRegistryMissGateTests (S1)
+
+    /// On a marshal-registry miss the cyclonedds variant falls back to a
+    /// raw-CDR writer/reader on a sibling CycloneDDS participant. Under
+    /// rmw_zenoh that participant's DDS domain has no counterpart (live-proven
+    /// silent data loss: a std_msgs/String talker published into the void), so
+    /// the zenoh variant must throw instead. The cyclonedds fallback stays
+    /// covered by the crcl-nonbundled-* loopbacks in ci-rcl.yml.
+    final class RclZenohRegistryMissGateTests: XCTestCase {
+        private let absentType = "foo_msgs/msg/Bar"
+
+        private func assertRegistryMissError(_ error: Error) {
+            guard case TransportError.unsupportedFeature(let message) = error else {
+                return XCTFail("expected unsupportedFeature, got \(error)")
+            }
+            XCTAssertTrue(message.contains(absentType), "type name missing from: \(message)")
+            XCTAssertTrue(message.contains(".dds"), "remedy missing from: \(message)")
+        }
+
+        func testCreatePublisherThrowsOnRegistryMiss() {
+            XCTAssertThrowsError(
+                try RclClient().createPublisher(
+                    node: FakeNodeHandle(), typeName: absentType, typeHash: nil,
+                    topic: "/gate_pub", qos: .sensorData)
+            ) { assertRegistryMissError($0) }
+        }
+
+        func testCreateSubscriptionThrowsOnRegistryMiss() {
+            XCTAssertThrowsError(
+                try RclClient().createSubscription(
+                    node: FakeNodeHandle(), typeName: absentType, typeHash: nil,
+                    topic: "/gate_sub", qos: .sensorData, handler: { _, _ in })
+            ) { assertRegistryMissError($0) }
+        }
+
+        func testBundledTypePassesGate() {
+            // A bundled type must get past the gate and fail on the (fake) node
+            // handle instead — the gate keys on the registry, not on the variant
+            // as a whole.
+            XCTAssertThrowsError(
+                try RclClient().createPublisher(
+                    node: FakeNodeHandle(), typeName: "sensor_msgs/msg/Imu", typeHash: nil,
+                    topic: "/gate_bundled", qos: .sensorData)
+            ) { error in
+                guard case TransportError.publisherCreationFailed(let message) = error else {
+                    return XCTFail("expected publisherCreationFailed, got \(error)")
+                }
+                XCTAssertTrue(message.contains("invalid node handle"), "unexpected: \(message)")
+            }
+        }
+
+        func testRequireBundledTypesupportAcceptsBundledType() {
+            XCTAssertNoThrow(try RclClient.requireBundledTypesupport("sensor_msgs/msg/Imu"))
+        }
+    }
+#endif

--- a/Tests/SwiftROS2RCLTests/RmwZenohConfigDriftTests.swift
+++ b/Tests/SwiftROS2RCLTests/RmwZenohConfigDriftTests.swift
@@ -1,4 +1,4 @@
-#if SWIFT_ROS2_RCL
+#if SWIFT_ROS2_RCL_RMW_ZENOH
     import Foundation
     import SwiftROS2RCL
     import XCTest

--- a/Tests/SwiftROS2RCLTests/RmwZenohConfigDriftTests.swift
+++ b/Tests/SwiftROS2RCLTests/RmwZenohConfigDriftTests.swift
@@ -1,0 +1,51 @@
+#if SWIFT_ROS2_RCL
+    import Foundation
+    import SwiftROS2RCL
+    import XCTest
+
+    /// Drift guard for the embedded rmw_zenoh default configs.
+    ///
+    /// Two independent copies of DEFAULT_RMW_ZENOH_{SESSION,ROUTER}_CONFIG
+    /// .json5 exist: the runtime synthesis embeds them as Swift constants
+    /// (`RmwZenohDefaultConfig`), and the xcframework build copies them from
+    /// the RMW_ZENOH_PIN checkout (`assemble_zenoh_ament_prefix` in
+    /// Scripts/build-ros2-xcframework.sh). A pin bump that re-vendors the
+    /// checkout without re-copying the constants would silently diverge the
+    /// runtime config from the built rmw — this test pins them together
+    /// byte-for-byte. Skips when the pinned checkout is not materialized
+    /// (default cyclonedds CI); the ci-rcl zenoh leg builds it.
+    final class RmwZenohConfigDriftTests: XCTestCase {
+        private var pinnedConfigDir: URL {
+            // Tests/SwiftROS2RCLTests/<file> → repo root → pinned checkout.
+            URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent(
+                    "build/ros2zenoh/src_ws/ros2/rmw_zenoh/rmw_zenoh_cpp/config",
+                    isDirectory: true)
+        }
+
+        func testEmbeddedConfigsMatchPinnedCheckout() throws {
+            let sessionURL = pinnedConfigDir.appendingPathComponent(
+                "DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5")
+            let routerURL = pinnedConfigDir.appendingPathComponent(
+                "DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5")
+            guard FileManager.default.fileExists(atPath: sessionURL.path) else {
+                throw XCTSkip(
+                    "pinned rmw_zenoh checkout not materialized — "
+                        + "RMW_VARIANT=zenoh Scripts/build-ros2-xcframework.sh populates it")
+            }
+            XCTAssertEqual(
+                RmwZenohDefaultConfig.sessionConfigJSON5,
+                try String(contentsOf: sessionURL, encoding: .utf8),
+                "embedded session config drifted from the pinned rmw_zenoh checkout — "
+                    + "re-copy RmwZenohDefaultConfig.sessionConfigJSON5")
+            XCTAssertEqual(
+                RmwZenohDefaultConfig.routerConfigJSON5,
+                try String(contentsOf: routerURL, encoding: .utf8),
+                "embedded router config drifted from the pinned rmw_zenoh checkout — "
+                    + "re-copy RmwZenohDefaultConfig.routerConfigJSON5")
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

Makes the zenoh-rmw RCL variant (`SWIFT_ROS2_RCL_RMW=zenoh`) fail loud and self-sufficient. Three correctness fixes, all confirmed by live testing before the change:

### Define plumbing (prerequisite)

`SWIFT_ROS2_RCL_RMW_ZENOH` previously reached only the `SwiftROS2` umbrella target and its tests — any `#if SWIFT_ROS2_RCL_RMW_ZENOH` inside `SwiftROS2RCL` was dead code. The define now also applies to the `SwiftROS2RCL` target (and its test target already had it).

### S1 — route-(b) registry-miss gate

On a `crcl_marshal_registry` miss, `RclClient.createPublisher` / `createSubscription` silently fell back to route (b): a raw-CDR writer/reader on a sibling **CycloneDDS** participant. Under rmw_zenoh the rcl graph speaks Zenoh through a router, so route-b traffic lands on a DDS multicast domain nobody watches — **silent data loss** (proven live: a `std_msgs/String` talker published into the void; String is not in the bundled marshal registry).

The zenoh variant now throws `TransportError.unsupportedFeature("type <name> has no bundled typesupport; the raw-CDR fallback is CycloneDDS-only and unreachable via rmw_zenoh — bundle the type or use the .dds transport")`. The gate runs before the node handle is inspected, so it is unit-testable without a live rmw context. Cyclonedds-variant behavior is unchanged (route-b stays covered by the `crcl-nonbundled-*` loopbacks in ci-rcl.yml).

### S2 — AMENT_PREFIX_PATH self-sufficiency

rmw_zenoh_cpp hard-requires `AMENT_PREFIX_PATH` at `rmw_init` to resolve `DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5` via ament_index (proven live: context creation threw `Environment variable AMENT_PREFIX_PATH is not set or empty` — rmw_init.cpp:114). Consumer apps can't be expected to export it.

`createContext` now (unconditionally in the zenoh variant) synthesizes a minimal ament prefix in a temp dir — `share/ament_index/resource_index/packages/rmw_zenoh_cpp` marker + the two default config json5 files, embedded verbatim (byte-identical, verified) from the pinned rmw_zenoh checkout (`RMW_ZENOH_PIN fe3553c7c127273280617d3d778859f22c4c3eb7`, `Scripts/build-ros2-xcframework.sh:196`) — whenever the env is unset/empty or lacks the rmw_zenoh_cpp resource. An existing-but-unusable value gets the synthesized prefix **prepended** (user resources stay resolvable); a valid user-provided prefix is left untouched. Save/restore uses the same `String??` env-slot discipline as `ZENOH_SESSION_CONFIG_URI` under `zenohEnvLock`; `restoreZenohSessionEnv()` restores the slot and deletes the temp prefix on `destroyContext` and on a failed create.

### S6 — reject `.rcl` / `.rclUnicast` in the zenoh variant

A `.rcl`/`.rclUnicast` config would open rmw_zenoh with default (router-less) session settings while exporting a meaningless `CYCLONEDDS_URI`. `ROS2Context.makeDefaultSession` now throws `unsupportedFeature` in this build — the supported transports are `.zenoh(locator:)` (RCL via rmw_zenoh) and `.dds` (wire CycloneDDS). Cyclonedds variant keeps serving `.rcl` unchanged.

## Live smoke (local, rmw_zenohd router at tcp/127.0.0.1:7447, domain 0)

```
$ env -u AMENT_PREFIX_PATH RMW_IMPLEMENTATION=rmw_zenoh_cpp .build-zenoh/debug/talker zenoh tcp/127.0.0.1:7447
Fatal error: Error raised at top level: TransportError.unsupportedFeature("type std_msgs/msg/String has no bundled typesupport; the raw-CDR fallback is CycloneDDS-only and unreachable via rmw_zenoh — bundle the type or use the .dds transport")
```

This one run proves both fixes: with `AMENT_PREFIX_PATH` cleared, rmw_init + rcl node creation + the parameter-service servers all came up over live rmw_zenoh (no AMENT error — S2), and the String publisher then failed **loudly** at creation instead of publishing into the void (S1; `std_msgs/String` is itself a registry miss, which is exactly the type the silent loss was proven with). The AMENT unit test additionally creates a real rmw_zenoh context against the live router with the env cleared.

## Verification

- zenoh variant: `swift build` + `swift test --filter SwiftROS2RCLTests` — 27 tests, 11 new, all new pass. The only failures are the two **pre-existing** `CrossBackendBytesTests.testPointCloud2ByteParity*` failures, present on unmodified `main` in this variant (unrelated: rmw_serialize byte divergence for PointCloud2; passes in the cyclonedds variant).
- cyclonedds variant: `swift build` + `swift test --filter SwiftROS2RCLTests` — 16 tests, 0 failures; full suite 619 tests, 0 failures.
- zenoh variant full suite: 626 tests, 2 failures (the same pre-existing pair), 19 skips (LINUX_IP etc.).
- `swift format lint --strict` clean.
- API gate: `Scripts/diagnose-api-breaking-changes.sh 1.2.0 Scripts/api-breakage-allowlist.txt` passes, allowlist untouched — all new seams are `package`-visibility, public surface unchanged.

## Notes

- The embedded json5 payloads were verified byte-identical (including the trailing newline) to `build/ros2zenoh/ament-prefix/share/rmw_zenoh_cpp/config/*.json5` from the pinned checkout.
- `rcl-bench` / `rcl-soak` use the `.rcl` backend and are therefore no longer runnable in the zenoh-variant build (they still compile); they remain the cyclonedds-variant benchmarking tools.
