### PR TITLE
ci(release): build + attach CRos2Jazzy(.Zenoh) xcframeworks on release tags

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -703,7 +703,7 @@ if enableRcl {
     targets.append(
         .executableTarget(
             name: "rcl-bench",
-            dependencies: ["SwiftROS2", "SwiftROS2RCL"],
+            dependencies: ["SwiftROS2", "SwiftROS2RCL", "SwiftROS2Bench"],
             path: "Sources/Examples/RclBench",
             linkerSettings: [.linkedLibrary("c++")]
         ))

--- a/Sources/Examples/RclBench/main.swift
+++ b/Sources/Examples/RclBench/main.swift
@@ -1,10 +1,13 @@
 // rcl-bench — typed rcl_publish (.rcl backend) vs pure-Swift wire-DDS (.dds)
-// benchmark (spec §19.3 M5). One backend per process so the two DDS stacks
-// never share a participant.
+// vs Zenoh (.zenoh) benchmark (spec §19.3 M5). One backend per process so the
+// two DDS stacks never share a participant. The `zenoh` backend resolves to
+// the zenoh-pico wire path on the default build and to rcl + rmw_zenoh_cpp on
+// the SWIFT_ROS2_RCL_RMW=zenoh variant; its router locator comes from
+// `--locator`, then SWIFT_ROS2_ZENOH_LOCATOR, then tcp/127.0.0.1:7447.
 //
 // Usage:
-//   rcl-bench <rcl|dds> <publish|roundtrip|roundtrip-lan|encode> [imu|image64k|cloud120k]
-//             [--count N] [--rate-hz N] [--domain N]
+//   rcl-bench <rcl|dds|zenoh> <publish|roundtrip|roundtrip-lan|encode> [imu|image64k|cloud120k]
+//             [--count N] [--rate-hz N] [--domain N] [--locator STR]
 //
 // Modes:
 //   publish       — per-publish call latency + max-rate throughput (no subscriber)
@@ -23,6 +26,7 @@
 
 import Foundation
 import SwiftROS2
+import SwiftROS2Bench
 import SwiftROS2RCL
 
 // MARK: - CLI
@@ -31,15 +35,15 @@ let args = CommandLine.arguments
 guard args.count >= 3 else {
     print(
         """
-        usage: rcl-bench <rcl|dds> <publish|roundtrip|roundtrip-lan|encode> \
-        [imu|image64k|cloud120k] [--count N] [--rate-hz N] [--domain N]
+        usage: rcl-bench <rcl|dds|zenoh> <publish|roundtrip|roundtrip-lan|encode> \
+        [imu|image64k|cloud120k] [--count N] [--rate-hz N] [--domain N] [--locator STR]
         """)
     exit(2)
 }
 let backend = args[1]
 let mode = args[2]
 let payload = args.count > 3 && !args[3].hasPrefix("--") ? args[3] : "imu"
-guard ["rcl", "dds"].contains(backend),
+guard HarnessCLI.supportedBackends.contains(backend),
     ["publish", "roundtrip", "roundtrip-lan", "encode"].contains(mode),
     ["imu", "image64k", "cloud120k"].contains(payload)
 else {
@@ -60,6 +64,8 @@ let count = intOption(
 let rateHz = intOption("--rate-hz", default: 0)  // 0 = max rate
 let warmup = isLarge ? 100 : 1_000
 let domainId = intOption("--domain", default: 42)
+let zenohLocator = HarnessCLI.resolveZenohLocator(
+    arguments: args, environment: ProcessInfo.processInfo.environment)
 
 // MARK: - timing helpers
 
@@ -158,7 +164,10 @@ func runEncode() throws {
     samples.reserveCapacity(count)
     var bytes = 0
     let start = nowNS()
-    switch (backend, payload) {
+    // `zenoh` measures the same pure-Swift CDREncoder the zenoh-pico wire
+    // path uses; the rcl marshal + rmw_serialize proxy stays on the `rcl`
+    // token (one encode seam per token, regardless of rmw variant).
+    switch (backend == "rcl" ? "rcl" : "dds", payload) {
     case ("dds", "imu"):
         let m = makeImu()
         for _ in 0..<count {
@@ -217,7 +226,11 @@ func runEncode() throws {
 // MARK: - publish / roundtrip modes
 
 func transportConfig() -> TransportConfig {
-    backend == "rcl" ? .rcl(domainId: domainId) : .ddsMulticast(domainId: domainId)
+    switch backend {
+    case "rcl": return .rcl(domainId: domainId)
+    case "zenoh": return .zenoh(locator: zenohLocator, domainId: domainId)
+    default: return .ddsMulticast(domainId: domainId)
+    }
 }
 
 func runPubSub() async throws {

--- a/Sources/Examples/RclSoak/main.swift
+++ b/Sources/Examples/RclSoak/main.swift
@@ -5,11 +5,20 @@
 // 2 s in-process smoke that asserts the harness itself works.
 //
 // Usage:
-//   rcl-soak <rcl|dds> [imu|image64k|cloud120k] [--duration-s N] [--sample-s N]
-//            [--rate-hz N] [--domain N] [--selftest] [--inject-malformed]
+//   rcl-soak <rcl|dds|zenoh> [imu|image64k|cloud120k] [--duration-s N] [--sample-s N]
+//            [--rate-hz N] [--domain N] [--locator STR] [--selftest]
+//            [--inject-malformed] [--expect-echo]
+//
+// The `zenoh` backend resolves to the zenoh-pico wire path on the default
+// build and to rcl + rmw_zenoh_cpp on the SWIFT_ROS2_RCL_RMW=zenoh variant;
+// its router locator comes from `--locator`, then SWIFT_ROS2_ZENOH_LOCATOR,
+// then tcp/127.0.0.1:7447. With `--expect-echo` the host relays `soak` ->
+// `soak_echo` (e.g. `ros2 run topic_tools relay`) and the harness counts
+// deliveries on the echo topic.
 //
 // Output: per-sample `rcl_soak SAMPLE t=.. rss_mb=.. fds=.. msgs_per_s=..`
-//         then a final `rcl_soak RESULT verdict=.. rss_slope_b_per_min=.. ...`.
+//         (plus `recv_per_s=..` with --expect-echo) then a final
+//         `rcl_soak RESULT verdict=.. rss_slope_b_per_min=.. ...`.
 
 import Darwin
 import Dispatch
@@ -37,9 +46,16 @@ let sampleS = intOpt("--sample-s", selftest ? 1 : 30)
 let rateHz = intOpt("--rate-hz", 100)
 let domainId = intOpt("--domain", 42)
 let injectMalformed = flag("--inject-malformed")
+let expectEcho = flag("--expect-echo")
+let zenohLocator = HarnessCLI.resolveZenohLocator(
+    arguments: args, environment: ProcessInfo.processInfo.environment)
 
-guard ["rcl", "dds"].contains(backend), ["imu", "image64k", "cloud120k"].contains(payload) else {
-    print("rcl_soak FAIL: usage: rcl-soak <rcl|dds> [imu|image64k|cloud120k] [--duration-s N] ...")
+guard HarnessCLI.supportedBackends.contains(backend),
+    ["imu", "image64k", "cloud120k"].contains(payload)
+else {
+    print(
+        "rcl_soak FAIL: usage: rcl-soak <rcl|dds|zenoh> [imu|image64k|cloud120k] [--duration-s N] ..."
+    )
     exit(2)
 }
 
@@ -113,8 +129,12 @@ final class Counter: @unchecked Sendable {
 
 func run() async throws {
     let qos = QoSProfile(reliability: .reliable, durability: .volatile, history: .keepLast(64))
-    let config: TransportConfig =
-        backend == "rcl" ? .rcl(domainId: domainId) : .ddsMulticast(domainId: domainId)
+    let config: TransportConfig
+    switch backend {
+    case "rcl": config = .rcl(domainId: domainId)
+    case "zenoh": config = .zenoh(locator: zenohLocator, domainId: domainId)
+    default: config = .ddsMulticast(domainId: domainId)
+    }
     let ctx = try await ROS2Context(transport: config)
     let node = try await ctx.createNode(
         name: "rcl_soak", namespace: "/rcl_soak",
@@ -128,6 +148,26 @@ func run() async throws {
         probe.onMessage { _ in }
     }
 
+    // H7 receive-side observability: with --expect-echo the host relays
+    // `soak` -> `soak_echo` and we count deliveries on the echo topic,
+    // mirroring rcl-bench's roundtrip-lan subscription.
+    let received = Counter()
+    if expectEcho {
+        switch payload {
+        case "imu":
+            let sub = try await node.createSubscription(Imu.self, topic: "soak_echo", qos: qos)
+            sub.onMessage { _ in received.add(1) }
+        case "image64k":
+            let sub = try await node.createSubscription(
+                CompressedImage.self, topic: "soak_echo", qos: qos)
+            sub.onMessage { _ in received.add(1) }
+        default:
+            let sub = try await node.createSubscription(
+                PointCloud2.self, topic: "soak_echo", qos: qos)
+            sub.onMessage { _ in received.add(1) }
+        }
+    }
+
     let published = Counter()
     let periodNS: UInt64 = rateHz > 0 ? UInt64(1_000_000_000 / UInt64(rateHz)) : 0
 
@@ -138,8 +178,10 @@ func run() async throws {
         let startNS = nowNS()
         let endNS = startNS + UInt64(durationS) * 1_000_000_000
         var samples: [SoakSample] = []
+        var recvSeries: [Double] = []
         var nextSampleNS = startNS + UInt64(sampleS) * 1_000_000_000
         var lastSampleCount = 0
+        var lastRecvCount = 0
         var lastSampleNS = startNS
         var lastFDs = max(0, openFDCount())  // baseline; carried if a read fails
         var next = startNS
@@ -160,28 +202,41 @@ func run() async throws {
                 let rawFDs = openFDCount()
                 let fds = rawFDs >= 0 ? rawFDs : lastFDs  // carry last good on a failed read
                 lastFDs = fds
+                let recvTotal = received.value
+                let recvPerS = dt > 0 ? Double(recvTotal - lastRecvCount) / dt : 0
                 let s = SoakSample(
                     tSeconds: Double(now - startNS) / 1e9, rssBytes: currentRSSBytes(),
                     openFDs: fds, msgsPerSec: mps)
                 samples.append(s)
+                if expectEcho { recvSeries.append(recvPerS) }
                 print(
                     "rcl_soak SAMPLE t=\(String(format: "%.1f", s.tSeconds)) "
                         + "rss_mb=\(String(format: "%.1f", Double(s.rssBytes) / 1_048_576)) "
-                        + "fds=\(s.openFDs) msgs_per_s=\(String(format: "%.0f", s.msgsPerSec))")
+                        + "fds=\(s.openFDs) msgs_per_s=\(String(format: "%.0f", s.msgsPerSec))"
+                        + (expectEcho ? " recv_per_s=\(String(format: "%.0f", recvPerS))" : ""))
                 fflush(stdout)
                 lastSampleCount = total
+                lastRecvCount = recvTotal
                 lastSampleNS = now
                 nextSampleNS = now + UInt64(sampleS) * 1_000_000_000
             }
         }
         let v = SoakAnalysis.analyze(samples)
-        print(
+        var result =
             "rcl_soak RESULT backend=\(backend) payload=\(payload) duration_s=\(durationS) "
-                + "samples=\(samples.count) published=\(published.value) "
-                + "verdict=\(v.leakSuspected ? "LEAK" : "healthy") "
-                + "rss_slope_b_per_min=\(Int(v.rssSlopeBytesPerMin.rounded())) "
-                + "fd_growth=\(v.fdGrowth) "
-                + "tput_degradation_pct=\(String(format: "%.1f", v.throughputDegradationPct))")
+            + "samples=\(samples.count) published=\(published.value) "
+            + "verdict=\(v.leakSuspected ? "LEAK" : "healthy") "
+            + "rss_slope_b_per_min=\(Int(v.rssSlopeBytesPerMin.rounded())) "
+            + "fd_growth=\(v.fdGrowth) "
+            + "tput_degradation_pct=\(String(format: "%.1f", v.throughputDegradationPct))"
+        if expectEcho {
+            let echo = SoakAnalysis.echoContinuity(recvPerSecond: recvSeries)
+            result +=
+                " received=\(received.value)"
+                + " recv_zero_run_max=\(echo.maxConsecutiveZeroRecvSamples)"
+                + " recv_recovered=\(echo.recoveredAfterZeroRecv)"
+        }
+        print(result)
         fflush(stdout)
         if selftest {
             guard samples.count >= 1, samples.allSatisfy({ $0.rssBytes > 0 }) else {

--- a/Sources/SwiftROS2Bench/HarnessCLI.swift
+++ b/Sources/SwiftROS2Bench/HarnessCLI.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Pure argument / environment resolution shared by the rcl-bench and
+/// rcl-soak harness executables. No I/O — unit-tested in normal CI.
+public enum HarnessCLI {
+    /// Backend tokens the harness executables accept.
+    public static let supportedBackends: Set<String> = ["rcl", "dds", "zenoh"]
+
+    /// Environment variable consulted when `--locator` is absent.
+    public static let zenohLocatorEnvVar = "SWIFT_ROS2_ZENOH_LOCATOR"
+
+    /// Fallback Zenoh router locator (a local rmw_zenohd).
+    public static let defaultZenohLocator = "tcp/127.0.0.1:7447"
+
+    /// Resolve the Zenoh router locator for the `zenoh` backend:
+    /// `--locator <str>` wins, then `SWIFT_ROS2_ZENOH_LOCATOR`, then
+    /// ``defaultZenohLocator``. A trailing `--locator` with no value and an
+    /// empty environment value both fall through to the next source.
+    public static func resolveZenohLocator(
+        arguments: [String],
+        environment: [String: String]
+    ) -> String {
+        if let i = arguments.firstIndex(of: "--locator"), i + 1 < arguments.count,
+            !arguments[i + 1].isEmpty
+        {
+            return arguments[i + 1]
+        }
+        if let env = environment[zenohLocatorEnvVar], !env.isEmpty {
+            return env
+        }
+        return defaultZenohLocator
+    }
+}

--- a/Sources/SwiftROS2Bench/SoakAnalysis.swift
+++ b/Sources/SwiftROS2Bench/SoakAnalysis.swift
@@ -94,4 +94,30 @@ public enum SoakAnalysis {
             fdGrowth: fdGrowth, throughputDegradationPct: throughputDegradationPct,
             summary: summary)
     }
+
+    /// Receive-side echo continuity for an `--expect-echo` soak run.
+    ///
+    /// Given the per-sample receive rates (the `recv_per_s` series), returns
+    /// the length of the longest run of consecutive zero-recv samples and
+    /// whether delivery recovered after stalling. `recoveredAfterZeroRecv` is
+    /// true iff the series contains at least one zero sample and does not end
+    /// in one (delivery resumed after the last stall). A series with no zero
+    /// samples reports `(0, false)` — there was nothing to recover from. An
+    /// empty series reports `(0, false)`.
+    public static func echoContinuity(
+        recvPerSecond: [Double]
+    ) -> (maxConsecutiveZeroRecvSamples: Int, recoveredAfterZeroRecv: Bool) {
+        var maxRun = 0
+        var run = 0
+        for value in recvPerSecond {
+            if value == 0 {
+                run += 1
+                maxRun = max(maxRun, run)
+            } else {
+                run = 0
+            }
+        }
+        // run == 0 here means the series does not end in a zero sample.
+        return (maxRun, maxRun > 0 && run == 0)
+    }
 }

--- a/Tests/SwiftROS2BenchTests/HarnessCLITests.swift
+++ b/Tests/SwiftROS2BenchTests/HarnessCLITests.swift
@@ -1,0 +1,52 @@
+import SwiftROS2Bench
+import XCTest
+
+final class HarnessCLITests: XCTestCase {
+    func testSupportedBackends() {
+        XCTAssertTrue(HarnessCLI.supportedBackends.contains("rcl"))
+        XCTAssertTrue(HarnessCLI.supportedBackends.contains("dds"))
+        XCTAssertTrue(HarnessCLI.supportedBackends.contains("zenoh"))
+        XCTAssertFalse(HarnessCLI.supportedBackends.contains("fastdds"))
+    }
+
+    func testLocatorFlagWinsOverEnvironment() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: ["rcl-bench", "zenoh", "publish", "--locator", "tcp/10.0.0.5:7447"],
+            environment: [HarnessCLI.zenohLocatorEnvVar: "tcp/192.168.1.1:7447"])
+        XCTAssertEqual(locator, "tcp/10.0.0.5:7447")
+    }
+
+    func testEnvironmentFallback() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: ["rcl-bench", "zenoh", "publish"],
+            environment: [HarnessCLI.zenohLocatorEnvVar: "tcp/192.168.1.1:7447"])
+        XCTAssertEqual(locator, "tcp/192.168.1.1:7447")
+    }
+
+    func testDefaultWhenNothingGiven() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: ["rcl-bench", "zenoh", "publish"], environment: [:])
+        XCTAssertEqual(locator, HarnessCLI.defaultZenohLocator)
+        XCTAssertEqual(locator, "tcp/127.0.0.1:7447")
+    }
+
+    func testTrailingLocatorFlagWithoutValueFallsThrough() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: ["rcl-bench", "zenoh", "publish", "--locator"],
+            environment: [HarnessCLI.zenohLocatorEnvVar: "tcp/192.168.1.1:7447"])
+        XCTAssertEqual(locator, "tcp/192.168.1.1:7447")
+    }
+
+    func testEmptyLocatorValueFallsThrough() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: ["rcl-bench", "zenoh", "publish", "--locator", ""],
+            environment: [HarnessCLI.zenohLocatorEnvVar: "tcp/192.168.1.1:7447"])
+        XCTAssertEqual(locator, "tcp/192.168.1.1:7447")
+    }
+
+    func testEmptyEnvironmentValueFallsThroughToDefault() {
+        let locator = HarnessCLI.resolveZenohLocator(
+            arguments: [], environment: [HarnessCLI.zenohLocatorEnvVar: ""])
+        XCTAssertEqual(locator, HarnessCLI.defaultZenohLocator)
+    }
+}

--- a/Tests/SwiftROS2BenchTests/SoakAnalysisTests.swift
+++ b/Tests/SwiftROS2BenchTests/SoakAnalysisTests.swift
@@ -81,4 +81,49 @@ final class SoakAnalysisTests: XCTestCase {
         XCTAssertEqual(v.rssSlopeBytesPerMin, 0)
         XCTAssertFalse(v.leakSuspected)
     }
+
+    // MARK: - echoContinuity (H7 receive-side observability)
+
+    func testEchoContinuityEmptySeries() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 0)
+        XCTAssertFalse(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityAllNonZeroHasNoStall() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [100, 99, 101])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 0)
+        // No zero sample means there was nothing to recover from.
+        XCTAssertFalse(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityMidRunStallThatRecovers() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [100, 0, 0, 0, 100])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 3)
+        XCTAssertTrue(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityStallAtEndIsNotRecovered() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [100, 100, 0, 0])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 2)
+        XCTAssertFalse(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityLongestZeroRunWins() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [0, 100, 0, 0, 0, 100, 0, 0, 100])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 3)
+        XCTAssertTrue(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuityAllZerosIsNeverRecovered() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [0, 0, 0])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 3)
+        XCTAssertFalse(r.recoveredAfterZeroRecv)
+    }
+
+    func testEchoContinuitySingleZeroThenRecovery() {
+        let r = SoakAnalysis.echoContinuity(recvPerSecond: [0, 100])
+        XCTAssertEqual(r.maxConsecutiveZeroRecvSamples, 1)
+        XCTAssertTrue(r.recoveredAfterZeroRecv)
+    }
 }


### PR DESCRIPTION
MZ2 release-packaging (V4, first half). Adds a `build-ros2-xcframework` job to the tag-driven release workflow: matrix over the two rmw variants (`cyclonedds` → `CRos2Jazzy`, `zenoh` → `CRos2JazzyZenoh`), each building all six Apple slices (maccatalyst, iphoneos, iphonesimulator, macosx, xros, xrsimulator), zipping with `ditto`, computing the SwiftPM checksum, and attaching zip+checksum to the GitHub Release. The publish job's asset assert now requires all eight artifacts, so a silently-dropped variant fails the release (same rationale as #35).

The dispatch utility `build-ros2-xcframework.yml` gains an `rmw_variant` input + Rust cross-target setup (incl. the now-stable `aarch64-apple-visionos` targets) and moves to the macos-26/Xcode 26.4.1 toolchain that ci-rcl already validates the cross-build on.

**Follow-up (second half of MZ2, after the first tagged release):** switch the `CRos2Jazzy*` binaryTargets in `Package.swift` from local-path to URL+checksum, re-computing checksums from the uploaded zips (GitHub re-zips on upload).

Note: the zenoh-variant xros/xrsimulator slices depend on the `zenohc_triple` visionOS mapping that lands with the tf2_msgs/audio_common_msgs/point_cloud_interfaces bundling PR — tag only after that merges.