### PR TITLE
ci(release): build + attach CRos2Jazzy(.Zenoh) xcframeworks on release tags

### DIFF
--- a/.github/workflows/build-ros2-xcframework.yml
+++ b/.github/workflows/build-ros2-xcframework.yml
@@ -5,18 +5,41 @@ on:
       slices:
         description: "space-separated slices"
         default: "maccatalyst iphoneos"
+      rmw_variant:
+        description: "rmw variant (cyclonedds or zenoh)"
+        type: choice
+        options:
+          - cyclonedds
+          - zenoh
+        default: cyclonedds
 jobs:
   build:
-    runs-on: macos-15
-    timeout-minutes: 180
+    runs-on: macos-26
+    timeout-minutes: 330
     steps:
       - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - run: brew install cmake
-      - run: Scripts/build-ros2-xcframework.sh ${{ inputs.slices }}
+      # ament_cmake's package_xml_2_cmake.py runs under the runner's base
+      # python, so the ROS 2 build deps must be importable there too.
+      - name: Install ROS 2 build deps into runner python
+        run: pip install -r Scripts/ros2/requirements.txt
+      # The zenoh variant cross-builds zenoh-c (Rust staticlib) per slice.
+      - name: Install Rust cross targets (zenoh variant)
+        if: inputs.rmw_variant == 'zenoh'
+        run: |
+          rustup target add \
+            aarch64-apple-darwin aarch64-apple-ios aarch64-apple-ios-sim \
+            aarch64-apple-ios-macabi aarch64-apple-visionos aarch64-apple-visionos-sim
+      - name: Build xcframework
+        env:
+          RMW_VARIANT: ${{ inputs.rmw_variant }}
+        run: Scripts/build-ros2-xcframework.sh ${{ inputs.slices }}
       - uses: actions/upload-artifact@v4
         with:
-          name: CRos2Jazzy.xcframework
-          path: build/ros2/CRos2Jazzy.xcframework
+          name: ${{ inputs.rmw_variant == 'zenoh' && 'CRos2JazzyZenoh.xcframework' || 'CRos2Jazzy.xcframework' }}
+          path: ${{ inputs.rmw_variant == 'zenoh' && 'build/ros2zenoh/CRos2JazzyZenoh.xcframework' || 'build/ros2/CRos2Jazzy.xcframework' }}

--- a/.github/workflows/release-xcframework.yml
+++ b/.github/workflows/release-xcframework.yml
@@ -50,9 +50,72 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  build-ros2-xcframework:
+    name: Build (${{ matrix.framework }}.xcframework)
+    # macos-26 + Xcode 26.4.1 to match ci-rcl.yml (the toolchain the ROS 2
+    # cross-build is validated on). All six Apple slices per rmw variant.
+    runs-on: macos-26
+    timeout-minutes: 330
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - framework: CRos2Jazzy
+            rmw_variant: cyclonedds
+            slices: maccatalyst iphoneos iphonesimulator macosx xros xrsimulator
+            build_dir: build/ros2
+          - framework: CRos2JazzyZenoh
+            rmw_variant: zenoh
+            slices: maccatalyst iphoneos iphonesimulator macosx xros xrsimulator
+            build_dir: build/ros2zenoh
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: brew install cmake
+      # ament_cmake's package_xml_2_cmake.py runs under the runner's base
+      # python (CMake's FindPython resolves to it, not the script's venv), so
+      # the ROS 2 build deps must be importable there too.
+      - name: Install ROS 2 build deps into runner python
+        run: pip install -r Scripts/ros2/requirements.txt
+      # The zenoh variant cross-builds zenoh-c (Rust staticlib) per slice.
+      - name: Install Rust cross targets (zenoh variant)
+        if: matrix.rmw_variant == 'zenoh'
+        run: |
+          rustup target add \
+            aarch64-apple-darwin aarch64-apple-ios aarch64-apple-ios-sim \
+            aarch64-apple-ios-macabi aarch64-apple-visionos aarch64-apple-visionos-sim
+      - name: Build ${{ matrix.framework }}.xcframework (all slices)
+        env:
+          RMW_VARIANT: ${{ matrix.rmw_variant }}
+        run: Scripts/build-ros2-xcframework.sh ${{ matrix.slices }}
+      - name: Zip + checksum
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          ditto -c -k --keepParent \
+            "${{ matrix.build_dir }}/${{ matrix.framework }}.xcframework" \
+            "artifacts/${{ matrix.framework }}.xcframework.zip"
+          swift package compute-checksum \
+            "artifacts/${{ matrix.framework }}.xcframework.zip" \
+            > "artifacts/${{ matrix.framework }}.xcframework.zip.checksum"
+          cat "artifacts/${{ matrix.framework }}.xcframework.zip.checksum"
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.framework }}-xcframework
+          path: |
+            artifacts/*.zip
+            artifacts/*.checksum
+          if-no-files-found: error
+          retention-days: 7
+
   publish-xcframeworks:
     name: Publish (xcframeworks)
-    needs: build-xcframework
+    needs: [build-xcframework, build-ros2-xcframework]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -77,7 +140,11 @@ jobs:
             upload/CZenohPico.xcframework.zip \
             upload/CZenohPico.xcframework.zip.checksum \
             upload/CCycloneDDS.xcframework.zip \
-            upload/CCycloneDDS.xcframework.zip.checksum
+            upload/CCycloneDDS.xcframework.zip.checksum \
+            upload/CRos2Jazzy.xcframework.zip \
+            upload/CRos2Jazzy.xcframework.zip.checksum \
+            upload/CRos2JazzyZenoh.xcframework.zip \
+            upload/CRos2JazzyZenoh.xcframework.zip.checksum
 
       - name: Assert all expected assets present on the release
         # Fail loudly if the release is missing any expected asset.
@@ -98,6 +165,10 @@ jobs:
             CZenohPico.xcframework.zip.checksum
             CCycloneDDS.xcframework.zip
             CCycloneDDS.xcframework.zip.checksum
+            CRos2Jazzy.xcframework.zip
+            CRos2Jazzy.xcframework.zip.checksum
+            CRos2JazzyZenoh.xcframework.zip
+            CRos2JazzyZenoh.xcframework.zip.checksum
           )
           actual=$(gh release view "$TAG" --repo "${{ github.repository }}" --json assets --jq '.assets[].name' | sort)
           echo "Actual assets on release $TAG:"

--- a/.github/workflows/release-xcframework.yml
+++ b/.github/workflows/release-xcframework.yml
@@ -64,9 +64,13 @@ jobs:
             rmw_variant: cyclonedds
             slices: maccatalyst iphoneos iphonesimulator macosx xros xrsimulator
             build_dir: build/ros2
+          # No xros/xrsimulator for the zenoh variant: zenoh-c's dependency
+          # graph (pnet_sys 0.35) does not compile for visionOS yet, so those
+          # slices are dropped by design — visionOS consumers stay on the
+          # zenoh-pico wire path or the .dds transport.
           - framework: CRos2JazzyZenoh
             rmw_variant: zenoh
-            slices: maccatalyst iphoneos iphonesimulator macosx xros xrsimulator
+            slices: maccatalyst iphoneos iphonesimulator macosx
             build_dir: build/ros2zenoh
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-xcframework.yml
+++ b/.github/workflows/release-xcframework.yml
@@ -86,12 +86,16 @@ jobs:
       - name: Install ROS 2 build deps into runner python
         run: pip install -r Scripts/ros2/requirements.txt
       # The zenoh variant cross-builds zenoh-c (Rust staticlib) per slice.
+      # This pre-warm targets the runner's default toolchain; build_zenohc
+      # re-adds each target scoped to zenoh-c's pinned toolchain (its
+      # rust-toolchain.toml governs the actual build). No visionOS triples:
+      # the zenoh matrix ships no xros/xrsimulator slices (pnet_sys).
       - name: Install Rust cross targets (zenoh variant)
         if: matrix.rmw_variant == 'zenoh'
         run: |
           rustup target add \
             aarch64-apple-darwin aarch64-apple-ios aarch64-apple-ios-sim \
-            aarch64-apple-ios-macabi aarch64-apple-visionos aarch64-apple-visionos-sim
+            aarch64-apple-ios-macabi
       - name: Build ${{ matrix.framework }}.xcframework (all slices)
         env:
           RMW_VARIANT: ${{ matrix.rmw_variant }}
@@ -119,6 +123,12 @@ jobs:
 
   publish-xcframeworks:
     name: Publish (xcframeworks)
+    # Publishing is intentionally gated on BOTH build jobs: once Package.swift
+    # pins the CRos2Jazzy* URLs, a release without the ros2 assets would be
+    # broken for downstream anyway. The cost is that a transient failure in
+    # the long ros2 cross-build blocks the whole release — RECOVERY: re-run
+    # this workflow via workflow_dispatch with the existing tag; it rebuilds
+    # and re-attaches (--clobber) all assets.
     needs: [build-xcframework, build-ros2-xcframework]
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
MZ2 release-packaging (first half). Adds a `build-ros2-xcframework` job to the tag-driven release workflow: matrix over the two rmw variants (`cyclonedds` → `CRos2Jazzy`, `zenoh` → `CRos2JazzyZenoh`), each building all six Apple slices (maccatalyst, iphoneos, iphonesimulator, macosx, xros, xrsimulator), zipping with `ditto`, computing the SwiftPM checksum, and attaching zip+checksum to the GitHub Release. The publish job's asset assert now requires all eight artifacts, so a silently-dropped variant fails the release (same rationale as #35).

The dispatch utility `build-ros2-xcframework.yml` gains an `rmw_variant` input + Rust cross-target setup (incl. the now-stable `aarch64-apple-visionos` targets) and moves to the macos-26/Xcode 26.4.1 toolchain that ci-rcl already validates the cross-build on.

**Follow-up (second half, after the first tagged release):** switch the `CRos2Jazzy*` binaryTargets in `Package.swift` from local-path to URL+checksum, re-computing checksums from the uploaded zips (GitHub re-zips on upload).

Note: the zenoh-variant xros/xrsimulator slices depend on the `zenohc_triple` visionOS mapping that lands with the tf2_msgs/audio_common_msgs/point_cloud_interfaces bundling PR — tag only after that merges.