### PR TITLE
refactor(wire): soft-deprecate the pure-Swift wire clients (removed in 2.0.0)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -235,3 +235,50 @@ extension ROS2Node {
 ### Adopting
 
 No code change is required to upgrade — `Context.createNode(...)` keeps its old signature and now also auto-registers the six parameter services (opt out via `ROS2NodeOptions(startParameterServices: false)` if you don't need them).
+
+## 1.2 → 1.3 — RCL everywhere; the wire path is deprecated
+
+1.3.0 completes the native RCL backend on every platform it can currently
+reach: Apple (prebuilt `CRos2Jazzy` / `CRos2JazzyZenoh` xcframeworks, one rmw
+baked per build variant) and Linux (system ROS 2 install via
+`ROS2_RCL_PREFIX`, rmw selected at runtime from the transport type). No public
+symbol changed; the release is additive plus the deprecation below.
+
+### What is deprecated
+
+Constructing the wire clients directly:
+
+```swift
+import SwiftROS2Zenoh
+let client = ZenohClient()   // warning: deprecated, removed in 2.0.0
+
+import SwiftROS2DDS
+let dds = DDSClient()        // warning: deprecated, removed in 2.0.0
+```
+
+### What is NOT deprecated
+
+The umbrella API — it is backend-agnostic and routes to the RCL backend where
+available, the wire path elsewhere:
+
+```swift
+let ctx = try await ROS2Context(transport: .zenoh(locator: "tcp/192.168.1.85:7447"))
+let node = try await ctx.createNode(name: "talker")
+```
+
+If you construct `ZenohClient` / `DDSClient` only to hand them to
+`ROS2Context`, drop the explicit construction and let `ROS2Context` pick the
+backend. If you use the wire clients standalone (raw key-expression puts,
+wire-level subscribers), plan the move to the umbrella API before 2.0.0 —
+the wire runtime path is removed there, while the CDR / wire codecs survive
+as the golden-byte correctness fixtures.
+
+### Per-variant nuance
+
+- Apple zenoh-rmw RCL variant (`SWIFT_ROS2_RCL_RMW=zenoh`): the zenoh wire
+  family is *physically absent* from the build graph (symbol collision with
+  the bundled zenoh-c), so `ZenohClient` does not exist there at all.
+- Linux RCL builds: both backends stay linked (no symbol collision — rmw is a
+  dlopen'd plugin); RCL is preferred at runtime for `.zenoh` and `.dds`.
+- Android, visionOS-zenoh, Windows: the wire path remains the automatic
+  fallback until an RCL path exists for them.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![SPI Swift compatibility](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyoutalk%2Fswift-ros2%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/youtalk/swift-ros2)
 [![SPI platform compatibility](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyoutalk%2Fswift-ros2%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/youtalk/swift-ros2)
 
-Native Swift client library for ROS 2. Publish and subscribe to ROS 2 topics over **Zenoh** (via `zenoh-pico`) or **DDS** (via CycloneDDS) — without a bridge, without `rcl` / `rclcpp`, on every consumer device OS that runs Swift.
+Native Swift client library for ROS 2. Publish and subscribe to ROS 2 topics over **Zenoh** or **DDS** on every consumer device OS that runs Swift — through the **native RCL backend** (real `rcl` + `rmw_zenoh_cpp` / `rmw_cyclonedds_cpp`; Apple and Linux) or the original pure-Swift **wire path** (`zenoh-pico` / CycloneDDS, no `rcl`; all platforms, now deprecated — see below).
 
 > The four CI badges above all reflect the same `ci.yml` workflow status (GitHub Actions does not expose per-matrix-job badges). Each label is the OS family that workflow exercises — when the badges are green, every Apple / Linux / Windows / Android matrix entry passed.
 
@@ -22,14 +22,23 @@ swift-ros2 1.0.0 inaugurates the [SemVer](https://semver.org/spec/v2.0.0.html) 1
 
 The frozen public surface covers `ROS2Context`, `ROS2Node`, `ROS2Publisher`, `ROS2Subscription`, `ROS2Service`, `ROS2Client`, `ROS2ActionServer`, `ROS2ActionClient`, `QoSProfile`, `TransportConfig`, the concrete `ZenohClient` / `DDSClient`, and every `ROS2Message` / `ROS2ServiceType` / `ROS2Action` type. Internal plumbing (`TransportQoS`, `QoSPolicy`, `DDSBridge*`, `ZenohClientProtocol` / `DDSClientProtocol`, `EntityManager`, `GIDManager`, etc.) was pulled out of the public surface at the 1.0 cut — see [`MIGRATION.md`](MIGRATION.md) for the full list and migration recipes.
 
+## Deprecation: the pure-Swift wire path
+
+As of **1.3.0** the recommended runtime is the **native RCL backend** — it is the upstream ROS 2 stack, so type hashes, QoS semantics, the node graph, and introspection match upstream by construction. The pure-Swift wire path (constructing `SwiftROS2Zenoh.ZenohClient` / `SwiftROS2DDS.DDSClient` directly) is **deprecated and will be removed in 2.0.0**:
+
+- The umbrella API is **unchanged and not deprecated**: `.zenoh(locator:)` / `.dds(...)` route to the RCL backend where available and to the wire path elsewhere. Most consumers need no change.
+- The wire path **remains fully functional through 1.x** as the automatic fallback where RCL is not yet available (Android; visionOS zenoh; Windows) and as the golden-byte correctness oracle for the CDR/wire codecs.
+- Nuance per build variant: in the Apple zenoh-rmw RCL variant the zenoh wire family is **physically absent** (zenoh-pico and the variant's bundled zenoh-c export the same C symbols and cannot co-link), not merely deprecated. On Linux RCL builds both stay linked; RCL is preferred at runtime.
+- Direct constructions now emit a deprecation warning; see [`MIGRATION.md`](MIGRATION.md) for the migration recipe.
+
 ## Why
 
 Bringing ROS 2 to a phone, headset, or laptop usually means cross-compiling `rcl` + `rclcpp` + a DDS implementation, fighting CMake on a non-Linux host, and shipping a 100+ MB toolchain. swift-ros2 sidesteps all of that by speaking the ROS 2 wire formats directly: a SwiftPM `.package(url:)` line on Apple targets, a single `apt install ros-<distro>-cyclonedds` on Linux, and a vanilla `swift build` on Windows / Android. The publisher / subscription API is Swift-native (`async`/`await`, `AsyncStream`, `Sendable`) and round-trip compatible with the `rmw_zenoh_cpp` and `rmw_cyclonedds_cpp` middlewares.
 
 ## Features
 
-- **Dual transport.** `SwiftROS2Zenoh` talks to `rmw_zenoh_cpp`; `SwiftROS2DDS` talks to `rmw_cyclonedds_cpp`. Switch transports with a single `TransportConfig` change.
-- **No `rcl` dependency.** Wire-level publish / subscribe means no `rcl`, no `rclcpp`, no Python / colcon, no `rmw_*` shim layer — and no transitive build of FastDDS or CycloneDDS from source on the consumer side (Apple targets get xcframeworks; Linux gets a `pkg-config` lookup; Windows resolves CycloneDDS through `vcpkg`; Android stays Zenoh-only for now).
+- **Dual transport, two backends.** `.zenoh(locator:)` and `.dds(...)` each resolve to the native RCL backend where it exists (upstream-identical type hashes, QoS, and node graph by construction) and to the pure-Swift wire path elsewhere. Switch transports with a single `TransportConfig` change; the public API is backend-agnostic.
+- **No mandatory `rcl` toolchain.** Consumers never cross-compile `rcl` / `rclcpp` themselves: Apple targets download prebuilt xcframeworks (including the RCL variants), Linux uses a system ROS 2 install for RCL (`ROS2_RCL_PREFIX`), and the wire path needs no ROS 2 install at all (Windows resolves CycloneDDS through `vcpkg`; Android stays Zenoh-only for now).
 - **Swift-native API.** `async`/`await` everywhere, `AsyncStream` subscriptions, `Sendable` conformance, structured concurrency, no opaque pointer juggling above the FFI seam.
 - **Pre-built Apple binaries.** `CZenohPico.xcframework` + `CCycloneDDS.xcframework` are attached to every GitHub Release. `swift build` downloads them in seconds — no CMake, no local bootstrap, no Apple-side codesigning dance.
 - **Source build everywhere else.** Linux, Windows, and Android compile `zenoh-pico` from `vendor/` via SwiftPM directly, each picking the matching backend (`unix` / `windows`). CycloneDDS comes from `pkg-config` on Linux and `vcpkg` on Windows. No vendored prebuilts needed.

--- a/Sources/SwiftROS2/Context.swift
+++ b/Sources/SwiftROS2/Context.swift
@@ -188,7 +188,7 @@ extension ROS2Context {
                 return RclTransportSession(client: RclClient())
             #elseif canImport(SwiftROS2Zenoh)
                 // Wire path (zenoh-pico) — every build except the zenoh-rmw variant.
-                return ZenohTransportSession(client: ZenohClient())
+                return ZenohTransportSession(client: ZenohClient(wireFallback: ()))
             #elseif SWIFT_ROS2_RCL_RMW_ZENOH
                 // zenoh-pico is carved out (symbol collision with the variant's
                 // zenoh-c); `.zenoh` resolves to rcl + rmw_zenoh_cpp instead. The
@@ -204,7 +204,7 @@ extension ROS2Context {
                 // Linux RCL: .dds resolves to rcl + rmw_cyclonedds_cpp (runtime rmw).
                 return RclTransportSession(client: RclClient())
             #else
-                return DDSTransportSession(client: DDSClient())
+                return DDSTransportSession(client: DDSClient(wireFallback: ()))
             #endif
         case .rcl:
             #if SWIFT_ROS2_RCL_RMW_ZENOH

--- a/Sources/SwiftROS2DDS/DDSClient.swift
+++ b/Sources/SwiftROS2DDS/DDSClient.swift
@@ -141,6 +141,17 @@ public final class DDSClient: DDSClientProtocol {
     private var session: OpaquePointer?
     private let lock = NSLock()
 
+    /// Non-deprecated construction seam for in-package callers: the wire
+    /// path stays the automatic fallback wherever the RCL backend is not
+    /// available (`makeDefaultSession`) and remains exercised by tests as
+    /// the golden-byte oracle — those uses are not themselves deprecated.
+    package init(wireFallback: ()) {}
+
+    /// Initializes the DDS client (session not yet created)
+    @available(
+        *, deprecated,
+        message: "The pure-Swift wire path is deprecated; use the RCL backend. Removed in 2.0.0."
+    )
     public init() {}
 
     public var isAvailable: Bool {

--- a/Sources/SwiftROS2Zenoh/ZenohClient.swift
+++ b/Sources/SwiftROS2Zenoh/ZenohClient.swift
@@ -169,7 +169,23 @@ public class ZenohClient: ZenohClientProtocol {
         return session
     }
 
+    /// Non-deprecated construction seam for in-package callers: the wire
+    /// path stays the automatic fallback wherever the RCL backend is not
+    /// available (`makeDefaultSession`) and remains exercised by tests as
+    /// the golden-byte oracle — those uses are not themselves deprecated.
+    package init(wireFallback: ()) {
+        // Empty init - call open() to connect
+    }
+
     /// Initializes the Zenoh client (session not yet opened)
+    ///
+    /// Stays a designated initializer (not a convenience delegate) so any
+    /// existing external subclass keeps a designated init to chain to —
+    /// the 1.x API freeze covers subclassers of this non-final class.
+    @available(
+        *, deprecated,
+        message: "The pure-Swift wire path is deprecated; use the RCL backend. Removed in 2.0.0."
+    )
     public init() {
         // Empty init - call open() to connect
     }

--- a/Tests/SwiftROS2DDSTests/DDSClientSmokeTests.swift
+++ b/Tests/SwiftROS2DDSTests/DDSClientSmokeTests.swift
@@ -4,16 +4,25 @@ import XCTest
 
 final class DDSClientSmokeTests: XCTestCase {
     func testAvailabilityFlag() {
-        let client = DDSClient()
+        let client = DDSClient(wireFallback: ())
         XCTAssertTrue(client.isAvailable)
     }
 
     func testInitializationDoesNotCrash() {
-        _ = DDSClient()
+        _ = DDSClient(wireFallback: ())
+    }
+
+    // The deprecated public initializer must keep constructing a working
+    // client through 1.x — the annotation is a migration signal, not a
+    // behavior change. The test method carries the same deprecation so the
+    // pinned usage compiles without a warning.
+    @available(*, deprecated)
+    func testDeprecatedPublicInitStillConstructs() {
+        XCTAssertTrue(DDSClient().isAvailable)
     }
 
     func testWriteWithForeignHandleThrows() throws {
-        let client = DDSClient()
+        let client = DDSClient(wireFallback: ())
         let foreign = ForeignWriterHandle()
         XCTAssertThrowsError(
             try client.writeRawCDR(
@@ -32,7 +41,7 @@ final class DDSClientSmokeTests: XCTestCase {
     }
 
     func testDestroyReaderWithForeignHandleIsNoOp() {
-        let client = DDSClient()
+        let client = DDSClient(wireFallback: ())
         let foreign = ForeignReaderHandle()
         // destroyReader is non-throwing; the client must silently no-op on a
         // handle it didn't create rather than force-cast into its private box.
@@ -40,7 +49,7 @@ final class DDSClientSmokeTests: XCTestCase {
     }
 
     func testCreateReaderWithoutSessionThrows() throws {
-        let client = DDSClient()
+        let client = DDSClient(wireFallback: ())
         XCTAssertThrowsError(
             try client.createRawReader(
                 topicName: "rt/test",

--- a/Tests/SwiftROS2ZenohTests/ZenohClientSmokeTests.swift
+++ b/Tests/SwiftROS2ZenohTests/ZenohClientSmokeTests.swift
@@ -9,7 +9,16 @@ private final class ForeignKeyExprHandle: ZenohKeyExprHandle {}
 
 final class ZenohClientSmokeTests: XCTestCase {
     func testInitializationDoesNotCrash() {
-        _ = ZenohClient()
+        _ = ZenohClient(wireFallback: ())
+    }
+
+    // The deprecated public initializer must keep constructing a working
+    // client through 1.x — the annotation is a migration signal, not a
+    // behavior change. The test method carries the same deprecation so the
+    // pinned usage compiles without a warning.
+    @available(*, deprecated)
+    func testDeprecatedPublicInitStillConstructs() {
+        XCTAssertFalse(ZenohClient().isSessionHealthy())
     }
 
     /// Verifies that passing a foreign ZenohKeyExprHandle to put() throws ZenohError.invalidParameter.
@@ -17,7 +26,7 @@ final class ZenohClientSmokeTests: XCTestCase {
     /// The foreign-handle guard in ZenohClient.put(keyExpr:payload:attachment:) runs
     /// BEFORE the session-open guard, so this test does not need a live Zenoh router.
     func testForeignKeyExprHandleIsRejected() throws {
-        let client = ZenohClient()
+        let client = ZenohClient(wireFallback: ())
         let foreign = ForeignKeyExprHandle()
 
         XCTAssertThrowsError(try client.put(keyExpr: foreign, payload: Data(), attachment: nil)) { error in
@@ -35,7 +44,7 @@ final class ZenohClientSmokeTests: XCTestCase {
 
     /// Verifies that calling close() on a client that was never opened throws ZenohError.sessionCloseFailed.
     func testDoubleCloseOnFreshClientThrows() throws {
-        let client = ZenohClient()
+        let client = ZenohClient(wireFallback: ())
         XCTAssertThrowsError(try client.close()) { error in
             guard let zErr = error as? ZenohError else {
                 XCTFail("Expected ZenohError, got \(type(of: error))")

--- a/Tests/SwiftROS2ZenohTests/ZenohQueryableSmokeTests.swift
+++ b/Tests/SwiftROS2ZenohTests/ZenohQueryableSmokeTests.swift
@@ -17,7 +17,7 @@ final class ZenohQueryableSmokeTests: XCTestCase {
         try XCTSkipIf(skipReason != nil, skipReason ?? "")
         let linuxIP = ProcessInfo.processInfo.environment["LINUX_IP"] ?? ""
 
-        let z = ZenohClient()
+        let z = ZenohClient(wireFallback: ())
         try z.open(locator: "tcp/\(linuxIP):7447")
         defer { try? z.close() }
 


### PR DESCRIPTION
## Summary

Completion-design §8 — the post-1.3.0-tag deprecation step (§12 PR 4). The pure-Swift wire path is now formally deprecated; **removal lands in 2.0.0**.

- `ZenohClient.init()` / `DDSClient.init()` carry `@available(*, deprecated, message: "The pure-Swift wire path is deprecated; use the RCL backend. Removed in 2.0.0.")`.
- **The umbrella API is unchanged and NOT deprecated** — `.zenoh(locator:)` / `.dds(...)` route to the RCL backend where available and to the wire path elsewhere (Android; visionOS zenoh; Windows).
- The public inits stay **designated** (ZenohClient is non-final; converting its only designated init to a convenience delegate would break external subclass chaining — a 1.x freeze violation). A parallel `package init(wireFallback:)` is the non-deprecated in-package seam, so `makeDefaultSession`'s automatic fallback and the golden-oracle tests build with **zero deprecation warnings**.
- Deprecated-init pin tests (themselves `@available(*, deprecated)`) assert the public inits keep working through 1.x.
- README gains the **Deprecation** section (recommended runtime; what is / is not deprecated; the *physically absent* vs *deprecated* nuance per build variant) and the headline/features reflect the two-backend reality; MIGRATION.md gains the 1.2 → 1.3 recipe.

## Verification
Full suite green; zero deprecation warnings in the package's own build; `swift format lint --strict` clean; API gate vs 1.2.0 unchanged (annotations do not register as breakage; only the two pre-allowlisted additive enum cases remain); zenoh-rmw variant carve-out build green.