### PR TITLE
fix(rcl): Linux runtime-rmw follow-ups — accept .dds, gate route-b on zenoh-backed contexts

### DIFF
--- a/Sources/SwiftROS2RCL/RclClient.swift
+++ b/Sources/SwiftROS2RCL/RclClient.swift
@@ -681,6 +681,12 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
     private var ctxDomainId: Int32 = 0
     private var ctxUnicastPeerAddresses: [String] = []
     private var ctxNetworkInterface: String?
+    /// Whether the most recent createContext asked for a `.zenoh` transport —
+    /// on runtime-rmw platforms (Linux, MZ5) that selects rmw_zenoh_cpp, so the
+    /// route-(b) CycloneDDS fallback must be gated off exactly as in the baked
+    /// zenoh-rmw variant. Captured with the other context inputs; overwritten
+    /// by the next createContext.
+    private var ctxTransportIsZenoh = false
 
     public init() {}
 
@@ -978,10 +984,12 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
             throw TransportError.alreadyConnected
         }
         // Capture the discovery inputs so a later route-(b) raw session matches
-        // the rcl context's domain + peers + interface.
+        // the rcl context's domain + peers + interface — and the transport
+        // intent, which gates route-(b) off entirely for zenoh-backed contexts.
         ctxDomainId = domainId
         ctxUnicastPeerAddresses = unicastPeerAddresses
         ctxNetworkInterface = networkInterface
+        ctxTransportIsZenoh = transportType == .zenoh
         lock.unlock()
         #if os(Linux)
             // Pick the process rmw from the transport TYPE (authoritative — not
@@ -1084,32 +1092,45 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         crcl_node_destroy(b.ptr)
     }
 
-    #if SWIFT_ROS2_RCL_RMW_ZENOH
-        /// Fail-loud gate for the zenoh-rmw variant: on a marshal-registry miss
-        /// the cyclonedds variant falls back to route (b) — a raw-CDR writer /
-        /// reader on a sibling **CycloneDDS** participant. Under rmw_zenoh the
-        /// rcl graph speaks Zenoh through a router, so that sibling participant's
-        /// DDS multicast domain has no counterpart: route-(b) traffic would go
-        /// out (or be listened for) where nobody communicates — silent data
-        /// loss, not degraded service. Throw instead. Runs before the node
-        /// handle is inspected, so SwiftROS2RCLTests can assert the gate
-        /// without a live rmw context (`package` for exactly that).
-        package static func requireBundledTypesupport(_ typeName: String) throws {
-            guard crcl_marshal_resolve_typesupport(typeName) == nil else { return }
-            throw TransportError.unsupportedFeature(
-                "type \(typeName) has no bundled typesupport; the raw-CDR fallback is "
-                    + "CycloneDDS-only and unreachable via rmw_zenoh — bundle the type or "
-                    + "use the .dds transport")
-        }
-    #endif
+    /// Fail-loud gate for zenoh-backed rcl graphs: on a marshal-registry miss
+    /// the cyclonedds path falls back to route (b) — a raw-CDR writer /
+    /// reader on a sibling **CycloneDDS** participant. Under rmw_zenoh the
+    /// rcl graph speaks Zenoh through a router, so that sibling participant's
+    /// DDS multicast domain has no counterpart: route-(b) traffic would go
+    /// out (or be listened for) where nobody communicates — silent data
+    /// loss, not degraded service. Throw instead. Applies both when the rmw
+    /// is baked at compile time (SWIFT_ROS2_RCL_RMW_ZENOH) and when it is
+    /// selected at runtime from the transport type (Linux, MZ5). Runs before
+    /// the node handle is inspected, so SwiftROS2RCLTests can assert the gate
+    /// without a live rmw context (`package` for exactly that).
+    package static func requireBundledTypesupport(_ typeName: String) throws {
+        guard crcl_marshal_resolve_typesupport(typeName) == nil else { return }
+        throw TransportError.unsupportedFeature(
+            "type \(typeName) has no bundled typesupport; the raw-CDR fallback is "
+                + "CycloneDDS-only and unreachable via rmw_zenoh — bundle the type or "
+                + "use the .dds transport")
+    }
+
+    /// Apply the fail-loud gate wherever the rcl graph speaks Zenoh: always in
+    /// the baked zenoh-rmw variant (rmw fixed at compile time, gate must fire
+    /// even before a context exists), and on a captured `.zenoh` transport
+    /// intent where the rmw is selected at runtime (Linux, MZ5).
+    private func requireBundledTypesupportIfZenohBacked(_ typeName: String) throws {
+        #if SWIFT_ROS2_RCL_RMW_ZENOH
+            try Self.requireBundledTypesupport(typeName)
+        #else
+            lock.lock()
+            let zenohBacked = ctxTransportIsZenoh
+            lock.unlock()
+            if zenohBacked { try Self.requireBundledTypesupport(typeName) }
+        #endif
+    }
 
     package func createPublisher(
         node: any RclNodeHandle, typeName: String, typeHash: String?, topic: String,
         qos: TransportQoS
     ) throws -> any RclPublisherHandle {
-        #if SWIFT_ROS2_RCL_RMW_ZENOH
-            try Self.requireBundledTypesupport(typeName)
-        #endif
+        try requireBundledTypesupportIfZenohBacked(typeName)
         guard let b = node as? RclNodeBox else {
             throw TransportError.publisherCreationFailed("invalid node handle")
         }
@@ -1269,9 +1290,7 @@ public final class RclClient: RclClientProtocol, @unchecked Sendable {
         qos: TransportQoS,
         handler: @escaping @Sendable (Data, UInt64) -> Void
     ) throws -> any RclSubscriptionHandle {
-        #if SWIFT_ROS2_RCL_RMW_ZENOH
-            try Self.requireBundledTypesupport(typeName)
-        #endif
+        try requireBundledTypesupportIfZenohBacked(typeName)
         guard let b = node as? RclNodeBox else {
             throw TransportError.subscriberCreationFailed("invalid node handle")
         }

--- a/Sources/SwiftROS2Transport/RclTransportSession.swift
+++ b/Sources/SwiftROS2Transport/RclTransportSession.swift
@@ -1,11 +1,13 @@
 // RclTransportSession.swift
-// TransportSession backed by the real rcl + rmw_cyclonedds_cpp stack via
-// RclClientProtocol. Publish (M1) + subscribe (M4); assumes a single node.
+// TransportSession backed by the real rcl stack via RclClientProtocol. The rmw
+// is baked per build variant on Apple (rmw_cyclonedds_cpp or rmw_zenoh_cpp)
+// and selected at runtime from the transport type on Linux (MZ5).
 
 import Foundation
 
-/// `TransportSession` backed by the real `rcl` + `rmw_cyclonedds_cpp` stack via
-/// `RclClientProtocol`. Publish (M1) + subscribe (M4); assumes a single node.
+/// `TransportSession` backed by the real `rcl` stack via `RclClientProtocol`.
+/// The rmw is baked per build variant on Apple and selected at runtime from
+/// the transport type on Linux (MZ5).
 public final class RclTransportSession: TransportSession, @unchecked Sendable {
     let client: any RclClientProtocol
     private let lock = NSLock()
@@ -43,11 +45,15 @@ public final class RclTransportSession: TransportSession, @unchecked Sendable {
     }
 
     public func open(config: TransportConfig) async throws {
-        // The zenoh-rmw variant routes `.zenoh` here (zenoh-pico is carved out);
-        // `.rcl` is the DDS variant. Both open a real rcl context.
-        guard config.type == .rcl || config.type == .zenoh else {
+        // Every accepted config opens a real rcl context; the client selects
+        // the rmw from the transport type. `.rcl` is the cyclonedds variant's
+        // config, `.zenoh` arrives from the zenoh-rmw variant (zenoh-pico
+        // carved out) or Linux runtime-rmw routing, and `.dds` arrives from
+        // Linux runtime-rmw routing (MZ5). The guard is exhaustive today and
+        // exists to fail loud if a future transport type lands unrouted.
+        guard config.type == .rcl || config.type == .zenoh || config.type == .dds else {
             throw TransportError.invalidConfiguration(
-                "Expected RCL or Zenoh configuration, got \(config.type)")
+                "Expected RCL, Zenoh, or DDS configuration, got \(config.type)")
         }
         try config.validate()
         guard client.isAvailable else {

--- a/Tests/SwiftROS2RCLTests/RclLinuxRuntimeRmwEndToEndTests.swift
+++ b/Tests/SwiftROS2RCLTests/RclLinuxRuntimeRmwEndToEndTests.swift
@@ -1,0 +1,25 @@
+// RclLinuxRuntimeRmwEndToEndTests.swift
+// End-to-end MZ5 regression net for the Linux runtime-rmw arm: a `.dds`
+// config must open an rcl-backed context (RMW_IMPLEMENTATION=
+// rmw_cyclonedds_cpp, selected from the transport type) through the PUBLIC
+// API. #163 shipped this path dead — RclTransportSession.open() rejected the
+// very `.dds` config makeDefaultSession routed to it — a break only an
+// end-to-end open catches. Runs on the ci-rcl Linux leg (system ROS 2
+// sourced); rmw_cyclonedds needs no router, so this is loopback-safe in CI.
+// The `.zenoh` counterpart needs a live rmw_zenohd and stays a manual /
+// LAN-gated procedure (see docs/verification-runbook.md).
+
+#if os(Linux) && SWIFT_ROS2_RCL
+    import SwiftROS2
+    import XCTest
+
+    final class RclLinuxRuntimeRmwEndToEndTests: XCTestCase {
+        func testDdsMulticastOpensRclBackedContextEndToEnd() async throws {
+            let ctx = try await ROS2Context(transport: .ddsMulticast(domainId: 87), distro: .jazzy)
+            let node = try await ctx.createNode(name: "mz5_dds_smoke")
+            let pub = try await node.createPublisher(StringMsg.self, topic: "mz5_dds_smoke")
+            try pub.publish(StringMsg(data: "mz5"))
+            await ctx.shutdown()
+        }
+    }
+#endif

--- a/Tests/SwiftROS2RCLTests/RclRuntimeZenohGateTests.swift
+++ b/Tests/SwiftROS2RCLTests/RclRuntimeZenohGateTests.swift
@@ -1,0 +1,92 @@
+// RclRuntimeZenohGateTests.swift
+// Runtime mirror of the zenoh-variant fail-loud gate (RclZenohFailLoudTests):
+// on Linux the rmw is selected at RUNTIME from the transport type (MZ5), so a
+// build without SWIFT_ROS2_RCL_RMW_ZENOH can still open a zenoh-backed rcl
+// context. A marshal-registry miss there must NOT fall back to the route-(b)
+// raw-CDR CycloneDDS sibling — the rcl graph speaks Zenoh, so route-(b)
+// traffic has no counterpart (silent data loss). The gate must key on the
+// captured context transport, not only on the compile-time variant.
+//
+// Compiled only where the compile-time gate is absent; the zenoh-rmw variant
+// keeps its static gate coverage in RclZenohFailLoudTests.
+
+#if SWIFT_ROS2_RCL && !SWIFT_ROS2_RCL_RMW_ZENOH
+    import Foundation
+    import SwiftROS2RCL
+    import SwiftROS2Transport
+    import XCTest
+
+    /// Stand-in node handle: the registry-miss gate fires before the node
+    /// handle is inspected, so these tests need no rcl context or node.
+    private final class FakeNodeHandle: RclNodeHandle {}
+
+    final class RclRuntimeZenohGateTests: XCTestCase {
+        private let absentType = "foo_msgs/msg/Bar"
+
+        /// Capture a `.zenoh` transport intent WITHOUT starting rmw: the
+        /// non-embeddable locator (embedded quote) fails createContext after
+        /// the transport type is captured but before any rcl call, and every
+        /// env slot the attempt applied is restored on that failure path.
+        private func makeZenohBackedClient() -> RclClient {
+            let client = RclClient()
+            XCTAssertThrowsError(
+                try client.createContext(
+                    domainId: 87, transportType: .zenoh, unicastPeerAddresses: [],
+                    networkInterface: nil, zenohRouterLocator: "tcp/127.0.0.1:7447\"oops")
+            ) { error in
+                guard case TransportError.invalidConfiguration = error else {
+                    return XCTFail("expected invalidConfiguration, got \(error)")
+                }
+            }
+            return client
+        }
+
+        private func assertRegistryMissError(_ error: Error) {
+            guard case TransportError.unsupportedFeature(let message) = error else {
+                return XCTFail("expected unsupportedFeature, got \(error)")
+            }
+            XCTAssertTrue(message.contains(absentType), "type name missing from: \(message)")
+        }
+
+        func testCreatePublisherThrowsOnRegistryMissWhenZenohBacked() {
+            let client = makeZenohBackedClient()
+            XCTAssertThrowsError(
+                try client.createPublisher(
+                    node: FakeNodeHandle(), typeName: absentType, typeHash: nil,
+                    topic: "/gate_pub", qos: .sensorData)
+            ) { assertRegistryMissError($0) }
+        }
+
+        func testCreateSubscriptionThrowsOnRegistryMissWhenZenohBacked() {
+            let client = makeZenohBackedClient()
+            XCTAssertThrowsError(
+                try client.createSubscription(
+                    node: FakeNodeHandle(), typeName: absentType, typeHash: nil,
+                    topic: "/gate_sub", qos: .sensorData, handler: { _, _ in })
+            ) { assertRegistryMissError($0) }
+        }
+
+        func testBundledTypePassesRuntimeGate() {
+            // A bundled type must get past the gate and fail on the (fake) node
+            // handle instead — the gate keys on the registry, not on the
+            // transport as a whole.
+            let client = makeZenohBackedClient()
+            XCTAssertThrowsError(
+                try client.createPublisher(
+                    node: FakeNodeHandle(), typeName: "sensor_msgs/msg/Imu", typeHash: nil,
+                    topic: "/gate_bundled", qos: .sensorData)
+            ) { error in
+                guard case TransportError.publisherCreationFailed(let message) = error else {
+                    return XCTFail("expected publisherCreationFailed, got \(error)")
+                }
+                XCTAssertTrue(message.contains("invalid node handle"), "unexpected: \(message)")
+            }
+        }
+
+        func testRequireBundledTypesupportIsAvailableOutsideZenohVariant() {
+            // The gate helper itself must compile (and accept bundled types) on
+            // every RCL arm, not only under SWIFT_ROS2_RCL_RMW_ZENOH.
+            XCTAssertNoThrow(try RclClient.requireBundledTypesupport("sensor_msgs/msg/Imu"))
+        }
+    }
+#endif

--- a/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
+++ b/Tests/SwiftROS2TransportTests/RclTransportSessionTests.swift
@@ -32,16 +32,21 @@ final class RclTransportSessionTests: XCTestCase {
         XCTAssertEqual(client.lastNetworkInterface, "en0")
     }
 
-    // `.rcl` and `.zenoh` (the zenoh-rmw variant) are accepted; a DDS-wire
-    // config is not — RclTransportSession does not back the wire DDS path.
-    func testOpenRejectsNonRclOrZenohConfig() async {
-        let s = RclTransportSession(client: MockRclClient())
-        do {
-            try await s.open(config: .ddsMulticast(domainId: 0))
-            XCTFail("expected invalidConfiguration")
-        } catch let e as TransportError {
-            guard case .invalidConfiguration = e else { return XCTFail("got \(e)") }
-        } catch { XCTFail("got \(error)") }
+    // `.dds` must be accepted, not rejected: on Linux (MZ5 runtime rmw
+    // selection) makeDefaultSession routes `.dds` configs here and the client
+    // picks rmw_cyclonedds_cpp from the forwarded transport type. Rejecting it
+    // makes the whole Linux DDS-RCL path dead on arrival.
+    func testOpenAcceptsDdsConfigAndForwardsTransportType() async throws {
+        let client = MockRclClient()
+        let s = RclTransportSession(client: client)
+        try await s.open(config: .ddsMulticast(domainId: 3))
+        XCTAssertEqual(client.lastTransportType, .dds)
+        guard let recordedLocator = client.recordedZenohLocator else {
+            return XCTFail("createContext was never called")
+        }
+        XCTAssertNil(recordedLocator, "a .dds config must not carry a zenoh locator")
+        XCTAssertTrue(s.isConnected)
+        XCTAssertEqual(s.sessionId, "rcl-3")
     }
 
     func testOpenFailsWhenUnavailable() async {


### PR DESCRIPTION
## Summary

Two MZ5 (#163) follow-up fixes on the Linux runtime-rmw arm, both release-blocking for 1.3.0 ("RCL everywhere"):

1. **`.dds` was dead on arrival on Linux RCL.** `makeDefaultSession` routes `.dds` to `RclTransportSession` on Linux, but `open()` still rejected everything except `.rcl`/`.zenoh`, so every Linux `.dds` `ROS2Context` failed with `invalidConfiguration`. The guard now admits `.dds` (initializer is package-scoped; Apple routing never hands `.dds` to this session, so Apple behavior is unchanged).
2. **The #155 fail-loud gate was compile-time only.** `requireBundledTypesupport` existed only under `SWIFT_ROS2_RCL_RMW_ZENOH`; the Linux build selects rmw_zenoh_cpp at *runtime*, so a `.zenoh` context there bypassed the gate and a marshal-registry miss fell back to the route-(b) raw-CDR CycloneDDS sibling — the exact silent-data-loss failure #155 was created to prevent. The gate now compiles on every RCL arm and keys on the compile-time variant OR the captured `.zenoh` transport intent from `createContext`.

## Tests

- `RclTransportSessionTests`: the stale `.dds`-rejection test is flipped into a forwarding test (transport type + nil locator reach the client).
- `RclRuntimeZenohGateTests` (new, compiled where the compile-time gate is absent): hermetic runtime-gate coverage — captures `.zenoh` intent via a createContext that fails before any rcl call, then asserts registry-miss publish/subscribe throw `unsupportedFeature` while bundled types pass. Runs on the cyclonedds macOS leg and the ci-rcl Linux leg.
- `RclLinuxRuntimeRmwEndToEndTests` (new, Linux-only): end-to-end `.ddsMulticast` → context → node → publisher → publish through the public API on the ci-rcl Linux leg — the net that would have caught fix 1.

Local verification: default suite, cyclonedds-variant and zenoh-variant `SwiftROS2RCLTests`, and `swift format lint --strict` all green; TDD red/green observed for both fixes on the macOS arms.