### PR TITLE
fix(rcl): enable timestamping in the injected zenoh session config

### DIFF
--- a/Sources/SwiftROS2RCL/RclClient.swift
+++ b/Sources/SwiftROS2RCL/RclClient.swift
@@ -706,6 +706,17 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
     /// ZENOH_SESSION_CONFIG_URI at session creation. Pure: no env, no rmw.
     /// `package` so SwiftROS2RCLTests can assert the shape without a router.
     package func makeZenohSessionConfigJSON5(locator: String) -> String {
+        // ZENOH_SESSION_CONFIG_URI REPLACES rmw_zenoh's DEFAULT_RMW_ZENOH_SESSION
+        // _CONFIG.json5 wholesale — it is not merged — so any default this minimal
+        // config omits reverts to the zenoh-c library default, not rmw_zenoh's.
+        // `timestamping` is the one that bites: rmw_zenoh_cpp creates every
+        // publisher as an AdvancedPublisher with Sequencing::Timestamp (needed for
+        // the PublicationCache behind transient_local durability), and zenoh-c
+        // refuses to build such a publisher unless timestamping is enabled — the
+        // library default for a client is disabled, so a config without it aborts
+        // the first publisher with "the 'timestamping' setting must be enabled in
+        // the Zenoh configuration." Mirror the default's block verbatim (see
+        // RmwZenohDefaultConfig, DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5).
         """
         {
           mode: "client",
@@ -716,6 +727,10 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
             multicast: {
               enabled: false,
             },
+          },
+          timestamping: {
+            enabled: { router: true, peer: true, client: true },
+            drop_future_timestamp: false,
           },
         }
         """

--- a/Tests/SwiftROS2RCLTests/RclZenohSessionEnvTests.swift
+++ b/Tests/SwiftROS2RCLTests/RclZenohSessionEnvTests.swift
@@ -124,6 +124,11 @@
             XCTAssertTrue(cfg.contains("mode: \"client\""), "client mode missing")
             XCTAssertTrue(cfg.contains("connect"), "connect block missing")
             XCTAssertTrue(cfg.contains("enabled: false"), "multicast scouting must be disabled")
+            // rmw_zenoh_cpp builds every publisher as an AdvancedPublisher with
+            // Sequencing::Timestamp; zenoh-c aborts publisher creation unless the
+            // (wholesale-replacing) session config enables client timestamping.
+            XCTAssertTrue(cfg.contains("timestamping"), "timestamping block missing")
+            XCTAssertTrue(cfg.contains("client: true"), "client timestamping must be enabled")
         }
 
         func testApplyZenohSessionEnvExportsAndRestores() {


### PR DESCRIPTION
## Problem

On the RCL-over-Zenoh path (`SWIFT_ROS2_RCL_RMW=zenoh`), creating the first publisher aborts the process:

```
[ERROR] [rmw_zenoh_cpp]: Unable to make PublisherData.
[ERROR] zenohc::advanced_publisher: Cannot create AdvancedPublisher …/camera_info/…
        with Sequencing::Timestamp: the 'timestamping' setting must be enabled in the
        Zenoh configuration.
→ App terminated due to signal 6 (SIGABRT)
```

## Root cause

`rmw_zenoh_cpp` builds every publisher as an `AdvancedPublisher` with `Sequencing::Timestamp` (the `PublicationCache` behind `transient_local` durability). `zenoh-c` refuses to create such a publisher unless the session config enables `timestamping`, and a client's library default is **disabled**.

`RclClient.makeZenohSessionConfigJSON5` — pointed at by `ZENOH_SESSION_CONFIG_URI` to inject the router locator (MZ1) — emitted a minimal config (`mode` / `connect` / `scouting` only). `ZENOH_SESSION_CONFIG_URI` **replaces** `rmw_zenoh`'s `DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5` wholesale rather than merging it, so the omitted `timestamping` reverted to the zenoh-c library default (disabled), and the first `transient_local` publisher aborted.

This did not surface in the MZ3 Docker verification — it first reproduced on the MZ4 on-device run.

## Fix

Mirror the default config's `timestamping` block verbatim in the injected session config:

```json5
timestamping: {
  enabled: { router: true, peer: true, client: true },
  drop_future_timestamp: false,
}
```

`RclZenohSessionEnvTests.testSessionConfigCarriesConnectEndpointInClientMode` now asserts the block is present and `client: true`.

## Verification

- `swift test --filter "RclZenohSessionEnvTests|RclZenohFailLoudTests|RmwZenohConfigDriftTests|RclDiscoveryEnvTests"` (zenoh variant) — all green; the config-drift guard confirms the embedded default is unchanged.
- **Live (MZ4):** iPhone 15 Pro publishing over `rcl+rmw_zenoh` to a Linux `rmw_zenohd` router (`ROS_DOMAIN_ID=123`). Before: SIGABRT on the first `camera_info` publisher. After: `/conduit/imu` (~100 Hz), `/conduit/camera/front/image_raw/compressed` (~30 Hz), `/conduit/camera/front/camera_info` and `/tf_static` all flow byte-correct to the ROS 2 host; no crash.